### PR TITLE
design: 하트 디자인토큰 추가

### DIFF
--- a/src/styles/tokens/primitive.css
+++ b/src/styles/tokens/primitive.css
@@ -30,9 +30,6 @@
   --palette-green-500: #22c55e;
   --palette-green-50: #f0fdf4;
 
-  /* Alpha */
-  --palette-black-20: rgb(0 0 0 / 20%);
-
   /* Typography */
   --font-family-heading: 'Aldrich', sans-serif;
   --font-family-body: 'Pretendard', system-ui, sans-serif;

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -26,12 +26,11 @@
   /* Button */
   --bt-gray: var(--palette-gray-200);
   --bt-black: var(--palette-gray-black);
+  --bt-heart-filled: var(--palette-red);
+  --bt-heart-border: var(--palette-gray-400);
 
   /* Border */
   --line: var(--palette-gray-300);
   --line-soft: var(--palette-gray-200);
   --line-active: var(--palette-blue);
-
-  /* 이미지 위 그라데이션 오버레이에 쓰는 값 */
-  --scrim: var(--palette-black-20);
 }

--- a/src/styles/tokens/theme.css
+++ b/src/styles/tokens/theme.css
@@ -27,6 +27,8 @@
   /* Button */
   --color-bt-gray: var(--bt-gray);
   --color-bt-black: var(--bt-black);
+  --color-bt-heart-filled: var(--bt-heart-filled);
+  --color-bt-heart-border: var(--bt-heart-border);
 
   /* Border */
   --color-line: var(--line);


### PR DESCRIPTION
## 📝 작업 내용

- 하트 디자인 토큰을 추가했습니다.

## 🔍 관련 이슈

- close #59 

## 🖼️ 스크린샷

<img width="463" height="141" alt="image" src="https://github.com/user-attachments/assets/614e932e-a1b6-4a54-9fde-9cc5e910fca8" />


## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 하트의 기본 border색상인 gray400과 채워졌을 때인 #c32427 색상을 따로 두었으니 잘 적용하시기 바랍니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 하트 버튼의 채움 및 테두리 색상 토큰을 추가해 일관된 스타일 적용을 지원합니다.

* **스타일**
  * 하트 버튼 색상 토큰이 각각 빨간색과 회색 팔레트를 사용하도록 설정되었습니다.
  * 사용되지 않는 검정색 투명도 팔레트 토큰을 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->