### PR TITLE
feat: 서버 상태 관리 api 훅 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@commitlint/config-conventional": "^20.5.3",
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.3.2",
+    "@tanstack/react-query-devtools": "^5.101.3",
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@fontsource/aldrich": "^5.2.7",
+    "@tanstack/react-query": "^5.101.3",
     "axios": "^1.18.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@fontsource/aldrich": "^5.2.7",
+    "axios": "^1.18.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.23.0",
     "pretendard": "^1.3.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0))
+      '@tanstack/react-query-devtools':
+        specifier: ^5.101.3
+        version: 5.101.3(@tanstack/react-query@5.101.3(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^22.10.2
         version: 22.20.0
@@ -872,6 +875,15 @@ packages:
 
   '@tanstack/query-core@5.101.3':
     resolution: {integrity: sha512-pWLyu7AjFFVM5G+frjcL81kKEW9R8GCCPKnL3uaWbMwd2f3ZINFCuy+PtKkdz/+pKw/f/XMsFsYq/H+uJHM4GQ==}
+
+  '@tanstack/query-devtools@5.101.3':
+    resolution: {integrity: sha512-twEAOB5uBmpFAdlIuy3KIUujwmoZIhCXZpu1PFMTress2XvK/CyzsvV70WrhtTcocszKpbvwMR0Bxq4dqkvH0g==}
+
+  '@tanstack/react-query-devtools@5.101.3':
+    resolution: {integrity: sha512-Xr4gCymObeVmtImtsPDVzOlvy3Itr2ti3IrtdbcyhsmpsM54v2A7VR9hTB40C6wzCf3yM4Q2LqkFbNm1u8wd3A==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.101.3
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.101.3':
     resolution: {integrity: sha512-ZjgcRwmQUSCythDPj6pE2NKFi9bpQegxIBxgt3hPytXI1ElFHNaa3A7aWW8vFaLCIRjPv467rbREYHbxcdgQbg==}
@@ -3218,6 +3230,14 @@ snapshots:
       vite: 5.4.21(@types/node@22.20.0)(lightningcss@1.32.0)
 
   '@tanstack/query-core@5.101.3': {}
+
+  '@tanstack/query-devtools@5.101.3': {}
+
+  '@tanstack/react-query-devtools@5.101.3(@tanstack/react-query@5.101.3(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-devtools': 5.101.3
+      '@tanstack/react-query': 5.101.3(react@18.3.1)
+      react: 18.3.1
 
   '@tanstack/react-query@5.101.3(react@18.3.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@fontsource/aldrich':
         specifier: ^5.2.7
         version: 5.2.7
+      '@tanstack/react-query':
+        specifier: ^5.101.3
+        version: 5.101.3(react@18.3.1)
       axios:
         specifier: ^1.18.1
         version: 1.18.1
@@ -866,6 +869,14 @@ packages:
     resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/query-core@5.101.3':
+    resolution: {integrity: sha512-pWLyu7AjFFVM5G+frjcL81kKEW9R8GCCPKnL3uaWbMwd2f3ZINFCuy+PtKkdz/+pKw/f/XMsFsYq/H+uJHM4GQ==}
+
+  '@tanstack/react-query@5.101.3':
+    resolution: {integrity: sha512-ZjgcRwmQUSCythDPj6pE2NKFi9bpQegxIBxgt3hPytXI1ElFHNaa3A7aWW8vFaLCIRjPv467rbREYHbxcdgQbg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -3205,6 +3216,13 @@ snapshots:
       '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.2
       vite: 5.4.21(@types/node@22.20.0)(lightningcss@1.32.0)
+
+  '@tanstack/query-core@5.101.3': {}
+
+  '@tanstack/react-query@5.101.3(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.101.3
+      react: 18.3.1
 
   '@types/estree@1.0.9': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@fontsource/aldrich':
         specifier: ^5.2.7
         version: 5.2.7
+      axios:
+        specifier: ^1.18.1
+        version: 1.18.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -967,6 +970,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -1035,9 +1042,15 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1119,6 +1132,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -1213,6 +1230,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1472,9 +1493,22 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1591,6 +1625,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -1939,6 +1977,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -2096,6 +2142,10 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3288,6 +3338,12 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3389,9 +3445,21 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   balanced-match@1.0.2: {}
 
@@ -3472,6 +3540,10 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   commander@14.0.3: {}
 
@@ -3562,6 +3634,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -3953,9 +4027,19 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
 
   fsevents@2.3.3:
     optional: true
@@ -4071,6 +4155,13 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 
@@ -4386,6 +4477,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   mimic-function@5.0.1: {}
 
   minimatch@10.2.5:
@@ -4555,6 +4652,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const axiosInstance = axios.create({
+  baseURL: '',
+  timeout: 10000,
+});

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,20 @@
 import axios from 'axios';
 
+const getAccessToken = () => localStorage.getItem('accessToken');
+
 export const axiosInstance = axios.create({
   baseURL: '',
   timeout: 10000,
+});
+
+axiosInstance.interceptors.request.use((config) => {
+  config.headers.set('Accept', 'application/json');
+
+  const accessToken = getAccessToken();
+
+  if (accessToken) {
+    config.headers.set('Authorization', `Bearer ${accessToken}`);
+  }
+
+  return config;
 });

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,23 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
+
+import type { ApiResponseDto } from '@/api/dto';
+
+export class ApiError extends Error {
+  code?: string;
+  details?: string | null;
+  status?: number;
+
+  constructor(
+    message: string,
+    options: { code?: string; details?: string | null; status?: number } = {},
+  ) {
+    super(message);
+    this.name = 'ApiError';
+    this.code = options.code;
+    this.details = options.details;
+    this.status = options.status;
+  }
+}
 
 const getAccessToken = () => localStorage.getItem('accessToken');
 
@@ -18,3 +37,41 @@ axiosInstance.interceptors.request.use((config) => {
 
   return config;
 });
+
+axiosInstance.interceptors.response.use(
+  (response) => {
+    const data = response.data as ApiResponseDto<unknown>;
+
+    //백엔드 쪽에서 2xx 응답을 보내면서 resultType이 FAIL인 경우가 있음. 이 경우 에러를 throw하도록 처리
+    if (data.resultType === 'FAIL') {
+      return Promise.reject(
+        new ApiError(data.error.message, {
+          code: data.error.code,
+          details: data.error.details,
+          status: response.status,
+        }),
+      );
+    }
+
+    return response;
+  },
+  (error: AxiosError<ApiResponseDto<unknown>>) => {
+    const data = error.response?.data;
+
+    if (data?.resultType === 'FAIL') {
+      return Promise.reject(
+        new ApiError(data.error.message, {
+          code: data.error.code,
+          details: data.error.details,
+          status: error.response?.status,
+        }),
+      );
+    }
+
+    return Promise.reject(
+      new ApiError(error.message || 'API request failed', {
+        status: error.response?.status,
+      }),
+    );
+  },
+);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,11 +1,16 @@
 import type { ApiResponseDto } from '@/api/dto';
 
+import { axiosInstance } from './axios';
+
 type QueryValue = string | number | boolean | null | undefined;
 type QueryParams = object;
 
-interface ApiRequestOptions<TBody> extends Omit<RequestInit, 'body'> {
+interface ApiRequestOptions<TBody> {
   body?: TBody;
+  headers?: Record<string, string>;
+  method?: string;
   query?: QueryParams;
+  signal?: AbortSignal;
 }
 
 // Query string builder for endpoint request params
@@ -34,25 +39,27 @@ export const apiRequest = async <TData, TBody = unknown>(
   path: string,
   options: ApiRequestOptions<TBody> = {},
 ): Promise<TData> => {
-  const { body, headers, query, ...init } = options;
-
-  const response = await fetch(`${path}${createQueryString(query)}`, {
-    ...init,
+  const { body, headers, method = 'GET', query, signal } = options;
+  const response = await axiosInstance.request<ApiResponseDto<TData>>({
+    data: body,
     headers: {
       ...(body instanceof FormData ? {} : { 'Content-Type': 'application/json' }),
       ...headers,
     },
-    body: body instanceof FormData ? body : body === undefined ? undefined : JSON.stringify(body),
+    method,
+    params: query,
+    paramsSerializer: (params) => createQueryString(params).slice(1),
+    signal,
+    url: path,
   });
-
-  const data = (await response.json().catch(() => null)) as ApiResponseDto<TData> | null;
+  const data = response.data;
 
   if (data?.resultType === 'FAIL') {
     throw new Error(data.error.message);
   }
 
-  if (!response.ok || !data) {
-    throw new Error(`API request failed: ${response.status}`);
+  if (!data) {
+    throw new Error('API request failed');
   }
 
   return data.success.data;

--- a/src/api/queryKeys.ts
+++ b/src/api/queryKeys.ts
@@ -93,8 +93,10 @@ export const queryKeys = {
     listPrefix: (postId: number) => [...queryKeys.loungeComments.lists(), postId] as const,
     list: (postId: number, params?: CursorPageRequestDto) =>
       [...queryKeys.loungeComments.listPrefix(postId), params ?? {}] as const,
+    replyLists: (commentId: number) =>
+      [...queryKeys.loungeComments.all, 'replies', commentId] as const,
     replies: (commentId: number, params?: CursorPageRequestDto) =>
-      [...queryKeys.loungeComments.all, 'replies', commentId, params ?? {}] as const,
+      [...queryKeys.loungeComments.replyLists(commentId), params ?? {}] as const,
   },
 
   archives: {

--- a/src/api/queryKeys.ts
+++ b/src/api/queryKeys.ts
@@ -36,8 +36,10 @@ export const queryKeys = {
     duPicks: () => [...queryKeys.displays.lists(), 'du-picks'] as const,
     details: () => [...queryKeys.displays.all, 'detail'] as const,
     detail: (displayId: number) => [...queryKeys.displays.details(), displayId] as const,
+    reviewLists: (displayId: number) =>
+      [...queryKeys.displays.detail(displayId), 'reviews'] as const,
     reviews: (displayId: number, params: { page: number; size: number }) =>
-      [...queryKeys.displays.detail(displayId), 'reviews', params] as const,
+      [...queryKeys.displays.reviewLists(displayId), params] as const,
   },
 
   displayArtworks: {

--- a/src/api/queryKeys.ts
+++ b/src/api/queryKeys.ts
@@ -1,0 +1,123 @@
+import type { CursorPageRequestDto } from '@/api/dto';
+import type {
+  GetDisplayArtworksRequestDto,
+  GetDisplayMapRequestDto,
+  GetDisplaysRequestDto,
+  SearchDisplaysRequestDto,
+} from '@/api/dto/display.dto';
+import type { GetArtworkPreviewRequestDto } from '@/api/dto/displayArtwork.dto';
+import type { GetLoungePostsRequestDto } from '@/api/dto/lounge.dto';
+
+type ListParams = Record<string, unknown>;
+
+export const queryKeys = {
+  auth: {
+    all: ['auth'] as const,
+  },
+
+  users: {
+    all: ['users'] as const,
+    me: () => [...queryKeys.users.all, 'me'] as const,
+    nicknameCheck: (nickname: string) =>
+      [...queryKeys.users.all, 'nickname-check', nickname] as const,
+  },
+
+  displays: {
+    all: ['displays'] as const,
+    lists: () => [...queryKeys.displays.all, 'list'] as const,
+    list: (params?: GetDisplaysRequestDto) =>
+      [...queryKeys.displays.lists(), params ?? {}] as const,
+    search: (params: SearchDisplaysRequestDto) =>
+      [...queryKeys.displays.lists(), 'search', params] as const,
+    map: (params: GetDisplayMapRequestDto) =>
+      [...queryKeys.displays.lists(), 'map', params] as const,
+    closingSoon: () => [...queryKeys.displays.lists(), 'closing-soon'] as const,
+    graduation: () => [...queryKeys.displays.lists(), 'graduation'] as const,
+    duPicks: () => [...queryKeys.displays.lists(), 'du-picks'] as const,
+    details: () => [...queryKeys.displays.all, 'detail'] as const,
+    detail: (displayId: number) => [...queryKeys.displays.details(), displayId] as const,
+    reviews: (displayId: number, params: { page: number; size: number }) =>
+      [...queryKeys.displays.detail(displayId), 'reviews', params] as const,
+  },
+
+  displayArtworks: {
+    all: ['displayArtworks'] as const,
+    lists: () => [...queryKeys.displayArtworks.all, 'list'] as const,
+    listPrefix: (displayId: number) => [...queryKeys.displayArtworks.lists(), displayId] as const,
+    list: (displayId: number, params: GetDisplayArtworksRequestDto) =>
+      [...queryKeys.displayArtworks.listPrefix(displayId), params] as const,
+    preview: (params?: GetArtworkPreviewRequestDto) =>
+      [...queryKeys.displayArtworks.lists(), 'preview', params ?? {}] as const,
+    details: () => [...queryKeys.displayArtworks.all, 'detail'] as const,
+    detail: (artworkId: number) => [...queryKeys.displayArtworks.details(), artworkId] as const,
+  },
+
+  displayCategories: {
+    all: ['displayCategories'] as const,
+  },
+
+  displayMembers: {
+    all: ['displayMembers'] as const,
+    lists: () => [...queryKeys.displayMembers.all, 'list'] as const,
+    list: (displayId: number) => [...queryKeys.displayMembers.lists(), displayId] as const,
+    inviteLink: (displayId: number) =>
+      [...queryKeys.displayMembers.all, 'invite-link', displayId] as const,
+  },
+
+  artworkFeelings: {
+    all: ['artworkFeelings'] as const,
+    lists: () => [...queryKeys.artworkFeelings.all, 'list'] as const,
+    list: (artworkId: number) => [...queryKeys.artworkFeelings.lists(), artworkId] as const,
+  },
+
+  artworkQuestions: {
+    all: ['artworkQuestions'] as const,
+    lists: () => [...queryKeys.artworkQuestions.all, 'list'] as const,
+    list: (artworkId: number) => [...queryKeys.artworkQuestions.lists(), artworkId] as const,
+  },
+
+  loungePosts: {
+    all: ['loungePosts'] as const,
+    lists: () => [...queryKeys.loungePosts.all, 'list'] as const,
+    list: (params?: GetLoungePostsRequestDto) =>
+      [...queryKeys.loungePosts.lists(), params ?? {}] as const,
+    details: () => [...queryKeys.loungePosts.all, 'detail'] as const,
+    detail: (postId: number) => [...queryKeys.loungePosts.details(), postId] as const,
+  },
+
+  loungeComments: {
+    all: ['loungeComments'] as const,
+    lists: () => [...queryKeys.loungeComments.all, 'list'] as const,
+    listPrefix: (postId: number) => [...queryKeys.loungeComments.lists(), postId] as const,
+    list: (postId: number, params?: CursorPageRequestDto) =>
+      [...queryKeys.loungeComments.listPrefix(postId), params ?? {}] as const,
+    replies: (commentId: number, params?: CursorPageRequestDto) =>
+      [...queryKeys.loungeComments.all, 'replies', commentId, params ?? {}] as const,
+  },
+
+  archives: {
+    all: ['archives'] as const,
+    calendar: (params: ListParams) => [...queryKeys.archives.all, 'calendar', params] as const,
+    calendarDay: (params: ListParams) =>
+      [...queryKeys.archives.all, 'calendar-day', params] as const,
+
+    displays: {
+      all: () => [...queryKeys.archives.all, 'displays'] as const,
+      lists: () => [...queryKeys.archives.displays.all(), 'list'] as const,
+      list: (params?: ListParams) =>
+        [...queryKeys.archives.displays.lists(), params ?? {}] as const,
+    },
+
+    works: {
+      all: () => [...queryKeys.archives.all, 'works'] as const,
+      lists: () => [...queryKeys.archives.works.all(), 'list'] as const,
+      list: (params?: ListParams) => [...queryKeys.archives.works.lists(), params ?? {}] as const,
+    },
+
+    artists: {
+      all: () => [...queryKeys.archives.all, 'artists'] as const,
+      lists: () => [...queryKeys.archives.artists.all(), 'list'] as const,
+      list: (params?: ListParams) => [...queryKeys.archives.artists.lists(), params ?? {}] as const,
+    },
+  },
+} as const;

--- a/src/api/queryKeys.ts
+++ b/src/api/queryKeys.ts
@@ -1,5 +1,9 @@
 import type { CursorPageRequestDto } from '@/api/dto';
 import type {
+  GetArchiveCalendarDayRequestDto,
+  GetArchiveCalendarRequestDto,
+} from '@/api/dto/archive.dto';
+import type {
   GetDisplayArtworksRequestDto,
   GetDisplayMapRequestDto,
   GetDisplaysRequestDto,
@@ -101,8 +105,9 @@ export const queryKeys = {
 
   archives: {
     all: ['archives'] as const,
-    calendar: (params: ListParams) => [...queryKeys.archives.all, 'calendar', params] as const,
-    calendarDay: (params: ListParams) =>
+    calendar: (params: GetArchiveCalendarRequestDto) =>
+      [...queryKeys.archives.all, 'calendar', params] as const,
+    calendarDay: (params: GetArchiveCalendarDayRequestDto) =>
       [...queryKeys.archives.all, 'calendar-day', params] as const,
 
     displays: {

--- a/src/hooks/queries/useArchive.ts
+++ b/src/hooks/queries/useArchive.ts
@@ -50,12 +50,13 @@ export const useArchiveExhibition = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (exhibitionId: number) => archiveExhibition(exhibitionId),
-    onSuccess: (_, exhibitionId) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.all() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(exhibitionId) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() });
-    },
+    mutationFn: archiveExhibition,
+    onSuccess: (_, exhibitionId) =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.all() }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(exhibitionId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() }),
+      ]),
   });
 };
 
@@ -63,12 +64,13 @@ export const useUnarchiveExhibition = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (exhibitionId: number) => unarchiveExhibition(exhibitionId),
-    onSuccess: (_, exhibitionId) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.all() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(exhibitionId) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() });
-    },
+    mutationFn: unarchiveExhibition,
+    onSuccess: (_, exhibitionId) =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.all() }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(exhibitionId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() }),
+      ]),
   });
 };
 
