### PR TITLE
fix: 작가 마이페이지 메모장, 북마크 제거 완료

### DIFF
--- a/src/components/mypage/ArtworkCard.tsx
+++ b/src/components/mypage/ArtworkCard.tsx
@@ -4,9 +4,10 @@ import type { SavedArtworkItem } from '@/types/mypage';
 
 interface ArtworkCardProps {
   item: SavedArtworkItem;
+  isArtistView?: boolean;
 }
 
-export function ArtworkCard({ item }: ArtworkCardProps) {
+export function ArtworkCard({ item, isArtistView = false }: ArtworkCardProps) {
   return (
     <article className="bg-neutral-50 rounded-2xl shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)] flex flex-col overflow-hidden font-['Pretendard']">
       <div className="p-1.5 pb-0">
@@ -18,13 +19,15 @@ export function ArtworkCard({ item }: ArtworkCardProps) {
               alt={item.title}
             />
           </div>
-          <button
-            type="button"
-            aria-label="북마크"
-            className="absolute bottom-2 right-2"
-          >
-            <Bookmark color="#D70004" fill="#D70004" className="size-4-10" />
-          </button>
+          {!isArtistView && (
+            <button
+              type="button"
+              aria-label="북마크"
+              className="absolute bottom-2 right-2"
+            >
+              <Bookmark color="#D70004" fill="#D70004" className="size-4-10" />
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/components/mypage/ExhibitionCard.tsx
+++ b/src/components/mypage/ExhibitionCard.tsx
@@ -31,13 +31,11 @@ export function ExhibitionCard({ item, isArtistView }: ExhibitionCardProps) {
                 {item.status}
               </span>
             </div>
-            <button type="button" aria-label="북마크" className="shrink-0">
-              <Bookmark
-                fill="#D70004"
-                color={isArtistView ? '#D70004' : '#D70004'}
-                className={isArtistView ? 'size-4' : 'size-4'}
-              />
-            </button>
+            {!isArtistView && (
+              <button type="button" aria-label="북마크" className="shrink-0">
+                <Bookmark fill="#D70004" color="#D70004" className="size-4" />
+              </button>
+            )}
           </div>
 
           <div className="self-stretch pt-2.5">
@@ -61,37 +59,39 @@ export function ExhibitionCard({ item, isArtistView }: ExhibitionCardProps) {
         </div>
       </div>
 
-      <footer className="px-4 py-2 bg-gray-200 flex flex-col justify-start items-start gap-1.5">
-        <div className="self-stretch flex justify-between items-center">
-          <div className="flex justify-start items-center gap-1.5">
-            <Pencil color="#99A1AF" className="size-2.5 shrink-0" />
-            <span className="text-neutral-400 text-xs font-semibold leading-4">
-              내 메모
-            </span>
+      {!isArtistView && (
+        <footer className="px-4 py-2 bg-gray-200 flex flex-col justify-start items-start gap-1.5">
+          <div className="self-stretch flex justify-between items-center">
+            <div className="flex justify-start items-center gap-1.5">
+              <Pencil color="#99A1AF" className="size-2.5 shrink-0" />
+              <span className="text-neutral-400 text-xs font-semibold leading-4">
+                내 메모
+              </span>
+            </div>
+            {hasMemo && (
+              <button
+                type="button"
+                className="text-neutral-400 text-xs font-normal underline leading-4 shrink-0"
+              >
+                확인
+              </button>
+            )}
           </div>
-          {hasMemo && (
+
+          {hasMemo ? (
+            <p className="self-stretch text-neutral-400 text-xs font-normal leading-4 line-clamp-2">
+              {item.memo}
+            </p>
+          ) : (
             <button
               type="button"
-              className="text-neutral-400 text-xs font-normal underline leading-4 shrink-0"
+              className="self-stretch text-left text-stone-300 text-xs font-normal underline leading-4"
             >
-              확인
+              메모 작성하기
             </button>
           )}
-        </div>
-
-        {hasMemo ? (
-          <p className="self-stretch text-neutral-400 text-xs font-normal leading-4 line-clamp-2">
-            {item.memo}
-          </p>
-        ) : (
-          <button
-            type="button"
-            className="self-stretch text-left text-stone-300 text-xs font-normal underline leading-4"
-          >
-            메모 작성하기
-          </button>
-        )}
-      </footer>
+        </footer>
+      )}
     </article>
   );
 }

--- a/src/mocks/mypage.ts
+++ b/src/mocks/mypage.ts
@@ -11,7 +11,8 @@ export const TABS: { key: TabKey; label: string }[] = [
   { key: 'artist', label: '작가' },
 ];
 
-export const EXHIBITIONS: ExhibitionItem[] = [
+// 내가 북마크한 전시 (일반 사용자 뷰)
+export const MY_BOOKMARKED_EXHIBITIONS: ExhibitionItem[] = [
   {
     id: '1',
     status: '전시 중',
@@ -43,7 +44,42 @@ export const EXHIBITIONS: ExhibitionItem[] = [
   },
 ];
 
-export const ARTWORKS: SavedArtworkItem[] = [
+// 내가 참여한 전시 (작가 뷰)
+export const MY_PARTICIPATED_EXHIBITIONS: ExhibitionItem[] = [
+  {
+    id: '4',
+    status: '전시 중',
+    title: '빛과 색의 경계',
+    org: '중앙대학교 예술대학',
+    period: '07.10 – 07.20',
+    place: '중앙대학교 아트센터',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+  {
+    id: '5',
+    status: '전시예정',
+    title: '일상의 순간들',
+    org: '서울시립미술관',
+    period: '08.01 – 08.15',
+    place: '서울시립미술관 북서울관',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+  {
+    id: '6',
+    status: '전시종료',
+    title: '색채의 향연',
+    org: '홍익대학교 미술대학',
+    period: '06.01 – 06.10',
+    place: '홍익대학교 미술관',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+];
+
+// 하위 호환성을 위한 alias (기본은 북마크한 전시)
+export const EXHIBITIONS = MY_BOOKMARKED_EXHIBITIONS;
+
+// 내가 북마크한 작품 (일반 사용자 뷰)
+export const MY_BOOKMARKED_ARTWORKS: SavedArtworkItem[] = [
   {
     id: '1',
     title: 'FROM 2026',
@@ -69,6 +105,37 @@ export const ARTWORKS: SavedArtworkItem[] = [
     thumbnail: 'https://placehold.co/112x140',
   },
 ];
+
+// 내가 등록한 작품 (작가 뷰)
+export const MY_REGISTERED_ARTWORKS: SavedArtworkItem[] = [
+  {
+    id: '5',
+    title: '빛의 파편',
+    artist: '김지원',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+  {
+    id: '6',
+    title: '색채의 울림',
+    artist: '김지원',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+  {
+    id: '7',
+    title: '순간의 기록',
+    artist: '김지원',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+  {
+    id: '8',
+    title: '경계의 풍경',
+    artist: '김지원',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+];
+
+// 하위 호환성을 위한 alias (기본은 북마크한 작품)
+export const ARTWORKS = MY_BOOKMARKED_ARTWORKS;
 
 export const ARTISTS: ArtistItem[] = [
   {

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -9,7 +9,13 @@ import {
   SettingsSheet,
 } from '@/components/mypage';
 import { useUserProfile } from '@/hooks/useUserProfile';
-import { ARTISTS, ARTWORKS, EXHIBITIONS } from '@/mocks/mypage';
+import {
+  ARTISTS,
+  MY_BOOKMARKED_ARTWORKS,
+  MY_BOOKMARKED_EXHIBITIONS,
+  MY_PARTICIPATED_EXHIBITIONS,
+  MY_REGISTERED_ARTWORKS,
+} from '@/mocks/mypage';
 import type { TabKey } from '@/types/mypage';
 
 export function MyPage() {
@@ -86,7 +92,10 @@ export function MyPage() {
       <section className="flex-1 min-h-0 overflow-y-auto px-4 py-6">
         {activeTab === 'exhibition' && (
           <div className="flex flex-col gap-3">
-            {EXHIBITIONS.map((item) => (
+            {(isArtistView
+              ? MY_PARTICIPATED_EXHIBITIONS
+              : MY_BOOKMARKED_EXHIBITIONS
+            ).map((item) => (
               <ExhibitionCard
                 key={item.id}
                 item={item}
@@ -98,8 +107,11 @@ export function MyPage() {
 
         {activeTab === 'artwork' && (
           <div className="grid grid-cols-2 gap-x-1.5 gap-y-3">
-            {ARTWORKS.map((item) => (
-              <ArtworkCard key={item.id} item={item} />
+            {(isArtistView
+              ? MY_REGISTERED_ARTWORKS
+              : MY_BOOKMARKED_ARTWORKS
+            ).map((item) => (
+              <ArtworkCard key={item.id} item={item} isArtistView={isArtistView} />
             ))}
           </div>
         )}


### PR DESCRIPTION
## 📝 작업 내용

- 작가 마이페이지 메모장, 북마크 제거 완료

## 🔍 관련 이슈

- #53 

## 🖼️ 스크린샷

<img width="379" height="681" alt="image" src="https://github.com/user-attachments/assets/194e91dc-2ce7-4225-a864-316b02fcad50" />
<img width="358" height="663" alt="image" src="https://github.com/user-attachments/assets/ecf98d1b-dadc-4ece-82b1-17efd56fe49b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 작가 화면에서 등록한 전시와 작품을 별도로 확인할 수 있습니다.
  * 일반 화면에서는 북마크한 전시와 작품을 확인할 수 있습니다.
* **개선 사항**
  * 작가 화면에서는 북마크 및 메모 관련 기능이 표시되지 않아 화면이 간결해졌습니다.
  * 화면 유형에 따라 카드에 제공되는 메뉴와 정보가 적절히 구분됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->