### PR TITLE
feat: 대표자 전시 등록 1/2 디자인 토큰 적용 완료

### DIFF
--- a/src/components/exhibition-register/AffiliationInput.tsx
+++ b/src/components/exhibition-register/AffiliationInput.tsx
@@ -21,22 +21,22 @@ export function AffiliationInput({
 }: AffiliationInputProps) {
   if (group === 'institution') {
     return (
-      <div className="rounded-2xl outline outline-1 outline-offset-[-1px] outline-zinc-300">
+      <div className="rounded-2xl outline outline-1 outline-offset-[-1px] outline-line">
         <SchoolSearchInput value={school} onChange={onSchoolChange} />
 
-        <div className="px-4 py-3.5 flex flex-col gap-2">
+        <div className="bg-card px-4 py-3.5 flex flex-col gap-2">
           <label htmlFor="department-input" className="flex items-center gap-1">
-            <span className="text-neutral-600 text-xs font-bold leading-4">
+            <span className="text-sub700 typo-body-xs-bold leading-4">
               세부소속
             </span>
-            <span className="text-red-400 text-xs leading-5">*</span>
+            <span className="text-red-400 typo-body-xs-regular leading-5">*</span>
           </label>
           <input
             id="department-input"
             value={department}
             onChange={(e) => onDepartmentChange(e.target.value)}
             placeholder="학과, 학회, 동아리명을 입력해주세요"
-            className="h-10 px-3 bg-neutral-100 rounded-2xl outline outline-1 outline-offset-[-1px] outline-gray-200 text-sm text-neutral-900 placeholder:text-stone-300 outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+            className="h-10 px-3 bg-page rounded-2xl outline outline-1 outline-offset-[-1px] outline-line-soft typo-body-sm-regular text-main placeholder:text-hint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
           />
         </div>
       </div>
@@ -44,20 +44,20 @@ export function AffiliationInput({
   }
 
   return (
-    <div className="rounded-2xl outline outline-1 outline-offset-[-1px] outline-zinc-300 overflow-hidden">
-      <div className="px-4 py-3.5 flex flex-col gap-2">
+    <div className="rounded-2xl outline outline-1 outline-offset-[-1px] outline-line overflow-hidden">
+      <div className="bg-card px-4 py-3.5 flex flex-col gap-2">
         <label htmlFor="organizer-input" className="flex items-center gap-1">
-          <span className="text-neutral-600 text-xs font-bold leading-4">
+          <span className="text-sub700 typo-body-xs-bold leading-4">
             주최 / 소속명
           </span>
-          <span className="text-red-400 text-xs leading-5">*</span>
+          <span className="text-red-400 typo-body-xs-regular leading-5">*</span>
         </label>
         <input
           id="organizer-input"
           value={organizer}
           onChange={(e) => onOrganizerChange(e.target.value)}
-          placeholder="주최 또는 소속명을 입력해주세요"
-          className="h-10 px-3 bg-neutral-100 rounded-2xl outline outline-1 outline-offset-[-1px] outline-gray-200 text-sm text-neutral-900 placeholder:text-stone-300 outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          placeholder="팀, 모임, 연합명을 입력해주세요"
+          className="h-10 px-3 bg-page rounded-2xl outline outline-1 outline-offset-[-1px] outline-line-soft typo-body-sm-regular text-main placeholder:text-hint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
         />
       </div>
     </div>

--- a/src/components/exhibition-register/ExhibitionHeader.tsx
+++ b/src/components/exhibition-register/ExhibitionHeader.tsx
@@ -14,7 +14,7 @@ export function ExhibitionHeader() {
       >
         <ChevronLeft />
       </button>
-      <div className="text-neutral-900 text-xl font-bold font-['Pretendard']">전시 기본 정보</div>
+      <div className="text-dark typo-body-xl-bold">전시 기본 정보</div>
     </div>
   );
 }

--- a/src/components/exhibition-register/ImageUploader.tsx
+++ b/src/components/exhibition-register/ImageUploader.tsx
@@ -54,7 +54,7 @@ export function ImageUploader({ maxImages = 4 }: ImageUploaderProps) {
       {imageUrls.map((url, index) => (
         <div
           key={index}
-          className="relative size-24 bg-neutral-50 rounded-xl outline outline-1 outline-offset-[-1px] outline-stone-300 overflow-hidden"
+          className="relative size-24 bg-card rounded-xl outline outline-1 outline-offset-[-1px] outline-line overflow-hidden"
         >
           <img
             src={url}
@@ -82,10 +82,10 @@ export function ImageUploader({ maxImages = 4 }: ImageUploaderProps) {
         <button
           type="button"
           onClick={handleImageClick}
-          className="size-24 bg-neutral-50 rounded-xl outline outline-1 outline-offset-[-1px] outline-stone-300 flex flex-col items-center justify-center gap-3"
+          className="size-24 bg-card rounded-xl outline outline-1 outline-offset-[-1px] outline-line flex flex-col items-center justify-center gap-3"
           aria-label="이미지 업로드"
         >
-          <div className="size-10 bg-gray-100 rounded-full flex items-center justify-center">
+          <div className="size-10 bg-box rounded-full flex items-center justify-center">
             <svg
               width="16"
               height="16"
@@ -112,7 +112,7 @@ export function ImageUploader({ maxImages = 4 }: ImageUploaderProps) {
               <circle cx="6" cy="6" r="1" stroke="#d4d4d4" strokeWidth="1.5" />
             </svg>
           </div>
-          <span className="text-neutral-900 text-xs">
+          <span className="text-main typo-body-xs-regular">
             {imageUrls.length}/{maxImages}
           </span>
         </button>

--- a/src/components/exhibition-register/SchoolSearchInput.tsx
+++ b/src/components/exhibition-register/SchoolSearchInput.tsx
@@ -48,15 +48,15 @@ export function SchoolSearchInput({ value, onChange }: SchoolSearchInputProps) {
   }, []);
 
   return (
-    <div className="px-4 py-3.5 border-b border-zinc-300 flex flex-col gap-2">
+    <div className="bg-card px-4 py-3.5 border-b border-line flex flex-col gap-2">
       <label htmlFor="school-search" className="flex items-center gap-1">
-        <span className="text-neutral-600 text-xs font-bold leading-4">
+        <span className="text-sub600 typo-body-xs-bold leading-4">
           학교 / 기관명
         </span>
-        <span className="text-red-400 text-xs leading-5">*</span>
+        <span className="text-red-400 typo-body-xs-regular leading-5">*</span>
       </label>
       <div className="relative">
-        <div className="h-10 px-3 bg-neutral-100 rounded-2xl outline outline-1 outline-offset-[-1px] outline-gray-200 flex items-center gap-2 overflow-hidden">
+        <div className="h-10 px-3 bg-page rounded-2xl outline outline-1 outline-offset-[-1px] outline-line-soft flex items-center gap-2 overflow-hidden">
           <input
             id="school-search"
             value={schoolQuery}
@@ -68,7 +68,7 @@ export function SchoolSearchInput({ value, onChange }: SchoolSearchInputProps) {
             onFocus={handleSchoolFocus}
             onBlur={() => setTimeout(() => setSchoolOpen(false), 200)}
             placeholder="학교명을 검색해주세요"
-            className="flex-1 bg-transparent text-sm text-neutral-900 placeholder:text-stone-300 outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 rounded"
+            className="flex-1 bg-transparent typo-body-sm-regular text-main placeholder:text-hint outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 rounded"
           />
           <svg
             width="14"
@@ -88,7 +88,7 @@ export function SchoolSearchInput({ value, onChange }: SchoolSearchInputProps) {
         </div>
 
         {schoolOpen && (
-          <div className="absolute z-50 left-0 right-0 mt-1 bg-neutral-50 rounded-2xl outline outline-1 outline-offset-[-1px] outline-zinc-300 shadow-lg overflow-hidden">
+          <div className="absolute z-50 left-0 right-0 mt-1 bg-card rounded-2xl outline outline-1 outline-offset-[-1px] outline-line shadow-lg overflow-hidden">
             <div className="max-h-56 overflow-y-auto">
               {filteredSchools.length > 0 ? (
                 filteredSchools.map((s) => (
@@ -99,13 +99,13 @@ export function SchoolSearchInput({ value, onChange }: SchoolSearchInputProps) {
                       e.preventDefault();
                       selectSchool(s);
                     }}
-                    className="w-full text-left px-4 py-2.5 text-sm text-neutral-700 hover:bg-neutral-100"
+                    className="w-full text-left px-4 py-2.5 text-sub700 typo-body-sm-regular hover:bg-box"
                   >
                     {s}
                   </button>
                 ))
               ) : (
-                <div className="px-4 py-3 text-sm text-neutral-400">
+                <div className="px-4 py-3 text-faint typo-body-sm-regular">
                   검색 결과가 없습니다
                 </div>
               )}

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -17,10 +17,10 @@ export const Chip = memo(function Chip({
       role="radio"
       aria-checked={selected}
       onClick={onClick}
-      className={`px-2.5 py-1.5 rounded-sm shadow-[4px_4px_12px_0px_rgba(67,0,209,0.05)] outline outline-1 outline-offset-[-1px] transition-colors text-xs leading-4 tracking-tight whitespace-nowrap ${
+      className={`px-2.5 py-1.5 rounded-sm shadow-[4px_4px_12px_0px_rgba(67,0,209,0.05)] outline outline-1 outline-offset-[-1px] transition-colors leading-4 tracking-tight whitespace-nowrap ${
         selected
-          ? 'outline-neutral-900 text-neutral-900 font-bold'
-          : 'outline-stone-300 text-neutral-600 font-normal'
+          ? 'outline-main text-main typo-body-xs-bold'
+          : 'outline-line text-sub600 typo-body-xs-regular'
       }`}
     >
       {label}

--- a/src/components/ui/RequiredLabel.tsx
+++ b/src/components/ui/RequiredLabel.tsx
@@ -13,10 +13,10 @@ export const RequiredLabel = memo(function RequiredLabel({
 }: RequiredLabelProps) {
   return (
     <label htmlFor={htmlFor} className="inline-flex items-center gap-1">
-      <span className="text-neutral-900 text-sm font-bold leading-5">
+      <span className="text-dark typo-body-sm-bold leading-5">
         {children}
       </span>
-      {required && <span className="text-red-400 text-xs leading-5">*</span>}
+      {required && <span className="text-red-400 typo-body-xs-regular leading-5">*</span>}
     </label>
   );
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,14 +8,18 @@ import { RouterProvider } from 'react-router-dom';
 import { router } from './Router';
 
 const enableMocking = async () => {
-  if (!import.meta.env.DEV) {
+  if (!import.meta.env.DEV && import.meta.env.VITE_ENABLE_MOCK !== 'true') {
     return;
   }
 
   const { worker } = await import('./mocks/browser');
 
   return worker.start({
-    onUnhandledRequest: 'bypass',
+    onUnhandledRequest(request, print) {
+      if (new URL(request.url).pathname.startsWith('/v1/')) {
+        print.warning();
+      }
+    },
   });
 };
 

--- a/src/pages/ExhibitionRegister.tsx
+++ b/src/pages/ExhibitionRegister.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/constants/exhibition';
 
 const BASE_INPUT_CLASS =
-  'px-3 py-2.5 bg-neutral-50 rounded-lg shadow-[0px_0px_8px_0px_rgba(67,0,209,0.05)] outline outline-1 outline-offset-[-1px] outline-stone-300 text-xs text-neutral-900 placeholder:text-neutral-400 leading-4';
+  'px-3 py-2.5 bg-card rounded-lg shadow-[0px_0px_8px_0px_rgba(67,0,209,0.05)] outline outline-1 outline-offset-[-1px] outline-line typo-body-xs-regular text-main placeholder:text-faint leading-4';
 
 export function ExhibitionRegister() {
   const [title, setTitle] = useState('');
@@ -32,7 +32,7 @@ export function ExhibitionRegister() {
   }, [type]);
 
   return (
-    <div className="w-full bg-neutral-50 relative flex flex-col h-screen">
+    <div className="w-full bg-page relative flex flex-col h-screen">
       <ExhibitionHeader />
 
       <main className="flex-1 overflow-y-auto overflow-x-hidden px-5 pb-28">
@@ -66,16 +66,16 @@ export function ExhibitionRegister() {
 
         <div className="mt-5 flex flex-col gap-3">
           <RequiredLabel htmlFor="exhibition-intro">전시소개</RequiredLabel>
-          <div className="px-3 py-2.5 bg-neutral-50 rounded-lg shadow-[0px_0px_8px_0px_rgba(67,0,209,0.05)] outline outline-1 outline-offset-[-1px] outline-stone-300 flex flex-col gap-2">
+          <div className="px-3 py-2.5 bg-card rounded-lg shadow-[0px_0px_8px_0px_rgba(67,0,209,0.05)] outline outline-1 outline-offset-[-1px] outline-line flex flex-col gap-2">
             <textarea
               id="exhibition-intro"
               value={intro}
               maxLength={500}
               onChange={(e) => setIntro(e.target.value)}
               placeholder="전시에 대해 소개해주세요"
-              className="h-24 resize-none bg-transparent text-xs text-neutral-900 placeholder:text-neutral-400 leading-4 outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 rounded"
+              className="h-24 resize-none bg-transparent typo-body-xs-regular text-faint placeholder:text-hint leading-4 outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 rounded"
             />
-            <div className="text-right text-neutral-400 text-xs leading-4">
+            <div className="text-right text-faint typo-body-xs-regular leading-4">
               {intro.length}/500
             </div>
           </div>
@@ -90,13 +90,16 @@ export function ExhibitionRegister() {
             role="radiogroup"
             aria-labelledby="exhibition-type-label"
           >
-            {EXHIBITION_TYPES.map((t) => (
-              <Chip
-                key={t.label}
-                label={t.label}
-                selected={type === t.label}
-                onClick={() => setType(t.label)}
-              />
+            {EXHIBITION_TYPES.map((t, index) => (
+              <>
+                <Chip
+                  key={t.label}
+                  label={t.label}
+                  selected={type === t.label}
+                  onClick={() => setType(t.label)}
+                />
+                {index === 2 && <div className="basis-full h-0" />}
+              </>
             ))}
           </div>
         </div>
@@ -140,11 +143,11 @@ export function ExhibitionRegister() {
         )}
       </main>
 
-      <footer className="fixed bottom-0 left-0 right-0 z-40 bg-neutral-50 border-t border-stone-300 shadow-[0px_-4px_18px_0px_rgba(4,0,250,0.06)]">
+      <footer className="fixed bottom-0 left-0 right-0 z-40 bg-card border-t border-line shadow-[0px_-4px_18px_0px_rgba(4,0,250,0.06)]">
         <div className="px-5 pt-4 pb-4">
           <button
             type="button"
-            className="w-full py-3 bg-neutral-900 rounded-xl text-neutral-50 text-sm font-bold leading-5"
+            className="w-full py-3 bg-dark rounded-xl text-card typo-body-sm-bold leading-5"
           >
             다음
           </button>

--- a/src/pages/ExhibitionRegister.tsx
+++ b/src/pages/ExhibitionRegister.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 
 import {
   AffiliationInput,
@@ -91,15 +91,14 @@ export function ExhibitionRegister() {
             aria-labelledby="exhibition-type-label"
           >
             {EXHIBITION_TYPES.map((t, index) => (
-              <>
+              <Fragment key={t.label}>
                 <Chip
-                  key={t.label}
                   label={t.label}
                   selected={type === t.label}
                   onClick={() => setType(t.label)}
                 />
                 {index === 2 && <div className="basis-full h-0" />}
-              </>
+              </Fragment>
             ))}
           </div>
         </div>

--- a/src/pages/ExhibitionRegister.tsx
+++ b/src/pages/ExhibitionRegister.tsx
@@ -52,9 +52,7 @@ export function ExhibitionRegister() {
         </div>
 
         <div className="mt-5 flex flex-col gap-3">
-          <RequiredLabel htmlFor="exhibition-subtitle">
-            전시 부제목
-          </RequiredLabel>
+          <RequiredLabel htmlFor="exhibition-subtitle">전시 부제목</RequiredLabel>
           <input
             id="exhibition-subtitle"
             value={subtitle}
@@ -113,12 +111,7 @@ export function ExhibitionRegister() {
             aria-labelledby="exhibition-field-label"
           >
             {EXHIBITION_FIELDS.map((f) => (
-              <Chip
-                key={f}
-                label={f}
-                selected={field === f}
-                onClick={() => setField(f)}
-              />
+              <Chip key={f} label={f} selected={field === f} onClick={() => setField(f)} />
             ))}
           </div>
         </div>


### PR DESCRIPTION
## 📝 작업 내용

- 대표자 전시 등록 디자인 토큰 적용 완료

## 🔍 관련 이슈

- close #47 

## 🖼️ 스크린샷

<img width="289" height="555" alt="image" src="https://github.com/user-attachments/assets/015f3357-0bf5-4693-ac09-e95a8e0a222f" />

## 🧪 테스트 결과

- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 다른 곳에서 사용되지 않는 색은 하드코딩함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 전시 등록 화면 전반의 색상, 글꼴, 입력창 및 버튼 스타일을 새 디자인 체계에 맞게 개선했습니다.
  * 전시 유형 선택 항목의 화면 배치를 조정했습니다.
  * 소속명 입력 안내 문구를 “팀, 모임, 연합명을 입력해주세요”로 변경했습니다.
  * 학교 검색 결과와 이미지 업로드 영역의 가독성 및 시각적 일관성을 향상했습니다.
  * 선택 칩과 필수 입력 라벨의 표시 스타일을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->