@@ -76,12 +78,13 @@ export const useArchiveArtwork = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (artworkId: number) => archiveArtwork(artworkId),
-    onSuccess: (_, artworkId) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.archives.works.all() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.detail(artworkId) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.lists() });
-    },
+    mutationFn: archiveArtwork,
+    onSuccess: (_, artworkId) =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.archives.works.all() }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.detail(artworkId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.lists() }),
+      ]),
   });
 };
 
@@ -89,12 +92,13 @@ export const useUnarchiveArtwork = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (artworkId: number) => unarchiveArtwork(artworkId),
-    onSuccess: (_, artworkId) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.archives.works.all() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.detail(artworkId) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.lists() });
-    },
+    mutationFn: unarchiveArtwork,
+    onSuccess: (_, artworkId) =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.archives.works.all() }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.detail(artworkId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.lists() }),
+      ]),
   });
 };
 
@@ -102,10 +106,8 @@ export const useArchiveArtist = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (artistId: number) => archiveArtist(artistId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.archives.artists.all() });
-    },
+    mutationFn: archiveArtist,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.archives.artists.all() }),
   });
 };
 
@@ -113,9 +115,7 @@ export const useUnarchiveArtist = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (artistId: number) => unarchiveArtist(artistId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.archives.artists.all() });
-    },
+    mutationFn: unarchiveArtist,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.archives.artists.all() }),
   });
 };

