### PR TITLE
feat: 메인페이지 기초 틀 구현 완료

### DIFF
--- a/src/components/homepage/ArtworkPreviewSection.tsx
+++ b/src/components/homepage/ArtworkPreviewSection.tsx
@@ -1,0 +1,48 @@
+import { useRef } from 'react';
+
+import { SectionHeader } from '@/components/homepage/SectionHeader';
+import type { ArtworkPreviewItem } from '@/types/home';
+
+type Props = {
+  items: ArtworkPreviewItem[];
+};
+
+export function ArtworkPreviewSection({ items }: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (e.shiftKey) {
+      e.preventDefault();
+      if (scrollRef.current) {
+        scrollRef.current.scrollLeft += e.deltaY;
+      }
+    }
+  };
+
+  return (
+    <section className="mb-7">
+      <SectionHeader title="작품 미리보기" />
+      <div
+        ref={scrollRef}
+        onWheel={handleWheel}
+        className="flex gap-3 overflow-x-auto px-4 pb-2 scrollbar-none"
+      >
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="relative shrink-0 w-[280px] h-[190px] rounded-xl overflow-hidden bg-[#D1D5DB]"
+          >
+            <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/15 to-transparent" />
+
+            <div className="absolute left-4 right-4 bottom-4">
+              <p className="text-[15px] font-bold text-white leading-snug mb-1">{item.name}</p>
+              <p className="text-[11px] text-white/80">
+                {item.date}&nbsp;&nbsp;{item.location}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/homepage/ArtworkPreviewSection.tsx
+++ b/src/components/homepage/ArtworkPreviewSection.tsx
@@ -25,20 +25,18 @@ export function ArtworkPreviewSection({ items }: Props) {
       <div
         ref={scrollRef}
         onWheel={handleWheel}
-        className="flex gap-3 overflow-x-auto px-4 pb-2 scrollbar-none"
+        className="flex gap-2 overflow-x-auto px-4 pb-2 scrollbar-none"
       >
         {items.map((item) => (
           <div
             key={item.id}
-            className="relative shrink-0 w-[280px] h-[190px] rounded-xl overflow-hidden bg-[#D1D5DB]"
+            className="relative shrink-0 w-34 h-55 rounded-xl overflow-hidden bg-[#D1D5DB]"
           >
             <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/15 to-transparent" />
 
             <div className="absolute left-4 right-4 bottom-4">
-              <p className="text-[15px] font-bold text-white leading-snug mb-1">{item.name}</p>
-              <p className="text-[11px] text-white/80">
-                {item.date}&nbsp;&nbsp;{item.location}
-              </p>
+              <p className="text-sm font-bold text-white leading-snug mb-1">{item.name}</p>
+              <p className="text-[10px] text-white/80">{item.date}</p>
             </div>
           </div>
         ))}

--- a/src/components/homepage/DuPickBanner.tsx
+++ b/src/components/homepage/DuPickBanner.tsx
@@ -10,6 +10,7 @@ export function DuPickBanner({ items }: Props) {
   const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
+    if (items.length === 0) return;
     const timer = setInterval(() => {
       setActiveIndex((prev) => (prev + 1) % items.length);
     }, 4000);
@@ -17,6 +18,7 @@ export function DuPickBanner({ items }: Props) {
   }, [items.length]);
 
   const current = items[activeIndex];
+  if (!current) return null;
 
   return (
     <section className="pb-7">

--- a/src/components/homepage/DuPickBanner.tsx
+++ b/src/components/homepage/DuPickBanner.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+
+import type { DuPickItem } from '@/types/home';
+
+type Props = {
+  items: DuPickItem[];
+};
+
+export function DuPickBanner({ items }: Props) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setActiveIndex((prev) => (prev + 1) % items.length);
+    }, 4000);
+    return () => clearInterval(timer);
+  }, [items.length]);
+
+  const current = items[activeIndex];
+
+  return (
+    <section className="pb-7">
+      <div className="px-4 mb-2.5">
+        <h2 className="text-3xl font-bold leading-snug text-[#111111]">DU Pick</h2>
+      </div>
+
+      <div className="px-4">
+        <div className="relative h-[513px] rounded-xl overflow-hidden bg-[#D1D5DB]">
+          <div className="absolute inset-0 bg-linear-to-t from-black/65 via-black/20 to-transparent" />
+
+          <div className="absolute left-4 right-4 bottom-9">
+            <p className="text-xl font-bold text-neutral-50 leading-snug mb-1.5">{current.name}</p>
+            <p className="text-xs text-neutral-400">
+              {current.date}&nbsp;&nbsp;{current.location}
+            </p>
+          </div>
+
+          <div className="absolute bottom-3.5 inset-x-0 flex justify-center items-center gap-1.5">
+            {items.map((_, i) => (
+              <button
+                key={i}
+                type="button"
+                aria-label={`슬라이드 ${i + 1}`}
+                onClick={() => setActiveIndex(i)}
+                className={`w-[7px] h-[7px] rounded-full border-none p-0 cursor-pointer shrink-0 transition-all duration-200 ${
+                  i === activeIndex ? 'bg-blue-500' : 'bg-white/50'
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/homepage/DuPickBanner.tsx
+++ b/src/components/homepage/DuPickBanner.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import plusIcon from '@/assets/iconoir_plus.svg';
+import logo from '@/assets/logo.svg';
 import type { DuPickItem } from '@/types/home';
 
 type Props = {
@@ -22,15 +24,21 @@ export function DuPickBanner({ items }: Props) {
 
   return (
     <section className="pb-7">
-      <div className="px-4 mb-2.5">
-        <h2 className="text-3xl font-bold leading-snug text-[#111111]">DU Pick</h2>
+      <div className="px-4 mb-2.5 flex justify-between items-center">
+        <h2 className="flex items-center gap-1.5 text-4xl font-semibold leading-none text-[#111111]">
+          <img src={logo} alt="DU" className="h-8 w-auto" />
+          <span>Pick</span>
+        </h2>
+        <button type="button" className="cursor-pointer p-0 bg-transparent border-none">
+          <img src={plusIcon} alt="더보기" className="size-10" />
+        </button>
       </div>
 
       <div className="px-4">
-        <div className="relative h-[513px] rounded-xl overflow-hidden bg-[#D1D5DB]">
+        <div className="relative h-128.25 overflow-hidden bg-[#D1D5DB]">
           <div className="absolute inset-0 bg-linear-to-t from-black/65 via-black/20 to-transparent" />
 
-          <div className="absolute left-4 right-4 bottom-9">
+          <div className="absolute left-7 right-4 bottom-9">
             <p className="text-xl font-bold text-neutral-50 leading-snug mb-1.5">{current.name}</p>
             <p className="text-xs text-neutral-400">
               {current.date}&nbsp;&nbsp;{current.location}
@@ -44,7 +52,7 @@ export function DuPickBanner({ items }: Props) {
                 type="button"
                 aria-label={`슬라이드 ${i + 1}`}
                 onClick={() => setActiveIndex(i)}
-                className={`w-[7px] h-[7px] rounded-full border-none p-0 cursor-pointer shrink-0 transition-all duration-200 ${
+                className={`w-1.75 h-1.75 rounded-full border-none p-0 cursor-pointer shrink-0 transition-all duration-200 ${
                   i === activeIndex ? 'bg-blue-500' : 'bg-white/50'
                 }`}
               />

--- a/src/components/homepage/ExhibitionSection.tsx
+++ b/src/components/homepage/ExhibitionSection.tsx
@@ -1,0 +1,33 @@
+import { SectionHeader } from '@/components/homepage/SectionHeader';
+import type { ExhibitionCardData } from '@/types/home';
+
+function ExhibitionCard({ item }: { item: ExhibitionCardData }) {
+  return (
+    <article className="flex flex-col gap-1.5 min-w-0 bg-white">
+      <div className="w-full aspect-3/4 rounded-md bg-[#D1D5DB] shrink-0" />
+      <div className="flex flex-col gap-0.5">
+        <p className="text-xs font-bold text-neutral-900 truncate">{item.title}</p>
+        <p className="text-xs text-neutral-600 truncate">{item.school}</p>
+        <p className="text-xs text-neutral-500">{item.period}</p>
+      </div>
+    </article>
+  );
+}
+
+type Props = {
+  title: string;
+  items: ExhibitionCardData[];
+};
+
+export function ExhibitionSection({ title, items }: Props) {
+  return (
+    <section className="mb-7">
+      <SectionHeader title={title} />
+      <div className="grid grid-cols-3 gap-2 px-4">
+        {items.map((item) => (
+          <ExhibitionCard key={item.id} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/homepage/ExhibitionSection.tsx
+++ b/src/components/homepage/ExhibitionSection.tsx
@@ -4,7 +4,7 @@ import type { ExhibitionCardData } from '@/types/home';
 function ExhibitionCard({ item }: { item: ExhibitionCardData }) {
   return (
     <article className="flex flex-col gap-1.5 min-w-0 bg-white">
-      <div className="w-full aspect-3/4 rounded-md bg-[#D1D5DB] shrink-0" />
+      <div className="w-full aspect-3/4 rounded-xl bg-[#D1D5DB] shrink-0" />
       <div className="flex flex-col gap-0.5">
         <p className="text-xs font-bold text-neutral-900 truncate">{item.title}</p>
         <p className="text-xs text-neutral-600 truncate">{item.school}</p>

--- a/src/components/homepage/LoungeSection.tsx
+++ b/src/components/homepage/LoungeSection.tsx
@@ -3,7 +3,7 @@ import type { LoungePost } from '@/types/home';
 
 function LoungePostItem({ post }: { post: LoungePost }) {
   return (
-    <div className="mx-4 mb-3 rounded-2xl border border-[#F0F0F0] bg-white p-4 flex flex-col gap-2.5">
+    <div className="mx-4 mb-4 rounded-lg shadow-sm border border-zinc-300 bg-white p-4 flex flex-col gap-2.5">
       <div className="flex items-center justify-between">
         <span
           className="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-bold

--- a/src/components/homepage/LoungeSection.tsx
+++ b/src/components/homepage/LoungeSection.tsx
@@ -1,0 +1,51 @@
+import { SectionHeader } from '@/components/homepage/SectionHeader';
+import type { LoungePost } from '@/types/home';
+
+function LoungePostItem({ post }: { post: LoungePost }) {
+  return (
+    <div className="mx-4 mb-3 rounded-2xl border border-[#F0F0F0] bg-white p-4 flex flex-col gap-2.5">
+      <div className="flex items-center justify-between">
+        <span
+          className="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-bold
+       text-sky-600 bg-gray-200"
+        >
+          {post.tag}
+        </span>
+
+        <button
+          type="button"
+          className="text-[#BBBBBB] hover:text-[#999999] bg-transparent border-none cursor-pointer p-0 text-lg font-bold leading-none"
+        >
+          ···
+        </button>
+      </div>
+
+      <p className="text-[14px] font-bold text-[#111111] leading-snug">{post.content}</p>
+
+      <div className="flex items-center gap-1.5 text-[11px] text-[#9CA3AF]">
+        <span>{post.author}</span>
+        <span className="text-[#D1D5DB]">·</span>
+        <span>{post.time}</span>
+        <span className="text-[#D1D5DB]">·</span>
+        <span>{post.views}</span>
+      </div>
+    </div>
+  );
+}
+
+type Props = {
+  posts: LoungePost[];
+};
+
+export function LoungeSection({ posts }: Props) {
+  return (
+    <section className="mb-8">
+      <SectionHeader title="라운지" />
+      <div>
+        {posts.map((post) => (
+          <LoungePostItem key={post.id} post={post} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/homepage/SectionHeader.tsx
+++ b/src/components/homepage/SectionHeader.tsx
@@ -13,7 +13,7 @@ export function SectionHeader({ title }: SectionHeaderProps) {
         className="flex items-center gap-px text-xs leading-none text-neutral-500 bg-transparent border-none cursor-pointer p-0"
       >
         더보기
-        <img src={ChevronRightIcon} className="size-2.5 " />
+        <img src={ChevronRightIcon} className="size-2.5" />
       </button>
     </div>
   );

--- a/src/components/homepage/SectionHeader.tsx
+++ b/src/components/homepage/SectionHeader.tsx
@@ -1,0 +1,20 @@
+import ChevronRightIcon from '@/assets/ChevronRightIcon.svg';
+
+type SectionHeaderProps = {
+  title: string;
+};
+
+export function SectionHeader({ title }: SectionHeaderProps) {
+  return (
+    <div className="flex items-center justify-between px-4 mb-2.5">
+      <h2 className="text-xl font-bold leading-7 text-neutral-900">{title}</h2>
+      <button
+        type="button"
+        className="flex items-center gap-px text-xs leading-none text-neutral-500 bg-transparent border-none cursor-pointer p-0"
+      >
+        더보기
+        <img src={ChevronRightIcon} className="size-2.5 " />
+      </button>
+    </div>
+  );
+}

--- a/src/mocks/home.ts
+++ b/src/mocks/home.ts
@@ -72,21 +72,18 @@ export const DEADLINE_EXHIBITIONS: ExhibitionCardData[] = [
 export const ARTWORK_ITEMS: ArtworkPreviewItem[] = [
   {
     id: '1',
-    name: '색과 형태, 우리가 마주한 순간들',
+    name: '머문 자리의 온기',
     date: '2026.05.23 – 05.30',
-    location: '중앙대학교 301관',
   },
   {
     id: '2',
-    name: '색과 형태, 우리가 마주한 순간들 2',
+    name: '머문 자리의 온기',
     date: '2026.05.23 – 05.30',
-    location: '중앙대학교 301관',
   },
   {
     id: '3',
-    name: '색과 형태, 우리가 마주한 순간들 3',
+    name: '머문 자리의 온기',
     date: '2026.05.23 – 05.30',
-    location: '중앙대학교 301관',
   },
 ];
 

--- a/src/mocks/home.ts
+++ b/src/mocks/home.ts
@@ -1,0 +1,118 @@
+import type { ArtworkPreviewItem, DuPickItem, ExhibitionCardData, LoungePost } from '@/types/home';
+
+export const DU_PICK_ITEMS: DuPickItem[] = [
+  {
+    id: '1',
+    name: '색과 형태, 우리가 마주한 순간들',
+    date: '2026.05.23 – 05.30',
+    location: '중앙대학교 301관',
+  },
+  {
+    id: '2',
+    name: '빛과 그림자, 경계 위의 시간들',
+    date: '2026.06.01 – 06.10',
+    location: '홍익대학교 현대미술관',
+  },
+  {
+    id: '3',
+    name: '정지된 움직임, 그 사이의 공간',
+    date: '2026.06.14 – 06.20',
+    location: '서울대학교 미술관',
+  },
+  {
+    id: '4',
+    name: '기억의 층위, 쌓인 감각들',
+    date: '2026.06.25 – 07.05',
+    location: '국립현대미술관 서울',
+  },
+];
+
+export const GRADUATION_EXHIBITIONS: ExhibitionCardData[] = [
+  {
+    id: '1',
+    title: 'FORM 2026',
+    school: '중앙대학교 디자인학부',
+    period: '05.28 - 06.05',
+  },
+  {
+    id: '2',
+    title: 'VISUAL WAVE',
+    school: '홍익대학교 시각디자인',
+    period: '06.02 - 06.10',
+  },
+  {
+    id: '3',
+    title: 'NEW OFFICE',
+    school: '홍익대학교 시각디자인',
+    period: '06.02 - 06.10',
+  },
+];
+
+export const DEADLINE_EXHIBITIONS: ExhibitionCardData[] = [
+  {
+    id: '1',
+    title: 'FORM 2026',
+    school: '중앙대학교 디자인학부',
+    period: '05.28 - 06.10',
+  },
+  {
+    id: '2',
+    title: 'VISUAL WAVE',
+    school: '홍익대학교 시각디자인',
+    period: '06.02 - 06.10',
+  },
+  {
+    id: '3',
+    title: 'NEW OFFICE',
+    school: '홍익대학교 시각디자인',
+    period: '06.02 - 06.10',
+  },
+];
+
+export const ARTWORK_ITEMS: ArtworkPreviewItem[] = [
+  {
+    id: '1',
+    name: '색과 형태, 우리가 마주한 순간들',
+    date: '2026.05.23 – 05.30',
+    location: '중앙대학교 301관',
+  },
+  {
+    id: '2',
+    name: '색과 형태, 우리가 마주한 순간들 2',
+    date: '2026.05.23 – 05.30',
+    location: '중앙대학교 301관',
+  },
+  {
+    id: '3',
+    name: '색과 형태, 우리가 마주한 순간들 3',
+    date: '2026.05.23 – 05.30',
+    location: '중앙대학교 301관',
+  },
+];
+
+export const LOUNGE_POSTS: LoungePost[] = [
+  {
+    id: '1',
+    tag: '전시 후기',
+    content: '이번 주 중앙대 회화 전시 다녀왔어요',
+    author: 'artseeker_j',
+    time: '1시간 전',
+    views: '댓글 8',
+  },
+  {
+    id: '2',
+    tag: '준비·작업 팁',
+    content: '전시 카드 인쇄 어디서 맡기나요?',
+    author: 'design_junho',
+    time: '3시간 전',
+    views: '댓글 14',
+  },
+  {
+    id: '3',
+    tag: '모집·협업',
+    content: '사진 전시 함께 준비할 팀원 구해요',
+    author: 'lens_mina',
+    time: '어제',
+    views: '댓글 6',
+  },
+];

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -1,3 +1,23 @@
+import { ArtworkPreviewSection } from '@/components/homepage/ArtworkPreviewSection';
+import { DuPickBanner } from '@/components/homepage/DuPickBanner';
+import { ExhibitionSection } from '@/components/homepage/ExhibitionSection';
+import { LoungeSection } from '@/components/homepage/LoungeSection';
+import {
+  ARTWORK_ITEMS,
+  DEADLINE_EXHIBITIONS,
+  DU_PICK_ITEMS,
+  GRADUATION_EXHIBITIONS,
+  LOUNGE_POSTS,
+} from '@/mocks/home';
+
 export const Homepage = () => {
-  return <div>Homepage</div>;
+  return (
+    <div className="w-full max-w-[480px] mx-auto bg-white min-h-dvh overflow-x-hidden pt-2.5 pb-10 font-[Pretendard,sans-serif]">
+      <DuPickBanner items={DU_PICK_ITEMS} />
+      <ExhibitionSection title="졸업전시" items={GRADUATION_EXHIBITIONS} />
+      <ExhibitionSection title="놓치기 전에 볼 전시" items={DEADLINE_EXHIBITIONS} />
+      <ArtworkPreviewSection items={ARTWORK_ITEMS} />
+      <LoungeSection posts={LOUNGE_POSTS} />
+    </div>
+  );
 };

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -12,7 +12,7 @@ import {
 
 export const Homepage = () => {
   return (
-    <div className="w-full max-w-[480px] mx-auto bg-white min-h-dvh overflow-x-hidden pt-2.5 pb-10 font-[Pretendard,sans-serif]">
+    <div className="w-full max-w-105 mx-auto bg-white min-h-dvh overflow-x-hidden pt-2.5 pb-10 font-[Pretendard,sans-serif]">
       <DuPickBanner items={DU_PICK_ITEMS} />
       <ExhibitionSection title="졸업전시" items={GRADUATION_EXHIBITIONS} />
       <ExhibitionSection title="놓치기 전에 볼 전시" items={DEADLINE_EXHIBITIONS} />

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -16,7 +16,6 @@ export interface ArtworkPreviewItem {
   id: string;
   name: string;
   date: string;
-  location: string;
 }
 
 export interface LoungePost {

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -1,0 +1,29 @@
+export interface DuPickItem {
+  id: string;
+  name: string;
+  date: string;
+  location: string;
+}
+
+export interface ExhibitionCardData {
+  id: string;
+  title: string;
+  school: string;
+  period: string;
+}
+
+export interface ArtworkPreviewItem {
+  id: string;
+  name: string;
+  date: string;
+  location: string;
+}
+
+export interface LoungePost {
+  id: string;
+  tag: string;
+  content: string;
+  author: string;
+  time: string;
+  views: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react-swc';
+import { resolve } from 'path';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
 });


### PR DESCRIPTION
## 📝 작업 내용

- 메인페이지 기초 틀 구현 완료
- DU Pick 슬라이드 4초마다 자동 슬라이드 되도록 구현
- 졸업전시 & 놓치기 전에 볼 전시 3개 카드만 배치
- 작품 미리보기 섹션 쉬프트 + 마우스 스크롤로 양 옆 자유롭게 슬라이드 가능
- 라운지는 아직 미정이나 우선 목데이터로 구현

## 🔍 관련 이슈

close #6 

## 🖼️ 스크린샷

<img width="429" height="2222" alt="localhost_5173_" src="https://github.com/user-attachments/assets/d672a8f7-cad7-4353-b50c-e30cdb8ce2c3" />

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

-  졸업 전시 및 놓치기 전에 볼 전시, 추후 해당 섹션에 몇개의 데이터를 보여주느냐에 따라 수정 할 예정 우선 3개 고정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Replaced the homepage placeholder with a full featured layout featuring a rotating “DU Pick” banner, two exhibition sections, an artwork preview strip, and a lounge feed.
  * Added reusable section headers and card-based section components.
  * Enabled horizontal scrolling for the artwork preview (wheel-to-scroll) and added slide indicators for the rotating banner.
* **Chores**
  * Added home-page mock data and TypeScript types to power the UI.
  * Updated Vite to support `@` path imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->