### PR TITLE
design: tag blue, tag gray추가 및 기존 box색상 token200으로 수정

### DIFF
--- a/src/styles/tokens/primitive.css
+++ b/src/styles/tokens/primitive.css
@@ -18,6 +18,7 @@
   --palette-gray-white: #fcfcfc;
   --palette-gray-100: #e9e9e9; /* 추후 수정(발견하면 승철에게 알려주기) */
   --palette-gray-200: #d9d9d9;
+  --palette-token-200: #d7d7df;
   --palette-gray-300: #c4c4c4; /* 추후 수정(발견하면 승철에게 알려주기) */
   --palette-gray-400: #9d9d9d;
   --palette-gray-500: #767676;

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -10,7 +10,7 @@
   /* Background */
   --bg-page: var(--palette-bg);
   --bg-card: var(--palette-gray-white);
-  --bg-box: var(--palette-gray-100);
+  --bg-box: var(--palette-token-200);
   --bg-dark: var(--palette-gray-black);
 
   /* Foreground — 텍스트와 아이콘이 같은 스케일을 공유한다 */
@@ -22,6 +22,10 @@
   --fg-white: var(--palette-gray-white);
   --fg-link: var(--palette-blue);
   --fg-error: var(--palette-red);
+
+  /* Tag */
+  --tag-blue: var(--palette-blue);
+  --tag-gray: var(--palette-token-200);
 
   /* Button */
   --bt-gray: var(--palette-gray-200);

--- a/src/styles/tokens/theme.css
+++ b/src/styles/tokens/theme.css
@@ -24,6 +24,10 @@
   --color-link: var(--fg-link);
   --color-error: var(--fg-error);
 
+  /* Tag */
+  --color-tag-blue: var(--tag-blue);
+  --color-tag-gray: var(--tag-gray);
+
   /* Button */
   --color-bt-gray: var(--bt-gray);
   --color-bt-black: var(--bt-black);


### PR DESCRIPTION
## 📝 작업 내용

-  tag blue, tag gray추가 및 기존 box색상 token200으로 수정

## 🔍 관련 이슈

- close #63 

<img width="334" height="93" alt="image" src="https://github.com/user-attachments/assets/2f71acb0-7522-47f0-9947-9540d7dba0cd" />
<img width="297" height="28" alt="image" src="https://github.com/user-attachments/assets/c36d3ec7-a844-4bc8-b5aa-2e5171c17e29" />



- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 태그에서 자주 사용되는 파란색과 회색을 시멘틱에 새로 추가했습니다.
- gray200이 아닌 token200이라는 색상이 자주 보여 주가했습니다. box를 token200으로 설정해두었으니 확인 후 사용 하시면 됩니다.