--- a/src/hooks/queries/useArchive.ts
+++ b/src/hooks/queries/useArchive.ts
@@ -1,0 +1,121 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { GetArchiveCalendarDayRequestDto, GetArchiveCalendarRequestDto } from '@/api/dto';
+import {
+  archiveArtist,
+  archiveArtwork,
+  archiveExhibition,
+  getArchiveCalendar,
+  getArchiveCalendarDay,
+  getArchivedArtists,
+  getArchivedArtworks,
+  getArchivedExhibitions,
+  unarchiveArtist,
+  unarchiveArtwork,
+  unarchiveExhibition,
+} from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useArchiveCalendar = (params: GetArchiveCalendarRequestDto) =>
+  useQuery({
+    queryKey: queryKeys.archives.calendar(params),
+    queryFn: () => getArchiveCalendar(params),
+  });
+
+export const useArchiveCalendarDay = (params: GetArchiveCalendarDayRequestDto) =>
+  useQuery({
+    queryKey: queryKeys.archives.calendarDay(params),
+    queryFn: () => getArchiveCalendarDay(params),
+  });
+
+export const useArchivedExhibitions = () =>
+  useQuery({
+    queryKey: queryKeys.archives.displays.list(),
+    queryFn: getArchivedExhibitions,
+  });
+
+export const useArchivedArtworks = () =>
+  useQuery({
+    queryKey: queryKeys.archives.works.list(),
+    queryFn: getArchivedArtworks,
+  });
+
+export const useArchivedArtists = () =>
+  useQuery({
+    queryKey: queryKeys.archives.artists.list(),
+    queryFn: getArchivedArtists,
+  });
+
+export const useArchiveExhibition = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (exhibitionId: number) => archiveExhibition(exhibitionId),
+    onSuccess: (_, exhibitionId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(exhibitionId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() });
+    },
+  });
+};
+
+export const useUnarchiveExhibition = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (exhibitionId: number) => unarchiveExhibition(exhibitionId),
+    onSuccess: (_, exhibitionId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(exhibitionId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() });
+    },
+  });
+};
+
+export const useArchiveArtwork = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (artworkId: number) => archiveArtwork(artworkId),
+    onSuccess: (_, artworkId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.archives.works.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.detail(artworkId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.lists() });
+    },
+  });
+};
+
+export const useUnarchiveArtwork = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (artworkId: number) => unarchiveArtwork(artworkId),
+    onSuccess: (_, artworkId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.archives.works.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.detail(artworkId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.lists() });
+    },
+  });
+};
+
+export const useArchiveArtist = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (artistId: number) => archiveArtist(artistId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.archives.artists.all() });
+    },
+  });
+};
+
+export const useUnarchiveArtist = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (artistId: number) => unarchiveArtist(artistId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.archives.artists.all() });
+    },
+  });
+};

