### PR TITLE
fix: vercel MSW 켜지지 않는 문제 수정

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,11 @@ const enableMocking = async () => {
   const { worker } = await import('./mocks/browser');
 
   return worker.start({
-    onUnhandledRequest: 'bypass',
+    onUnhandledRequest(request, print) {
+      if (new URL(request.url).pathname.startsWith('/v1/')) {
+        print.warning();
+      }
+    },
   });
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,7 @@ import { RouterProvider } from 'react-router-dom';
 import { router } from './Router';
 
 const enableMocking = async () => {
-  if (!import.meta.env.DEV) {
+  if (!import.meta.env.DEV && import.meta.env.VITE_ENABLE_MOCK !== 'true') {
     return;
   }
 


### PR DESCRIPTION
## 📝 작업 내용

- 어떤 기능을 개발/수정했는지 요약해주세요.

vercel 환경 변수와 main의 조건분기를 수정해서 문제를 해결했습니다.
개발 모드가 아니면서 VITE_ENABLE_MOCK이 'true'가 아닌 경우에만 mocking을 중단하도록 조건을 변경했습니다.

## 🔍 관련 이슈

- close #70

## 🖼️ 스크린샷

- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 개발 모드가 아니더라도 설정을 통해 모킹 기능을 활성화할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->