### PR TITLE
fix: base 브랜치 대비 파일 변경사항 라벨링

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
## 📝 작업 내용

- PR Labeler가 현재 PR 변경 파일 기준으로 라벨을 동기화하도록 설정했습니다.
- `sync-labels: true` 옵션을 추가해 조건에 맞지 않는 기존 라벨이 제거되도록 수정했습니다.

## 🔍 관련 이슈

- close #77

## 🖼️ 스크린샷

- 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인

## 💬 기타 참고 사항

- `Re-run all jobs`만으로는 PR diff가 변경되지 않으므로 라벨 제거가 반영되지 않을 수 있습니다.
- 새 커밋 push 시 현재 PR 변경사항 기준으로 라벨이 다시 동기화됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 변경된 라벨 설정이 자동으로 동기화되도록 개선했습니다.
  * 라벨러 설정과 실제 라벨 상태가 일관되게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->