--- a/src/hooks/queries/useArtworkFeelings.ts
+++ b/src/hooks/queries/useArtworkFeelings.ts
@@ -1,0 +1,86 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { CreateArtworkFeelingRequestDto, UpdateArtworkFeelingRequestDto } from '@/api/dto';
+import {
+  createArtworkFeeling,
+  deleteArtworkFeeling,
+  getArtworkFeelings,
+  toggleArtworkFeelingLike,
+  updateArtworkFeeling,
+} from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useArtworkFeelings = (artworkId: number) =>
+  useQuery({
+    queryKey: queryKeys.artworkFeelings.list(artworkId),
+    queryFn: () => getArtworkFeelings(artworkId),
+    enabled: Number.isFinite(artworkId),
+  });
+
+export const useCreateArtworkFeeling = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      artworkId,
+      body,
+    }: {
+      artworkId: number;
+      body: CreateArtworkFeelingRequestDto;
+    }) => createArtworkFeeling(artworkId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkFeelings.list(variables.artworkId),
+      });
+    },
+  });
+};
+
+export const useUpdateArtworkFeeling = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      artworkId,
+      feelingId,
+      body,
+    }: {
+      artworkId: number;
+      feelingId: number;
+      body: UpdateArtworkFeelingRequestDto;
+    }) => updateArtworkFeeling(artworkId, feelingId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkFeelings.list(variables.artworkId),
+      });
+    },
+  });
+};
+
+export const useDeleteArtworkFeeling = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ artworkId, feelingId }: { artworkId: number; feelingId: number }) =>
+      deleteArtworkFeeling(artworkId, feelingId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkFeelings.list(variables.artworkId),
+      });
+    },
+  });
+};
+
+export const useToggleArtworkFeelingLike = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ artworkId, feelingId }: { artworkId: number; feelingId: number }) =>
+      toggleArtworkFeelingLike(artworkId, feelingId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkFeelings.list(variables.artworkId),
+      });
+    },
+  });
+};

