### PR TITLE
refactor: 메인페이지 디자인 토큰 적용 완료

### DIFF
--- a/src/components/homepage/ArtworkPreviewSection.tsx
+++ b/src/components/homepage/ArtworkPreviewSection.tsx
@@ -28,7 +28,10 @@ export function ArtworkPreviewSection({ items }: Props) {
         className="flex gap-2 overflow-x-auto px-4 pb-2 scrollbar-none"
       >
         {items.map((item) => (
-          <div key={item.id} className="relative shrink-0 w-34 h-55 rounded-xl overflow-hidden">
+          <div
+            key={item.id}
+            className="relative shrink-0 w-34 h-55 rounded-xl overflow-hidden bg-box"
+          >
             <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/15 to-transparent" />
 
             <div className="absolute left-3 right-3 bottom-3">

--- a/src/components/homepage/ArtworkPreviewSection.tsx
+++ b/src/components/homepage/ArtworkPreviewSection.tsx
@@ -28,15 +28,12 @@ export function ArtworkPreviewSection({ items }: Props) {
         className="flex gap-2 overflow-x-auto px-4 pb-2 scrollbar-none"
       >
         {items.map((item) => (
-          <div
-            key={item.id}
-            className="relative shrink-0 w-34 h-55 rounded-xl overflow-hidden bg-[#D1D5DB]"
-          >
+          <div key={item.id} className="relative shrink-0 w-34 h-55 rounded-xl overflow-hidden">
             <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/15 to-transparent" />
 
-            <div className="absolute left-4 right-4 bottom-4">
-              <p className="text-sm font-bold text-white leading-snug mb-1">{item.name}</p>
-              <p className="text-[10px] text-white/80">{item.date}</p>
+            <div className="absolute left-3 right-3 bottom-3">
+              <p className="typo-body-sm-bold text-white">{item.name}</p>
+              <p className="typo-body-xs-regular text-faint">{item.date}</p>
             </div>
           </div>
         ))}

--- a/src/components/homepage/DuPickBanner.tsx
+++ b/src/components/homepage/DuPickBanner.tsx
@@ -28,7 +28,7 @@ export function DuPickBanner({ items }: Props) {
   return (
     <section className="pb-7">
       <div className="px-4 mb-2.5 flex justify-between items-center">
-        <h2 className="flex items-center gap-1.5 typo-heading-3xl text-[#06032d]">
+        <h2 className="flex items-center gap-1.5 typo-heading-3xl text-main">
           <img src={logo} alt="DU" className="h-7 w-auto" />
           <span>Pick</span>
         </h2>
@@ -47,8 +47,8 @@ export function DuPickBanner({ items }: Props) {
           <div className="absolute inset-0 bg-linear-to-t from-black/65 via-black/20 to-transparent" />
 
           <div className="absolute left-7 right-4 bottom-9">
-            <p className="typo-body-xl-bold mb-1.5">{current.name}</p>
-            <p className="typo-body-xs-regular">
+            <p className="typo-body-xl-bold text-white mb-1.5">{current.name}</p>
+            <p className="typo-body-xs-regular text-faint">
               {current.date}&nbsp;&nbsp;{current.location}
             </p>
           </div>
@@ -61,7 +61,7 @@ export function DuPickBanner({ items }: Props) {
                 aria-label={`슬라이드 ${i + 1}`}
                 onClick={() => setActiveIndex(i)}
                 className={`w-1.75 h-1.75 rounded-full border-none p-0 cursor-pointer shrink-0 transition-all duration-200 ${
-                  i === activeIndex ? 'bg-blue-500' : 'bg-white/50'
+                  i === activeIndex ? 'bg-line-active' : 'bg-[#667281]'
                 }`}
               />
             ))}

--- a/src/components/homepage/ExhibitionSection.tsx
+++ b/src/components/homepage/ExhibitionSection.tsx
@@ -8,13 +8,13 @@ function ExhibitionCard({ item }: { item: ExhibitionCardData }) {
 
   return (
     <article
-      className="flex flex-col gap-1.5 min-w-0 bg-bg cursor-pointer"
+      className="flex flex-col gap-1.5 min-w-0 bg-page cursor-pointer"
       onClick={() => navigate(`/display/${item.id}`)}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => e.key === 'Enter' && navigate(`/display/${item.id}`)}
     >
-      <div className="w-full aspect-3/4 rounded-xl shrink-0 overflow-hidden">
+      <div className="w-full aspect-3/4 rounded-xl shrink-0 overflow-hidden bg-box">
         {item.thumbnail ? (
           <img src={item.thumbnail} alt={item.title} className="w-full h-full object-cover" />
         ) : null}

--- a/src/components/homepage/ExhibitionSection.tsx
+++ b/src/components/homepage/ExhibitionSection.tsx
@@ -8,21 +8,21 @@ function ExhibitionCard({ item }: { item: ExhibitionCardData }) {
 
   return (
     <article
-      className="flex flex-col gap-1.5 min-w-0 bg-white cursor-pointer"
+      className="flex flex-col gap-1.5 min-w-0 bg-bg cursor-pointer"
       onClick={() => navigate(`/display/${item.id}`)}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => e.key === 'Enter' && navigate(`/display/${item.id}`)}
     >
-      <div className="w-full aspect-3/4 rounded-xl bg-[#D1D5DB] shrink-0 overflow-hidden">
+      <div className="w-full aspect-3/4 rounded-xl shrink-0 overflow-hidden">
         {item.thumbnail ? (
           <img src={item.thumbnail} alt={item.title} className="w-full h-full object-cover" />
         ) : null}
       </div>
-      <div className="flex flex-col gap-0.5">
+      <div className="flex flex-col">
         <p className="typo-body-xs-bold text-main truncate">{item.title}</p>
-        <p className="typo-body-xs-regular text-sub truncate">{item.school}</p>
-        <p className="typo-body-xs-regular text-hint">{item.period}</p>
+        <p className="typo-body-xs-regular text-sub700 truncate">{item.school}</p>
+        <p className="typo-body-xs-regular text-hint mt-0.5">{item.period}</p>
       </div>
     </article>
   );

--- a/src/components/homepage/ExhibitionSection.tsx
+++ b/src/components/homepage/ExhibitionSection.tsx
@@ -20,9 +20,9 @@ function ExhibitionCard({ item }: { item: ExhibitionCardData }) {
         ) : null}
       </div>
       <div className="flex flex-col gap-0.5">
-        <p className="text-xs font-bold text-neutral-900 truncate">{item.title}</p>
-        <p className="text-xs text-neutral-600 truncate">{item.school}</p>
-        <p className="text-xs text-neutral-500">{item.period}</p>
+        <p className="typo-body-xs-bold text-main truncate">{item.title}</p>
+        <p className="typo-body-xs-regular text-sub truncate">{item.school}</p>
+        <p className="typo-body-xs-regular text-hint">{item.period}</p>
       </div>
     </article>
   );

--- a/src/components/homepage/LoungeSection.tsx
+++ b/src/components/homepage/LoungeSection.tsx
@@ -3,31 +3,24 @@ import type { LoungePost } from '@/types/exhibition';
 
 function LoungePostItem({ post }: { post: LoungePost }) {
   return (
-    <div className="mx-4 mb-4 rounded-lg shadow-sm border border-zinc-300 bg-white p-4 flex flex-col gap-2.5">
-      <div className="flex items-center justify-between">
-        <span
-          className="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-bold
-       text-sky-600 bg-gray-200"
-        >
-          {post.tag}
-        </span>
+    <div className="mx-4 mb-4 px-4 py-3.5 bg-card rounded-lg shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)] flex flex-col gap-2.5">
+      <div className="flex justify-between items-start w-full">
+        <div className="flex flex-col gap-3 flex-1 min-w-0">
+          <div className="px-2 py-0.5 bg-bt-gray rounded-sm inline-flex items-center self-start">
+            <span className="text-link text-[10px] font-bold">{post.tag}</span>
+          </div>
 
-        <button
-          type="button"
-          className="text-[#BBBBBB] hover:text-[#999999] bg-transparent border-none cursor-pointer p-0 text-lg font-bold leading-none"
-        >
-          ···
-        </button>
-      </div>
-
-      <p className="text-[14px] font-bold text-[#111111] leading-snug">{post.content}</p>
-
-      <div className="flex items-center gap-1.5 text-[11px] text-[#9CA3AF]">
-        <span>{post.author}</span>
-        <span className="text-[#D1D5DB]">·</span>
-        <span>{post.time}</span>
-        <span className="text-[#D1D5DB]">·</span>
-        <span>{post.views}</span>
+          <div className="flex flex-col gap-1">
+            <p className="typo-body-sm-bold text-main">{post.content}</p>
+            <div className="flex items-center gap-2 typo-body-xs-regular text-faint">
+              <span>{post.author}</span>
+              <span>·</span>
+              <span>{post.time}</span>
+              <span>·</span>
+              <span>{post.views}</span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -39,7 +32,7 @@ type Props = {
 
 export function LoungeSection({ posts }: Props) {
   return (
-    <section className="mb-8">
+    <section>
       <SectionHeader title="라운지" />
       <div>
         {posts.map((post) => (

--- a/src/components/homepage/SectionHeader.tsx
+++ b/src/components/homepage/SectionHeader.tsx
@@ -1,4 +1,4 @@
-import ChevronRightIcon from '@/assets/ChevronRightIcon.svg';
+import { ChevronRightIcon } from 'lucide-react';
 
 type SectionHeaderProps = {
   title: string;
@@ -7,13 +7,13 @@ type SectionHeaderProps = {
 export function SectionHeader({ title }: SectionHeaderProps) {
   return (
     <div className="flex items-center justify-between px-4 mb-2.5">
-      <h2 className="text-xl font-bold leading-7 text-neutral-900">{title}</h2>
+      <h2 className="typo-body-xl-bold text-main">{title}</h2>
       <button
         type="button"
-        className="flex items-center gap-px text-xs leading-none text-neutral-500 bg-transparent border-none cursor-pointer p-0"
+        className="flex items-center gap-px typo-body-xs-regular text-hint bg-transparent border-none cursor-pointer p-0"
       >
         더보기
-        <img src={ChevronRightIcon} className="size-2.5" />
+        <ChevronRightIcon className="text-hint size-3" />
       </button>
     </div>
   );

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -58,7 +58,7 @@ export const Homepage = () => {
   }, []);
 
   return (
-    <div className="w-full max-w-105 mx-auto bg-bg min-h-dvh overflow-x-hidden pt-2.5 font-[Pretendard,sans-serif]">
+    <div className="w-full max-w-105 mx-auto bg-page min-h-dvh overflow-x-hidden pt-2.5 font-[Pretendard,sans-serif]">
       <DuPickBanner items={DU_PICK_ITEMS} />
       <ExhibitionSection title="졸업전시" items={graduationExhibitions} />
       <ExhibitionSection title="놓치기 전에 볼 전시" items={DEADLINE_EXHIBITIONS} />

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -58,7 +58,7 @@ export const Homepage = () => {
   }, []);
 
   return (
-    <div className="w-full max-w-105 mx-auto bg-white min-h-dvh overflow-x-hidden pt-2.5 pb-10 font-[Pretendard,sans-serif]">
+    <div className="w-full max-w-105 mx-auto bg-bg min-h-dvh overflow-x-hidden pt-2.5 font-[Pretendard,sans-serif]">
       <DuPickBanner items={DU_PICK_ITEMS} />
       <ExhibitionSection title="졸업전시" items={graduationExhibitions} />
       <ExhibitionSection title="놓치기 전에 볼 전시" items={DEADLINE_EXHIBITIONS} />


### PR DESCRIPTION
## 📝 작업 내용

- 메인페이지 디자인토큰 적용

## 🔍 관련 이슈

- close #44 

## 🖼️ 스크린샷

<img width="926" height="2106" alt="localhost_5173_ (2)" src="https://github.com/user-attachments/assets/778bfc07-b263-4a4a-bd37-ca2757e9a22f" />

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 홈페이지 전반의 배경색을 `bg-page`로 조정하고 하단 패딩을 변경했습니다.
  - 작품 미리보기/전시 카드의 외곽 배경, 텍스트 타이포그래피·색상, 간격을 개선했습니다.
  - 배너 슬라이드의 제목·보조 문구 색상 및 활성/비활성 인디케이터 색을 업데이트했습니다.
  - 라운지 게시물의 표시 레이아웃을 정리하고 불필요한 메뉴 버튼을 제거했습니다.
  - 섹션 헤더의 “더보기” 버튼과 오른쪽 화살표 아이콘 스타일을 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->