### PR TITLE
refactor: 전시 상세페이지 디자인 토큰 적용 완료

### DIFF
--- a/src/components/displaydetailpage/ArtworkTab.tsx
+++ b/src/components/displaydetailpage/ArtworkTab.tsx
@@ -7,12 +7,12 @@ type ArtworkCardProps = {
 function ArtworkCard({ item }: ArtworkCardProps) {
   return (
     <article className="bg-white rounded-xl overflow-hidden shadow-sm flex flex-col px-2 py-3">
-      <div className="aspect-square w-full rounded-xl overflow-hidden bg-[#f5f5f5]">
+      <div className="aspect-square w-full rounded-xl overflow-hidden bg-page">
         <img src={item.thumbnail} alt={item.title} className="w-full h-full object-cover" />
       </div>
-      <div className="px-1 pt-2 font-[Pretendard,sans-serif] flex flex-col gap-0.5">
-        <p className="text-sm font-bold text-[#111] truncate leading-tight">{item.title}</p>
-        <p className="text-xs text-[#666] truncate leading-none">{item.artist}</p>
+      <div className="pt-3 font-[Pretendard,sans-serif] flex flex-col">
+        <p className="typo-body-sm-bold truncate text-main">{item.title}</p>
+        <p className="typo-body-xs-regular truncate text-main">{item.artist}</p>
       </div>
     </article>
   );
@@ -24,8 +24,8 @@ type Props = {
 
 export function ArtworkTab({ artworks }: Props) {
   return (
-    <div className="px-5 py-5 min-h-[400px] font-[Pretendard,sans-serif]">
-      <h1 className="mb-3 text-[#111111] text-xl font-bold">작품 미리보기</h1>
+    <div className="px-5 py-6 min-h-100 font-[Pretendard,sans-serif]">
+      <h1 className="mb-3 typo-body-xl-bold text-main">작품 미리보기</h1>
       <div className="grid grid-cols-2 gap-3">
         {artworks.map((item) => (
           <ArtworkCard key={item.id} item={item} />

--- a/src/components/displaydetailpage/ArtworkTab.tsx
+++ b/src/components/displaydetailpage/ArtworkTab.tsx
@@ -24,7 +24,7 @@ type Props = {
 
 export function ArtworkTab({ artworks }: Props) {
   return (
-    <div className="px-5 py-6 min-h-100 font-[Pretendard,sans-serif]">
+    <div className="px-5 py-6 min-h-100">
       <h1 className="mb-3 typo-body-xl-bold text-main">작품 미리보기</h1>
       <div className="grid grid-cols-2 gap-3">
         {artworks.map((item) => (

--- a/src/components/displaydetailpage/ArtworkTab.tsx
+++ b/src/components/displaydetailpage/ArtworkTab.tsx
@@ -10,7 +10,7 @@ function ArtworkCard({ item }: ArtworkCardProps) {
       <div className="aspect-square w-full rounded-xl overflow-hidden bg-page">
         <img src={item.thumbnail} alt={item.title} className="w-full h-full object-cover" />
       </div>
-      <div className="pt-3 font-[Pretendard,sans-serif] flex flex-col">
+      <div className="pt-3 flex flex-col">
         <p className="typo-body-sm-bold truncate text-main">{item.title}</p>
         <p className="typo-body-xs-regular truncate text-main">{item.artist}</p>
       </div>

--- a/src/components/displaydetailpage/BottomFixedBar.tsx
+++ b/src/components/displaydetailpage/BottomFixedBar.tsx
@@ -4,9 +4,12 @@ import { DisplaySaveButton } from './DisplaySaveButton';
 
 export function BottomFixedBar() {
   return (
-    <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full bg-white border-t border-[#e5e5e5] px-5 py-3 flex items-center justify-between z-50 pb-[calc(12px+env(safe-area-inset-bottom))]">
-      <button type="button" className="w-12 h-12 flex items-center justify-center shrink-0">
-        <Share2 size={24} color="#333" />
+    <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full bg-white border-t border-line px-5 py-3 flex items-center justify-between z-50">
+      <button
+        type="button"
+        className="w-12 h-12 flex items-center justify-center shrink-0 cursor-pointer"
+      >
+        <Share2 size={24} className="text-sub700" />
       </button>
 
       <DisplaySaveButton className="flex-1 ml-2" />

--- a/src/components/displaydetailpage/BottomFixedBar.tsx
+++ b/src/components/displaydetailpage/BottomFixedBar.tsx
@@ -4,7 +4,7 @@ import { DisplaySaveButton } from './DisplaySaveButton';
 
 export function BottomFixedBar() {
   return (
-    <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full bg-white border-t border-line px-5 py-3 flex items-center justify-between z-50">
+    <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-md bg-white border-t border-line px-5 pt-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] flex items-center justify-between z-50">
       <button
         type="button"
         className="w-12 h-12 flex items-center justify-center shrink-0 cursor-pointer"

--- a/src/components/displaydetailpage/DetailTabNav.tsx
+++ b/src/components/displaydetailpage/DetailTabNav.tsx
@@ -1,4 +1,5 @@
 import type { DetailTabKey } from '@/types/exhibition';
+import { cn } from '@/utils/cn';
 
 const DETAIL_TABS: { key: DetailTabKey; label: string }[] = [
   { key: 'intro', label: '소개' },
@@ -22,7 +23,10 @@ export function DetailTabNav({ activeTab, onTabChange }: Props) {
             id={`tab-${tab.key}`}
             type="button"
             onClick={() => onTabChange(tab.key)}
-            className={`py-4 typo-body-sm-regular transition-all duration-150 relative whitespace-nowrap ${isActive ? 'text-main' : 'text-faint'}`}
+            className={cn(
+              'py-4 typo-body-sm-regular transition-all duration-150 relative whitespace-nowrap',
+              isActive ? 'text-main' : 'text-faint',
+            )}
           >
             {tab.label}
             {isActive && <span className="absolute -bottom-0.5 left-0 right-0 h-0.5 bg-main" />}

--- a/src/components/displaydetailpage/DetailTabNav.tsx
+++ b/src/components/displaydetailpage/DetailTabNav.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 export function DetailTabNav({ activeTab, onTabChange }: Props) {
   return (
-    <nav className="bg-[#F0F0F3] sticky top-0 z-10 border-b-2 border-[#e5e5e5] flex px-5 gap-10">
+    <nav className="bg-page sticky top-0 z-10 border-b-2 border-line-soft flex px-5 gap-10">
       {DETAIL_TABS.map((tab) => {
         const isActive = tab.key === activeTab;
         return (
@@ -22,14 +22,10 @@ export function DetailTabNav({ activeTab, onTabChange }: Props) {
             id={`tab-${tab.key}`}
             type="button"
             onClick={() => onTabChange(tab.key)}
-            className="py-3 text-[14px] font-[Pretendard,sans-serif] transition-all duration-150 relative whitespace-nowrap"
-            style={{
-              color: isActive ? '#111' : '#aaa',
-              fontWeight: isActive ? 700 : 400,
-            }}
+            className={`py-4 typo-body-sm-regular transition-all duration-150 relative whitespace-nowrap ${isActive ? 'text-main' : 'text-faint'}`}
           >
             {tab.label}
-            {isActive && <span className="absolute bottom-[-2px] left-0 right-0 h-0.5 bg-[#111]" />}
+            {isActive && <span className="absolute -bottom-0.5 left-0 right-0 h-0.5 bg-main" />}
           </button>
         );
       })}

--- a/src/components/displaydetailpage/DisplaySaveButton.tsx
+++ b/src/components/displaydetailpage/DisplaySaveButton.tsx
@@ -1,11 +1,16 @@
 import { Bookmark } from 'lucide-react';
 
+import { cn } from '@/utils/cn';
+
 export function DisplaySaveButton({ className = '', id }: { className?: string; id?: string }) {
   return (
     <button
       type="button"
       id={id}
-      className={`w-full py-3.5 rounded-xl bg-main text-white typo-body-sm-bold tracking-tight transition-all duration-200 active:scale-90 flex items-center justify-center gap-2 cursor-pointer ${className}`}
+      className={cn(
+        'w-full py-3.5 rounded-xl bg-main text-white typo-body-sm-bold tracking-tight transition-all duration-200 active:scale-90 flex items-center justify-center gap-2 cursor-pointer',
+        className,
+      )}
     >
       <Bookmark size={15} />
       전시 저장

--- a/src/components/displaydetailpage/DisplaySaveButton.tsx
+++ b/src/components/displaydetailpage/DisplaySaveButton.tsx
@@ -5,9 +5,9 @@ export function DisplaySaveButton({ className = '', id }: { className?: string; 
     <button
       type="button"
       id={id}
-      className={`w-full py-3.5 rounded-xl bg-main text-white typo-body-sm-bold tracking-tight transition-all duration-200 active:scale-[0.98] flex items-center justify-center gap-2 ${className}`}
+      className={`w-full py-3.5 rounded-xl bg-main text-white typo-body-sm-bold tracking-tight transition-all duration-200 active:scale-90 flex items-center justify-center gap-2 cursor-pointer ${className}`}
     >
-      <Bookmark size={15} color="#fff" />
+      <Bookmark size={15} />
       전시 저장
     </button>
   );

--- a/src/components/displaydetailpage/DisplaySaveButton.tsx
+++ b/src/components/displaydetailpage/DisplaySaveButton.tsx
@@ -5,7 +5,7 @@ export function DisplaySaveButton({ className = '', id }: { className?: string; 
     <button
       type="button"
       id={id}
-      className={`w-full py-3.5 rounded-xl bg-[#111] text-white text-[15px] font-bold font-[Pretendard,sans-serif] tracking-tight transition-all duration-200 active:scale-[0.98] flex items-center justify-center gap-2 ${className}`}
+      className={`w-full py-3.5 rounded-xl bg-main text-white typo-body-sm-bold tracking-tight transition-all duration-200 active:scale-[0.98] flex items-center justify-center gap-2 ${className}`}
     >
       <Bookmark size={15} color="#fff" />
       전시 저장

--- a/src/components/displaydetailpage/ExhibitionMeta.tsx
+++ b/src/components/displaydetailpage/ExhibitionMeta.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Calendar, Clock, Heart, MapPin } from 'lucide-react';
 
 import type { ExhibitionDetail } from '@/types/exhibition';
+import { cn } from '@/utils/cn';
 
 import { DisplaySaveButton } from './DisplaySaveButton';
 
@@ -15,7 +16,7 @@ export function ExhibitionMeta({ exhibition: ex }: Props) {
   const likeCount = ex.bookmarkCount;
 
   return (
-    <section className="px-5 pt-6 pb-4 font-[Pretendard,sans-serif]">
+    <section className="px-5 pt-6 pb-4">
       {/* 제목/하트 */}
       <div className="flex items-start justify-between gap-2">
         <h1 className="flex-1 typo-body-xl-bold text-main">{ex.title}</h1>
@@ -23,12 +24,14 @@ export function ExhibitionMeta({ exhibition: ex }: Props) {
           type="button"
           id="meta-heart-btn"
           onClick={() => setBookmarked((v) => !v)}
-          className="flex flex-col items-center gap-0.5 shrink-0 pt-0.5 transition-all duration-200 active:scale-95"
+          className="flex flex-col items-center gap-0.5 shrink-0 pt-0.5 transition-all duration-200 active:scale-95 cursor-pointer"
         >
           <Heart
             size={17}
-            fill={bookmarked ? 'var(--bt-heart-filled)' : 'none'}
-            color={bookmarked ? 'var(--bt-heart-filled)' : 'var(--bt-heart-border)'}
+            className={cn(
+              'transition-colors duration-200',
+              bookmarked ? 'fill-heart text-heart' : 'fill-none text-sub700',
+            )}
           />
           <span className="typo-body-xs-regular text-main">{likeCount}</span>
         </button>

--- a/src/components/displaydetailpage/ExhibitionMeta.tsx
+++ b/src/components/displaydetailpage/ExhibitionMeta.tsx
@@ -27,8 +27,8 @@ export function ExhibitionMeta({ exhibition: ex }: Props) {
         >
           <Heart
             size={17}
-            fill={bookmarked ? '#c32427' : 'none'}
-            color={bookmarked ? '#c32427' : '#888'}
+            fill={bookmarked ? 'var(--bt-heart-filled)' : 'none'}
+            color={bookmarked ? 'var(--bt-heart-filled)' : 'var(--bt-heart-border)'}
           />
           <span className="typo-body-xs-regular text-main">{likeCount}</span>
         </button>

--- a/src/components/displaydetailpage/ExhibitionMeta.tsx
+++ b/src/components/displaydetailpage/ExhibitionMeta.tsx
@@ -15,10 +15,10 @@ export function ExhibitionMeta({ exhibition: ex }: Props) {
   const likeCount = ex.bookmarkCount;
 
   return (
-    <section className="px-5 pt-4 pb-4 font-[Pretendard,sans-serif]">
-      {/* 제목 + 하트 */}
+    <section className="px-5 pt-6 pb-4 font-[Pretendard,sans-serif]">
+      {/* 제목/하트 */}
       <div className="flex items-start justify-between gap-2">
-        <h1 className="flex-1 text-neutral-900 text-xl font-bold leading-snug">{ex.title}</h1>
+        <h1 className="flex-1 typo-body-xl-bold text-main">{ex.title}</h1>
         <button
           type="button"
           id="meta-heart-btn"
@@ -27,29 +27,29 @@ export function ExhibitionMeta({ exhibition: ex }: Props) {
         >
           <Heart
             size={17}
-            fill={bookmarked ? '#ef4444' : 'none'}
-            color={bookmarked ? '#ef4444' : '#888'}
+            fill={bookmarked ? '#c32427' : 'none'}
+            color={bookmarked ? '#c32427' : '#888'}
           />
-          <span className="text-[13px] text-[#888]">{likeCount}</span>
+          <span className="typo-body-xs-regular text-main">{likeCount}</span>
         </button>
       </div>
-      <p className="mt-0.5 text-neutral-600 text-sm">{ex.subtitle}</p>
+      <p className="typo-body-sm-regular text-sub600">{ex.subtitle}</p>
 
-      {/* 메타 정보 행: 일정/운영/장소 라벨 포함 */}
-      <div className="mt-3 flex flex-col gap-1.5">
-        <div className="flex items-center gap-2 text-[13px] text-[#444]">
-          <Calendar size={13} className="text-[#888] shrink-0" />
-          <span className="text-[#999] font-medium w-6 shrink-0">일정</span>
+      {/* 일정/운영/장소 */}
+      <div className="mt-5 flex flex-col gap-1.5">
+        <div className="flex items-center gap-2 typo-body-sm-regular">
+          <Calendar size={13} className="text-faint shrink-0" />
+          <span className="text-faint font-medium w-6 shrink-0">일정</span>
           <span>{ex.period}</span>
         </div>
-        <div className="flex items-center gap-2 text-[13px] text-[#444]">
-          <Clock size={13} className="text-[#888] shrink-0" />
-          <span className="text-[#999] font-medium w-6 shrink-0">운영</span>
+        <div className="flex items-center gap-2 typo-body-sm-regular">
+          <Clock size={13} className="text-faint shrink-0" />
+          <span className="text-faint font-medium w-6 shrink-0">운영</span>
           <span>{ex.hours}</span>
         </div>
-        <div className="flex items-center gap-2 text-[13px] text-[#444]">
-          <MapPin size={13} className="text-[#888] shrink-0" />
-          <span className="text-[#999] font-medium w-6 shrink-0">장소</span>
+        <div className="flex items-center gap-2 typo-body-sm-regular">
+          <MapPin size={13} className="text-faint shrink-0" />
+          <span className="text-faint font-medium w-6 shrink-0">장소</span>
           <span>{ex.location}</span>
         </div>
       </div>

--- a/src/components/displaydetailpage/HeroSlider.tsx
+++ b/src/components/displaydetailpage/HeroSlider.tsx
@@ -11,7 +11,7 @@ export function HeroSlider({ images, onBack }: Props) {
   const [current, setCurrent] = useState(0);
 
   return (
-    <div className="relative w-full overflow-hidden bg-[#111]" style={{ height: '568px' }}>
+    <div className="relative w-full overflow-hidden bg-main" style={{ height: '568px' }}>
       {images.map((src, idx) => (
         <img
           key={src}
@@ -33,16 +33,9 @@ export function HeroSlider({ images, onBack }: Props) {
             type="button"
             aria-label={`슬라이드 ${idx + 1}`}
             onClick={() => setCurrent(idx)}
-            style={{
-              width: 7,
-              height: 7,
-              borderRadius: '50%',
-              background: idx === current ? '#3B82F6' : 'rgba(255,255,255,0.5)',
-              border: 'none',
-              padding: 0,
-              cursor: 'pointer',
-              transition: 'background 0.2s',
-            }}
+            className={`w-1.75 h-1.75 rounded-full border-none p-0 cursor-pointer shrink-0 transition-all duration-200 ${
+              idx === current ? 'bg-line-active' : 'bg-[#667281]'
+            }`}
           />
         ))}
       </div>

--- a/src/components/displaydetailpage/HeroSlider.tsx
+++ b/src/components/displaydetailpage/HeroSlider.tsx
@@ -11,7 +11,7 @@ export function HeroSlider({ images, onBack }: Props) {
   const [current, setCurrent] = useState(0);
 
   return (
-    <div className="relative w-full overflow-hidden bg-[#111]" style={{ height: '500px' }}>
+    <div className="relative w-full overflow-hidden bg-[#111]" style={{ height: '568px' }}>
       {images.map((src, idx) => (
         <img
           key={src}

--- a/src/components/displaydetailpage/HeroSlider.tsx
+++ b/src/components/displaydetailpage/HeroSlider.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { BackButton } from '@/components/ui/BackButton';
+import { cn } from '@/utils/cn';
 
 type Props = {
   images: string[];
@@ -33,9 +34,10 @@ export function HeroSlider({ images, onBack }: Props) {
             type="button"
             aria-label={`슬라이드 ${idx + 1}`}
             onClick={() => setCurrent(idx)}
-            className={`w-1.75 h-1.75 rounded-full border-none p-0 cursor-pointer shrink-0 transition-all duration-200 ${
-              idx === current ? 'bg-line-active' : 'bg-[#667281]'
-            }`}
+            className={cn(
+              'w-1.75 h-1.75 rounded-full border-none p-0 cursor-pointer shrink-0 transition-all duration-200',
+              idx === current ? 'bg-line-active' : 'bg-[#667281]',
+            )}
           />
         ))}
       </div>

--- a/src/components/displaydetailpage/IntroTab.tsx
+++ b/src/components/displaydetailpage/IntroTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { CircleAlert } from 'lucide-react';
+import { ChevronRightIcon, CircleAlert } from 'lucide-react';
 
 import type { ExhibitionDetail } from '@/types/exhibition';
 
@@ -12,12 +12,12 @@ export function IntroTab({ exhibition: ex }: Props) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="bg-[#F0F0F3] font-[Pretendard,sans-serif]">
+    <div className="bg-page">
       {/* 전시소개 */}
-      <section className="px-5 py-5 border-b border-[#f3f3f3]">
-        <h1 className="mb-2 text-[#111111] text-xl font-bold">전시소개</h1>
+      <section className="px-5 py-6">
+        <h1 className="mb-2 text-main typo-body-xl-bold">전시소개</h1>
         <p
-          className="text-[14px] text-[#444] leading-[1.6]"
+          className="typo-body-sm-regular text-main"
           style={{
             display: '-webkit-box',
             WebkitBoxOrient: 'vertical',
@@ -27,25 +27,28 @@ export function IntroTab({ exhibition: ex }: Props) {
         >
           {ex.description}
         </p>
-        <button
-          type="button"
-          id="intro-expand-btn"
-          onClick={() => setExpanded((v) => !v)}
-          className="mt-1.5 text-[12px] text-[#999] font-medium"
-        >
-          {expanded ? '접기' : '더보기'}
-        </button>
+        <div className="flex justify-end mt-3">
+          <button
+            type="button"
+            id="intro-expand-btn"
+            onClick={() => setExpanded((v) => !v)}
+            className="flex items-center typo-body-xs-regular text-faint"
+          >
+            {expanded ? '접기' : '더보기'}
+            <ChevronRightIcon className="text-faint size-3" />
+          </button>
+        </div>
       </section>
 
-      {/* 전시콘텐츠 — 회색 배경으로 구분 */}
-      <section className="py-5 border-b border-[#f3f3f3] bg-gray-300">
-        <h2 className="text-xl font-bold text-neutral-900 mb-3 px-5">전시콘텐츠</h2>
-        <div className="flex gap-3 overflow-x-auto pb-2 px-5" style={{ scrollbarWidth: 'none' }}>
+      {/* 전시콘텐츠 */}
+      <section className="py-5 bg-[#D7D7DF]">
+        <h2 className="typo-body-xl-bold text-main mb-4 px-5">전시콘텐츠</h2>
+        <div className="flex gap-2 overflow-x-auto pb-2 px-5">
           {ex.contentImages.map((src, idx) => (
             <div
               key={idx}
               className="shrink-0 rounded-xl overflow-hidden bg-[#e0e0e0]"
-              style={{ width: 400, height: 170 }}
+              style={{ width: 362, height: 152 }}
             >
               <img
                 src={src}
@@ -58,15 +61,12 @@ export function IntroTab({ exhibition: ex }: Props) {
       </section>
 
       {/* 유의사항 */}
-      <section className="px-5 py-5 border-b border-[#f3f3f3]">
-        <h2 className="text-xl font-bold text-neutral-900 mb-3">유의사항</h2>
-        <ul className="flex flex-col gap-2">
+      <section className="px-5 p-6">
+        <h2 className="typo-body-xl-bold text-main mb-3">유의사항</h2>
+        <ul className="flex flex-col gap-1.5">
           {ex.notices.map((notice, idx) => (
-            <li
-              key={idx}
-              className="flex items-start gap-2 text-[13px] text-neutral-600 leading-relaxed"
-            >
-              <CircleAlert size={14} className="text-neutral-600 shrink-0 mt-0.5" />
+            <li key={idx} className="flex items-start gap-2 typo-body-sm-regular text-sub600">
+              <CircleAlert size={14} className="text-sub600 shrink-0 mt-0.5" />
               <span>{notice}</span>
             </li>
           ))}
@@ -74,16 +74,16 @@ export function IntroTab({ exhibition: ex }: Props) {
       </section>
 
       {/* 주최·문의 */}
-      <section className="px-5 py-5">
-        <h2 className="text-xl font-bold text-neutral-900 mb-3">주최 · 문의</h2>
-        <div className="flex flex-col gap-[6px]">
-          <div className="flex items-start gap-1 text-sm text-neutral-900">
-            <span className="text-sm text-neutral-400 w-8 shrink-0">주최</span>
+      <section className="px-5 pb-6">
+        <h2 className="typo-body-xl-bold text-main mb-3">주최 · 문의</h2>
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-start gap-2 typo-body-sm-regular text-main">
+            <span className="text-faint w-6 shrink-0">주최</span>
             <span>{ex.host}</span>
           </div>
-          <div className="flex items-start gap-1 text-sm text-neutral-900">
-            <span className="text-sm text-neutral-400 w-8 shrink-0">문의</span>
-            <span className="break-all">{ex.sns}</span>
+          <div className="flex items-start gap-2 typo-body-sm-regular text-main">
+            <span className="text-faint w-6 shrink-0">문의</span>
+            <span>{ex.sns}</span>
           </div>
         </div>
       </section>

--- a/src/components/displaydetailpage/IntroTab.tsx
+++ b/src/components/displaydetailpage/IntroTab.tsx
@@ -43,7 +43,7 @@ export function IntroTab({ exhibition: ex }: Props) {
       {/* 전시콘텐츠 */}
       <section className="py-5 bg-[#D7D7DF]">
         <h2 className="typo-body-xl-bold text-main mb-4 px-5">전시콘텐츠</h2>
-        <div className="flex gap-2 overflow-x-auto pb-2 px-5">
+        <div className="flex gap-2 overflow-x-auto pb-2 px-5" style={{ scrollbarWidth: 'none' }}>
           {ex.contentImages.map((src, idx) => (
             <div
               key={idx}

--- a/src/components/displaydetailpage/ReviewTab.tsx
+++ b/src/components/displaydetailpage/ReviewTab.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Heart, MoreHorizontal, SquarePen } from 'lucide-react';
 
 import type { ReviewItem } from '@/types/exhibition';
+import { cn } from '@/utils/cn';
 
 import defaultProfileIcon from '../../assets/DefaultProfileIcon.svg';
 
@@ -57,17 +58,16 @@ function ReviewCard({ item }: { item: ReviewItem }) {
           type="button"
           id={`review-like-${item.id}`}
           onClick={() => setLiked((v) => !v)}
-          className="flex items-center gap-1 transition-all duration-200 active:scale-95"
+          className="flex items-center gap-1 transition-all duration-200 active:scale-95 cursor-pointer"
         >
           <Heart
             size={14}
-            fill={liked ? 'var(--bt-heart-filled)' : 'none'}
-            color={liked ? 'var(--bt-heart-filled)' : 'var(--bt-heart-border)'}
+            className={cn(
+              'transition-colors duration-200',
+              liked ? 'fill-heart text-heart' : 'fill-none text-sub700',
+            )}
           />
-          <span
-            className="typo-body-xs-regular"
-            style={{ color: liked ? 'var(--bt-heart-filled)' : 'var(--bt-heart-border)' }}
-          >
+          <span className={cn('typo-body-xs-regular', liked ? 'text-heart' : 'text-sub700')}>
             {likeCount}
           </span>
         </button>

--- a/src/components/displaydetailpage/ReviewTab.tsx
+++ b/src/components/displaydetailpage/ReviewTab.tsx
@@ -6,40 +6,37 @@ import type { ReviewItem } from '@/types/exhibition';
 
 import defaultProfileIcon from '../../assets/DefaultProfileIcon.svg';
 
-/* ------------------------------------------------------------------ */
-/* ReviewCard — ReviewTab 내부에서만 사용                               */
-/* ------------------------------------------------------------------ */
+/* ReviewCard — ReviewTab 내부에서만 사용 */
 function ReviewCard({ item }: { item: ReviewItem }) {
   const [liked, setLiked] = useState(false);
   const likeCount = item.likes + (liked ? 1 : 0);
 
   return (
-    <article className="py-5 border-b border-[#ddd] last:border-0 font-[Pretendard,sans-serif]">
-      {/* 헤더 */}
+    <article className="py-4 last:border-0">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2.5">
           <img
             src={defaultProfileIcon}
             alt="기본 프로필"
-            className="w-10 h-10 rounded-full shrink-0"
+            className="w-8 h-8 rounded-full shrink-0"
           />
           <div className="flex flex-col">
-            <p className="text-[14px] font-bold text-[#111] leading-tight">{item.author}</p>
-            <p className="text-[12px] text-[#888] mt-0.5">{item.date}</p>
+            <p className="typo-body-sm-bold text-main">{item.author}</p>
+            <p className="typo-body-xs-regular text-faint">{item.date}</p>
           </div>
         </div>
         <button type="button" aria-label="옵션 더보기">
-          <MoreHorizontal size={20} color="#888" />
+          <MoreHorizontal size={24} className="text-sub700" />
         </button>
       </div>
 
-      {/* 첨부 이미지 (텍스트 위) */}
+      {/* 첨부 이미지 */}
       {item.images && item.images.length > 0 && (
-        <div className="flex gap-1.5 mb-3 overflow-x-auto pb-1" style={{ scrollbarWidth: 'none' }}>
+        <div className="flex gap-1 mb-3 overflow-x-auto pb-1" style={{ scrollbarWidth: 'none' }}>
           {item.images.map((src, idx) => (
             <div
               key={idx}
-              className="shrink-0 w-[140px] aspect-square rounded-lg overflow-hidden bg-[#e5e5e5]"
+              className="shrink-0 w-35 aspect-square rounded-lg overflow-hidden bg-box"
             >
               <img
                 src={src}
@@ -52,7 +49,7 @@ function ReviewCard({ item }: { item: ReviewItem }) {
       )}
 
       {/* 내용 */}
-      <p className="text-[13px] text-[#444] leading-relaxed mb-3">{item.content}</p>
+      <p className="typo-body-xs-regular text-sub600 mb-6">{item.content}</p>
 
       {/* 좋아요 */}
       <div className="flex items-center">
@@ -60,10 +57,10 @@ function ReviewCard({ item }: { item: ReviewItem }) {
           type="button"
           id={`review-like-${item.id}`}
           onClick={() => setLiked((v) => !v)}
-          className="flex items-center gap-1.5 transition-all duration-200 active:scale-95"
+          className="flex items-center gap-1 transition-all duration-200 active:scale-95"
         >
           <Heart size={14} fill={liked ? '#ef4444' : 'none'} color={liked ? '#ef4444' : '#888'} />
-          <span className="text-[12px]" style={{ color: liked ? '#ef4444' : '#888' }}>
+          <span className="typo-body-xs-regular" style={{ color: liked ? '#ef4444' : '#888' }}>
             {likeCount}
           </span>
         </button>
@@ -72,22 +69,20 @@ function ReviewCard({ item }: { item: ReviewItem }) {
   );
 }
 
-/* ------------------------------------------------------------------ */
-/* ReviewTab                                                            */
-/* ------------------------------------------------------------------ */
+/* ReviewTab */
 type Props = {
   reviews: ReviewItem[];
 };
 
 export function ReviewTab({ reviews }: Props) {
   return (
-    <div className="min-h-[400px] px-5 py-5 font-[Pretendard,sans-serif]">
+    <div className="px-5 py-6">
       {/* 전시 후기 헤더 */}
-      <div className="flex items-center justify-between mb-3">
-        <h1 className="text-[#111111] text-xl font-bold">전시 후기</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="typo-body-xl-bold text-main">전시 후기</h1>
         <button className="flex flex-col items-center gap-1 active:opacity-70 transition-opacity">
-          <SquarePen size={18} color="#aaa" />
-          <span className="text-[10px] text-[#aaa] font-medium">후기작성</span>
+          <SquarePen size={18} className="text-faint" />
+          <span className="typo-body-xs-regular text-faint">후기작성</span>
         </button>
       </div>
 

--- a/src/components/displaydetailpage/ReviewTab.tsx
+++ b/src/components/displaydetailpage/ReviewTab.tsx
@@ -59,8 +59,15 @@ function ReviewCard({ item }: { item: ReviewItem }) {
           onClick={() => setLiked((v) => !v)}
           className="flex items-center gap-1 transition-all duration-200 active:scale-95"
         >
-          <Heart size={14} fill={liked ? '#ef4444' : 'none'} color={liked ? '#ef4444' : '#888'} />
-          <span className="typo-body-xs-regular" style={{ color: liked ? '#ef4444' : '#888' }}>
+          <Heart
+            size={14}
+            fill={liked ? 'var(--bt-heart-filled)' : 'none'}
+            color={liked ? 'var(--bt-heart-filled)' : 'var(--bt-heart-border)'}
+          />
+          <span
+            className="typo-body-xs-regular"
+            style={{ color: liked ? 'var(--bt-heart-filled)' : 'var(--bt-heart-border)' }}
+          >
             {likeCount}
           </span>
         </button>

--- a/src/components/homepage/SectionHeader.tsx
+++ b/src/components/homepage/SectionHeader.tsx
@@ -10,10 +10,10 @@ export function SectionHeader({ title }: SectionHeaderProps) {
       <h2 className="typo-body-xl-bold text-main">{title}</h2>
       <button
         type="button"
-        className="flex items-center gap-px typo-body-xs-regular text-hint bg-transparent border-none cursor-pointer p-0"
+        className="flex items-center typo-body-xs-regular text-faint bg-transparent border-none cursor-pointer p-0"
       >
         더보기
-        <ChevronRightIcon className="text-hint size-3" />
+        <ChevronRightIcon className="text-faint size-3" />
       </button>
     </div>
   );

--- a/src/components/ui/BackButton.tsx
+++ b/src/components/ui/BackButton.tsx
@@ -1,7 +1,9 @@
 import { ChevronLeft } from 'lucide-react';
 
+import { cn } from '@/utils/cn';
+
 type Props = {
-  onClick: () => void;
+  onClick?: () => void;
   className?: string;
   id?: string;
 };
@@ -13,10 +15,15 @@ export function BackButton({ onClick, className = '', id }: Props) {
       id={id}
       aria-label="뒤로가기"
       onClick={onClick}
-      className={`flex items-center justify-center size-10 bg-white/10 rounded-[100px] shadow-[2px_4px_18px_0px_rgba(67,0,209,0.08),inset_-3px_-3px_3px_-2px_rgba(241,241,241,0.60),inset_4px_4px_3px_-2px_rgba(255,255,255,1.00)] backdrop-blur-[10px] cursor-pointer ${className}`}
+      className={cn(
+        'flex items-center justify-center size-10 bg-white/10 rounded-[100px]',
+        'shadow-[2px_4px_18px_0px_rgba(67,0,209,0.08),inset_-3px_-3px_3px_-2px_rgba(241,241,241,0.60),inset_4px_4px_3px_-2px_rgba(255,255,255,1.00)]',
+        'backdrop-blur-[10px] cursor-pointer',
+        className,
+      )}
     >
       <div className="size-10 flex items-center justify-center pr-1">
-        <ChevronLeft size={35} strokeWidth={1.5} className="text-[#06032D]" />
+        <ChevronLeft size={35} strokeWidth={1.5} className="text-logo" />
       </div>
     </button>
   );

--- a/src/components/ui/BackButton.tsx
+++ b/src/components/ui/BackButton.tsx
@@ -16,7 +16,7 @@ export function BackButton({ onClick, className = '', id }: Props) {
       className={`flex items-center justify-center size-10 bg-white/10 rounded-[100px] shadow-[2px_4px_18px_0px_rgba(67,0,209,0.08),inset_-3px_-3px_3px_-2px_rgba(241,241,241,0.60),inset_4px_4px_3px_-2px_rgba(255,255,255,1.00)] backdrop-blur-[10px] cursor-pointer ${className}`}
     >
       <div className="size-10 flex items-center justify-center pr-1">
-        <ChevronLeft size={35} strokeWidth={1.5} />
+        <ChevronLeft size={35} strokeWidth={1.5} className="text-[#06032D]" />
       </div>
     </button>
   );

--- a/src/mocks/exhibition.ts
+++ b/src/mocks/exhibition.ts
@@ -34,9 +34,9 @@ export const EXHIBITION_DETAILS: Record<string, ExhibitionDetail> = {
       'https://picsum.photos/seed/ct3/400/300',
     ],
     notices: [
-      '관람료는 사전에 예약하시면 16:00까지만 입장이 가능합니다.',
-      '전시품 손수건 임의로 접지하시면 안됩니다.',
-      '날씨에 문제 발생 시 다른 다른 3 일정이 있으실 경우에는 확인해주세요.',
+      '금요일은 전시 마감으로 16:00까지만 진행합니다.',
+      '작품을 손으로 만지지 말아주세요.',
+      '날짜별 운영 시간이 다를 수 있으니 방문 전 확인해주세요.',
     ],
     host: '중앙대학교 OO동아리',
     sns: '@displayu_oo (인스타그램 DM)',


### PR DESCRIPTION
## 📝 작업 내용

- 전시 상세페이지 디자인 토큰 적용 완료

## 🔍 관련 이슈

- close #55 

## 🖼️ 스크린샷
<img width="434" height="1821" alt="localhost_5173_display_1 (2)" src="https://github.com/user-attachments/assets/aa742546-b301-48c0-abaa-6b2a77430fe8" />

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일 개선**
  * 디자인 토큰 기반으로 전시 상세 저장 버튼, 탭 내비게이션, 메타/소개·콘텐츠/아트워크 카드/후기 카드, 더보기 버튼, 하단 고정 바를 재정렬하고 타이포·색상·간격을 일관화했습니다.
  * 아이콘 색상 제어와 하트/북마크 표시(채움·테두리) 규칙을 CSS 변수 기반으로 정리했으며, 슬라이더 높이와 인디케이터 스타일도 업데이트했습니다.
* **콘텐츠 업데이트**
  * 전시 안내 문구를 운영 종료 시간 및 유의사항 중심으로 최신화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->