--- a/src/hooks/queries/useArtworkQuestions.ts
+++ b/src/hooks/queries/useArtworkQuestions.ts
@@ -1,0 +1,97 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  CreateArtworkQuestionReplyRequestDto,
+  CreateArtworkQuestionRequestDto,
+  UpdateArtworkQuestionRequestDto,
+} from '@/api/dto';
+import {
+  createArtworkQuestion,
+  createArtworkQuestionReply,
+  deleteArtworkQuestion,
+  getArtworkQuestions,
+  updateArtworkQuestion,
+} from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useArtworkQuestions = (artworkId: number) =>
+  useQuery({
+    queryKey: queryKeys.artworkQuestions.list(artworkId),
+    queryFn: () => getArtworkQuestions(artworkId),
+    enabled: Number.isFinite(artworkId),
+  });
+
+export const useCreateArtworkQuestion = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      artworkId,
+      body,
+    }: {
+      artworkId: number;
+      body: CreateArtworkQuestionRequestDto;
+    }) => createArtworkQuestion(artworkId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkQuestions.list(variables.artworkId),
+      });
+    },
+  });
+};
+
+export const useUpdateArtworkQuestion = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      artworkId,
+      questionId,
+      body,
+    }: {
+      artworkId: number;
+      questionId: number;
+      body: UpdateArtworkQuestionRequestDto;
+    }) => updateArtworkQuestion(artworkId, questionId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkQuestions.list(variables.artworkId),
+      });
+    },
+  });
+};
+
+export const useDeleteArtworkQuestion = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ artworkId, questionId }: { artworkId: number; questionId: number }) =>
+      deleteArtworkQuestion(artworkId, questionId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkQuestions.list(variables.artworkId),
+      });
+    },
+  });
+};
+
+export const useCreateArtworkQuestionReply = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      artworkId,
+      questionId,
+      body,
+    }: {
+      artworkId: number;
+      questionId: number;
+      body: CreateArtworkQuestionReplyRequestDto;
+    }) => createArtworkQuestionReply(artworkId, questionId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkQuestions.list(variables.artworkId),
+      });
+    },
+  });
+};

--- a/src/hooks/queries/useAuth.ts
+++ b/src/hooks/queries/useAuth.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { LoginRequestDto, LogoutRequestDto, SignupRequestDto } from '@/api/dto';
+import { login, logout, signup } from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useLogin = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: LoginRequestDto) => login(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+    },
+  });
+};
+
+export const useSignup = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: SignupRequestDto) => signup(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+    },
+  });
+};
+
+export const useLogout = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: LogoutRequestDto) => logout(body),
+    onSuccess: () => {
+      queryClient.clear();
+    },
+  });
+};

--- a/src/hooks/queries/useDisplayBrowse.ts
+++ b/src/hooks/queries/useDisplayBrowse.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+
+import type {
+  GetDisplayMapRequestDto,
+  GetDisplaysRequestDto,
+  SearchDisplaysRequestDto,
+} from '@/api/dto';
+import { getDisplayMap, getDisplays, searchDisplays } from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useDisplays = (params: GetDisplaysRequestDto = {}) =>
+  useQuery({
+    queryKey: queryKeys.displays.list(params),
+    queryFn: () => getDisplays(params),
+  });
+
+export const useSearchDisplays = (params: SearchDisplaysRequestDto) =>
+  useQuery({
+    queryKey: queryKeys.displays.search(params),
+    queryFn: () => searchDisplays(params),
+  });
+
+export const useDisplayMap = (params: GetDisplayMapRequestDto) =>
+  useQuery({
+    queryKey: queryKeys.displays.map(params),
+    queryFn: () => getDisplayMap(params),
+  });

--- a/src/hooks/queries/useDisplayDetail.ts
+++ b/src/hooks/queries/useDisplayDetail.ts
@@ -35,7 +35,6 @@ export const useToggleDisplayLike = () => {
   return useMutation({
     mutationFn: (displayId: number) => toggleDisplayLike(displayId),
     onSuccess: (data, displayId) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(displayId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() });
       queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.lists() });
       queryClient.setQueryData(
@@ -46,10 +45,6 @@ export const useToggleDisplayLike = () => {
     },
   });
 };
