### PR TITLE
design: 10px 폰트 추가 완료

### DIFF
--- a/src/styles/tokens/primitive.css
+++ b/src/styles/tokens/primitive.css
@@ -43,9 +43,9 @@
   --font-size-body-md: 16px;
   --font-size-body-sm: 14px;
   --font-size-body-xs: 12px;
+  --font-size-body-xxs: 10px;
 
   --font-weight-regular: 400;
-  --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
 

--- a/src/styles/tokens/typography.css
+++ b/src/styles/tokens/typography.css
@@ -149,3 +149,27 @@
   line-height: var(--line-height-body);
   letter-spacing: var(--letter-spacing-tight);
 }
+
+@utility typo-body-xxs-bold {
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-body-xxs);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-body);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+@utility typo-body-xxs-semibold {
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-body-xxs);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-body);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+@utility typo-body-xxs-regular {
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-body-xxs);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-body);
+  letter-spacing: var(--letter-spacing-tight);
+}


### PR DESCRIPTION
## 📝 작업 내용

- 10px 폰트의 bold/semibold/regular를 추가했습니다.
- xxs로 이름 지어뒀습니다.

## 🔍 관련 이슈

- close #61

## 🖼️ 스크린샷

<img width="588" height="567" alt="image" src="https://github.com/user-attachments/assets/7d529ee5-bb36-4408-abd5-51aa7956faf5" />

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 10px 크기의 초소형 본문 텍스트 스타일을 추가했습니다.
  - 굵게, 중간 굵기, 일반 굵기의 초소형 본문 타이포그래피 유틸리티를 제공합니다.

- **변경 사항**
  - 기존 중간 굵기 폰트 토큰을 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->