-
-export const useLikeDisplay = useToggleDisplayLike;
-
-export const useCancelLikeDisplay = useToggleDisplayLike;
 
 export const useCreateDisplayReview = () => {
   const queryClient = useQueryClient();

--- a/src/hooks/queries/useDisplayDetail.ts
+++ b/src/hooks/queries/useDisplayDetail.ts
@@ -1,0 +1,104 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  CreateDisplayReviewRequestDto,
+  DisplayDetailDto,
+  UpdateDisplayReviewRequestDto,
+} from '@/api/dto';
+import {
+  createDisplayReview,
+  deleteDisplayReview,
+  getDisplayDetail,
+  getDisplayReviews,
+  toggleDisplayLike,
+  updateDisplayReview,
+} from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useDisplayDetail = (displayId: number) =>
+  useQuery({
+    queryKey: queryKeys.displays.detail(displayId),
+    queryFn: () => getDisplayDetail(displayId),
+    enabled: Number.isFinite(displayId),
+  });
+
+export const useDisplayReviews = (displayId: number, params: { page: number; size: number }) =>
+  useQuery({
+    queryKey: queryKeys.displays.reviews(displayId, params),
+    queryFn: () => getDisplayReviews(displayId, params),
+    enabled: Number.isFinite(displayId),
+  });
+
+export const useToggleDisplayLike = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (displayId: number) => toggleDisplayLike(displayId),
+    onSuccess: (data, displayId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(displayId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.lists() });
+      queryClient.setQueryData(
+        queryKeys.displays.detail(displayId),
+        (current: DisplayDetailDto | undefined) =>
+          current ? { ...current, isLiked: data.isLiked, likeCount: data.likeCount } : current,
+      );
+    },
+  });
+};
+
+export const useLikeDisplay = useToggleDisplayLike;
+
+export const useCancelLikeDisplay = useToggleDisplayLike;
+
+export const useCreateDisplayReview = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ displayId, body }: { displayId: number; body: CreateDisplayReviewRequestDto }) =>
+      createDisplayReview(displayId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(variables.displayId) });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.displays.reviewLists(variables.displayId),
+      });
+    },
+  });
+};
+
+export const useUpdateDisplayReview = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      displayId,
+      reviewId,
+      body,
+    }: {
+      displayId: number;
+      reviewId: number;
+      body: UpdateDisplayReviewRequestDto;
+    }) => updateDisplayReview(displayId, reviewId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(variables.displayId) });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.displays.reviewLists(variables.displayId),
+      });
+    },
+  });
+};
+
+export const useDeleteDisplayReview = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ displayId, reviewId }: { displayId: number; reviewId: number }) =>
+      deleteDisplayReview(displayId, reviewId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(variables.displayId) });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.displays.reviewLists(variables.displayId),
+      });
+    },
+  });
+};

--- a/src/hooks/queries/useHome.ts
+++ b/src/hooks/queries/useHome.ts
@@ -8,48 +8,40 @@ import {
 } from '@/api/endpoints';
 import { queryKeys } from '@/api/queryKeys';
 
-export const useGraduationDisplays = () =>
-  useQuery({
-    queryKey: queryKeys.displays.graduation(),
-    queryFn: getGraduationDisplays,
-  });
+const graduationDisplaysQuery = () => ({
+  queryKey: queryKeys.displays.graduation(),
+  queryFn: getGraduationDisplays,
+});
 
-export const useClosingSoonDisplays = () =>
-  useQuery({
-    queryKey: queryKeys.displays.closingSoon(),
-    queryFn: getClosingSoonDisplays,
-  });
+const closingSoonDisplaysQuery = () => ({
+  queryKey: queryKeys.displays.closingSoon(),
+  queryFn: getClosingSoonDisplays,
+});
 
-export const useDuPicks = () =>
-  useQuery({
-    queryKey: queryKeys.displays.duPicks(),
-    queryFn: getDuPicks,
-  });
+const duPicksQuery = () => ({
+  queryKey: queryKeys.displays.duPicks(),
+  queryFn: getDuPicks,
+});
 
-export const useHomeArtworkPreview = () =>
-  useQuery({
-    queryKey: queryKeys.displayArtworks.preview(),
-    queryFn: () => getArtworkPreview(),
-  });
+const homeArtworkPreviewQuery = () => ({
+  queryKey: queryKeys.displayArtworks.preview(),
+  queryFn: () => getArtworkPreview(),
+});
+
+export const useGraduationDisplays = () => useQuery(graduationDisplaysQuery());
+
+export const useClosingSoonDisplays = () => useQuery(closingSoonDisplaysQuery());
+
+export const useDuPicks = () => useQuery(duPicksQuery());
+
+export const useHomeArtworkPreview = () => useQuery(homeArtworkPreviewQuery());
 
 export const useHome = () =>
   useQueries({
     queries: [
-      {
-        queryKey: queryKeys.displays.graduation(),
-        queryFn: getGraduationDisplays,
-      },
-      {
-        queryKey: queryKeys.displays.closingSoon(),
-        queryFn: getClosingSoonDisplays,
-      },
-      {
-        queryKey: queryKeys.displays.duPicks(),
-        queryFn: getDuPicks,
-      },
-      {
-        queryKey: queryKeys.displayArtworks.preview(),
-        queryFn: () => getArtworkPreview(),
-      },
+      graduationDisplaysQuery(),
+      closingSoonDisplaysQuery(),
+      duPicksQuery(),
+      homeArtworkPreviewQuery(),
     ],
   });

--- a/src/hooks/queries/useHome.ts
+++ b/src/hooks/queries/useHome.ts
@@ -1,0 +1,55 @@
+import { useQueries, useQuery } from '@tanstack/react-query';
+
+import {
+  getArtworkPreview,
+  getClosingSoonDisplays,
+  getDuPicks,
+  getGraduationDisplays,
+} from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useGraduationDisplays = () =>
+  useQuery({
+    queryKey: queryKeys.displays.graduation(),
+    queryFn: getGraduationDisplays,
+  });
+
+export const useClosingSoonDisplays = () =>
+  useQuery({
+    queryKey: queryKeys.displays.closingSoon(),
+    queryFn: getClosingSoonDisplays,
+  });
+
+export const useDuPicks = () =>
+  useQuery({
+    queryKey: queryKeys.displays.duPicks(),
+    queryFn: getDuPicks,
+  });
+
+export const useHomeArtworkPreview = () =>
+  useQuery({
+    queryKey: queryKeys.displayArtworks.preview(),
+    queryFn: () => getArtworkPreview(),
+  });
+
+export const useHome = () =>
+  useQueries({
+    queries: [
+      {
+        queryKey: queryKeys.displays.graduation(),
+        queryFn: getGraduationDisplays,
+      },
+      {
+        queryKey: queryKeys.displays.closingSoon(),
+        queryFn: getClosingSoonDisplays,
+      },
+      {
+        queryKey: queryKeys.displays.duPicks(),
+        queryFn: getDuPicks,
+      },
+      {
+        queryKey: queryKeys.displayArtworks.preview(),
+        queryFn: () => getArtworkPreview(),
+      },
+    ],
+  });

--- a/src/hooks/queries/useLounge.ts
+++ b/src/hooks/queries/useLounge.ts
@@ -1,0 +1,116 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  CreateLoungePostRequestDto,
+  GetLoungePostsRequestDto,
+  UpdateLoungePostRequestDto,
+} from '@/api/dto';
+import {
+  createLoungePost,
+  deleteLoungePost,
+  getLoungePostDetail,
+  getLoungePosts,
+  likeLoungePost,
+  scrapLoungePost,
+  unlikeLoungePost,
+  unscrapLoungePost,
+  updateLoungePost,
+} from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useLoungePosts = (params: GetLoungePostsRequestDto = {}) =>
+  useQuery({
+    queryKey: queryKeys.loungePosts.list(params),
+    queryFn: () => getLoungePosts(params),
+  });
+
+export const useLoungePostDetail = (postId: number) =>
+  useQuery({
+    queryKey: queryKeys.loungePosts.detail(postId),
+    queryFn: () => getLoungePostDetail(postId),
+    enabled: Number.isFinite(postId),
+  });
+
+export const useCreateLoungePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: CreateLoungePostRequestDto) => createLoungePost(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+    },
+  });
+};
+
+export const useUpdateLoungePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ postId, body }: { postId: number; body: UpdateLoungePostRequestDto }) =>
+      updateLoungePost(postId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(variables.postId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+    },
+  });
+};
+
+export const useDeleteLoungePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => deleteLoungePost(postId),
+    onSuccess: (_, postId) => {
+      queryClient.removeQueries({ queryKey: queryKeys.loungePosts.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+    },
+  });
+};
+
+export const useLikeLoungePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => likeLoungePost(postId),
+    onSuccess: (_, postId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+    },
+  });
+};
+
+export const useUnlikeLoungePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => unlikeLoungePost(postId),
+    onSuccess: (_, postId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+    },
+  });
+};
+
+export const useScrapLoungePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => scrapLoungePost(postId),
+    onSuccess: (_, postId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+    },
+  });
+};
+
+export const useUnscrapLoungePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => unscrapLoungePost(postId),
+    onSuccess: (_, postId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+    },
+  });
+};

--- a/src/hooks/queries/useLoungeComments.ts
+++ b/src/hooks/queries/useLoungeComments.ts
@@ -1,0 +1,101 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  CreateLoungeCommentRequestDto,
+  CursorPageRequestDto,
+  UpdateLoungeCommentRequestDto,
+} from '@/api/dto';
+import {
+  createLoungeComment,
+  deleteLoungeComment,
+  getLoungeComments,
+  likeLoungeComment,
+  unlikeLoungeComment,
+  updateLoungeComment,
+} from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useLoungeComments = (postId: number, params: CursorPageRequestDto = {}) =>
+  useQuery({
+    queryKey: queryKeys.loungeComments.list(postId, params),
+    queryFn: () => getLoungeComments(postId, params),
+    enabled: Number.isFinite(postId),
+  });
+
+export const useCreateLoungeComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ postId, body }: { postId: number; body: CreateLoungeCommentRequestDto }) =>
+      createLoungeComment(postId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.loungeComments.listPrefix(variables.postId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(variables.postId) });
+    },
+  });
+};
+
+export const useUpdateLoungeComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      commentId,
+      body,
+    }: {
+      postId: number;
+      commentId: number;
+      body: UpdateLoungeCommentRequestDto;
+    }) => updateLoungeComment(commentId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.loungeComments.listPrefix(variables.postId),
+      });
+    },
+  });
+};
+
+export const useDeleteLoungeComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ commentId }: { postId: number; commentId: number }) =>
+      deleteLoungeComment(commentId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.loungeComments.listPrefix(variables.postId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(variables.postId) });
+    },
+  });
+};
+
+export const useLikeLoungeComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ commentId }: { postId: number; commentId: number }) =>
+      likeLoungeComment(commentId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.loungeComments.listPrefix(variables.postId),
+      });
+    },
+  });
+};
+
+export const useUnlikeLoungeComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ commentId }: { postId: number; commentId: number }) =>
+      unlikeLoungeComment(commentId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.loungeComments.listPrefix(variables.postId),
+      });
+    },
+  });
+};

--- a/src/hooks/queries/useLoungeReplies.ts
+++ b/src/hooks/queries/useLoungeReplies.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { CreateLoungeReplyRequestDto, CursorPageRequestDto } from '@/api/dto';
+import { createLoungeReply, getLoungeReplies } from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useLoungeReplies = (commentId: number, params: CursorPageRequestDto = {}) =>
+  useQuery({
+    queryKey: queryKeys.loungeComments.replies(commentId, params),
+    queryFn: () => getLoungeReplies(commentId, params),
+    enabled: Number.isFinite(commentId),
+  });
+
+export const useCreateLoungeReply = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      commentId,
+      body,
+    }: {
+      postId: number;
+      commentId: number;
+      body: CreateLoungeReplyRequestDto;
+    }) => createLoungeReply(commentId, body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.loungeComments.replyLists(variables.commentId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.loungeComments.listPrefix(variables.postId),
+      });
+    },
+  });
+};

--- a/src/hooks/queries/useMyPage.ts
+++ b/src/hooks/queries/useMyPage.ts
@@ -1,0 +1,12 @@
+export {
+  useArchiveArtist,
+  useArchiveArtwork,
+  useArchivedArtists,
+  useArchivedArtworks,
+  useArchivedExhibitions,
+  useArchiveExhibition,
+  useUnarchiveArtist,
+  useUnarchiveArtwork,
+  useUnarchiveExhibition,
+} from './useArchive';
+export { useDeleteUserMe, useUpdateNickname, useUserMe } from './useUserProfile';

--- a/src/hooks/queries/useSchoolEmailVerification.ts
+++ b/src/hooks/queries/useSchoolEmailVerification.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  ConfirmVerificationEmailRequestDto,
+  ResendVerificationEmailRequestDto,
+  SendVerificationEmailRequestDto,
+} from '@/api/dto';
+import {
+  confirmVerificationEmail,
+  resendVerificationEmail,
+  sendVerificationEmail,
+} from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useSendVerificationEmail = () =>
+  useMutation({
+    mutationFn: (body: SendVerificationEmailRequestDto) => sendVerificationEmail(body),
+  });
+
+export const useConfirmVerificationEmail = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: ConfirmVerificationEmailRequestDto) => confirmVerificationEmail(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+    },
+  });
+};
+
+export const useResendVerificationEmail = () =>
+  useMutation({
+    mutationFn: (body: ResendVerificationEmailRequestDto) => resendVerificationEmail(body),
+  });

--- a/src/hooks/queries/useUserProfile.ts
+++ b/src/hooks/queries/useUserProfile.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { CheckNicknameRequestDto, UpdateNicknameRequestDto } from '@/api/dto';
+import { checkNickname, deleteUserMe, getUserMe, updateNickname } from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+export const useUserMe = () =>
+  useQuery({
+    queryKey: queryKeys.users.me(),
+    queryFn: getUserMe,
+  });
+
+export const useCheckNickname = (params: CheckNicknameRequestDto, enabled = true) =>
+  useQuery({
+    queryKey: queryKeys.users.nicknameCheck(params.nickname),
+    queryFn: () => checkNickname(params),
+    enabled: enabled && params.nickname.trim().length > 0,
+  });
+
+export const useUpdateNickname = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: UpdateNicknameRequestDto) => updateNickname(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+    },
+  });
+};
+
+export const useDeleteUserMe = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteUserMe,
+    onSuccess: () => {
+      queryClient.clear();
+    },
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,11 @@ import './styles/index.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RouterProvider } from 'react-router-dom';
 
+import { queryClient } from './queryClient';
 import { router } from './Router';
 
 const enableMocking = async () => {
@@ -26,7 +29,10 @@ const enableMocking = async () => {
 const renderApp = () => {
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-      <RouterProvider router={router} />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
     </React.StrictMode>,
   );
 };

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -1,5 +1,7 @@
 import { QueryClient } from '@tanstack/react-query';
 
+import { ApiError } from '@/api/axios';
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     mutations: {
@@ -7,7 +9,17 @@ export const queryClient = new QueryClient({
     },
     queries: {
       refetchOnWindowFocus: false,
-      retry: 1,
+      retry: (failureCount, error) => {
+        if (failureCount >= 1) {
+          return false;
+        }
+
+        if (error instanceof ApiError) {
+          return !error.status || error.status >= 500;
+        }
+
+        return true;
+      },
       staleTime: 1000 * 60,
     },
   },

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -1,0 +1,14 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    mutations: {
+      retry: 0,
+    },
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+      staleTime: 1000 * 60,
+    },
+  },
+});


### PR DESCRIPTION
## 📝 작업 내용

- TanStack Query 기반 서버 상태 관리 훅을 추가했습니다.
- `src/api/queryKeys.ts`에 로컬 endpoint 기준 query key factory를 추가했습니다.
- 인증/사용자, 홈/전시, 작품 상호작용, 라운지, 아카이브/마이페이지 query/mutation 훅을 추가했습니다.
- `refreshToken`은 컴포넌트 훅으로 만들지 않고, 인터셉터 전용 endpoint 함수로 유지했습니다.
- `useMyPage.ts`에서는 archive 훅을 재구현하지 않고 `useArchive.ts` 훅을 재사용하도록 구성했습니다.

## 🔍 관련 이슈

- close #86

## 🖼️ 스크린샷

- UI 연결 작업은 이번 PR 범위에 포함하지 않아 스크린샷은 없습니다.

## 🧪 테스트 결과

- [x] 정상 작동 확인
  - `pnpm build`
  - `pnpm lint`
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- Swagger 말고 현재 로컬에 정의된 `src/api/endpoints/*.ts`를 중심으로 훅을 작성했습니다. 추후 엔드포인트 수정하면서 같이 수정할 예정입니다.
- 작가 프로필/개인 작품/파일 업로드(presigned URL)는 로컬 endpoint가 아직 없어 이번 범위에서 제외했습니다.
- 컴포넌트 연결은 후속 이슈에서 진행 예정입니다.
- **이 PR은 #84에서 분기한 서브 이슈 작업용 Draft PR입니다.** #85 머지하고 이후에 머지해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 서버 데이터 조회와 캐싱을 위한 React Query 기반 데이터 관리가 추가되었습니다.
  * 로그인, 회원가입, 로그아웃 및 학교 이메일 인증 흐름을 지원합니다.
  * 전시·작품·아티스트 보관 및 해제 기능을 사용할 수 있습니다.
  * 전시 검색·지도·상세·리뷰, 홈 콘텐츠 조회 기능이 추가되었습니다.
  * 라운지 게시글·댓글·답글의 작성, 수정, 삭제, 좋아요 및 스크랩을 지원합니다.
  * 작품 감정과 질문·답변을 관리할 수 있습니다.

* **개선**
  * 인증 토큰이 요청에 자동 적용됩니다.
  * API 오류 메시지와 상태를 일관되게 처리합니다.
  * 데이터 변경 후 관련 화면이 자동으로 최신 상태로 갱신됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->