### PR TITLE
Fix: FNB 냅바 반응형 디자인 제거

### DIFF
--- a/src/components/homepage/DuPickBanner.tsx
+++ b/src/components/homepage/DuPickBanner.tsx
@@ -4,6 +4,7 @@ import { Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import type { DuPickDto } from '@/api/dto';
+import DUfontlogo from '@/assets/DUfontlogo.svg';
 
 type Props = {
   items: DuPickDto[];
@@ -28,7 +29,8 @@ export function DuPickBanner({ items }: Props) {
     <section className="pb-7">
       <div className="px-4 mb-2.5 flex justify-between items-center">
         <h2 className="flex items-center gap-1.5 typo-heading-3xl text-main">
-          <span>DU Pick</span>
+          <img src={DUfontlogo} alt="DU" className="h-7 w-auto" />
+          <span>Pick</span>
         </h2>
         <button
           type="button"

--- a/src/components/layout/FNB.tsx
+++ b/src/components/layout/FNB.tsx
@@ -1,42 +1,27 @@
 import DUfontlogo from '../../assets/DUfontlogo.svg';
 
-interface DUMember {
-  names: string[];
-  role: string;
-}
-
-const credits: DUMember[] = [
-  { names: ['고상준'], role: 'PM' },
-  { names: ['최유성'], role: 'DESIGN' },
-  { names: ['안재인', '이승철', '서현민', '정아람'], role: 'FrontEnd' },
-  { names: ['임도현', '최건희', '김승완', '김수빈', '김민지', '우서윤'], role: 'BackEnd' },
-];
-
 export function FNB() {
   return (
-    <footer className="w-full bg-line-soft py-8 px-6 md:py-10 md:px-10 lg:py-12 lg:px-16">
-      <div className="mx-auto flex flex-col md:flex-row md:items-start md:justify-between gap-8 lg:gap-16 max-w-7xl">
-        <div className="flex flex-col items-start gap-2.5 md:gap-3 shrink-0">
-          <img alt="DISPLAYU" className="h-6 md:h-7 lg:h-8 w-auto self-start" src={DUfontlogo} />
-          <p className="typo-body-xs-regular md:typo-body-sm-regular text-logo">전시공유 플랫폼</p>
+    <footer className="relative mx-auto h-60 w-96 max-w-full overflow-hidden bg-zinc-300 mix-blend-multiply">
+      <div className="absolute top-6 left-[30px] inline-flex w-80 flex-col items-start justify-start gap-6">
+        <div className="flex flex-col items-start justify-start gap-3 self-stretch">
+          <img alt="DISPLAYU" className="h-7 w-[57px]" src={DUfontlogo} />
+          <p className="text-xs leading-4 font-normal text-slate-950">대학생 전시 플랫폼</p>
         </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 sm:gap-7 md:gap-8 lg:gap-12">
-          {credits.map((item) => (
-            <div className="flex shrink-0 flex-col gap-0.5" key={item.role}>
-              <p className="typo-body-xs-semibold md:typo-body-sm-semibold text-sub600 whitespace-pre">
-                {item.role}
-              </p>
-              {item.names.map((name, idx) => (
-                <p
-                  className="typo-body-xs-regular md:typo-body-sm-regular text-hint whitespace-pre"
-                  key={idx}
-                >
-                  {name}
-                </p>
-              ))}
-            </div>
-          ))}
+        <div className="inline-flex items-start justify-start gap-7">
+          <p className="shrink-0 text-xs leading-4 font-normal whitespace-pre text-neutral-500">
+            {'PM \n고상준'}
+          </p>
+          <p className="shrink-0 text-xs leading-4 font-normal whitespace-pre text-neutral-500">
+            {'DESIGN \n최유성'}
+          </p>
+          <p className="w-16 shrink-0 text-xs leading-4 font-normal whitespace-pre text-neutral-500">
+            {'FrontEnd \n이승철  서현민\n안재인  정아람'}
+          </p>
+          <p className="shrink-0 text-xs leading-4 font-normal whitespace-pre text-neutral-500">
+            {'BackEnd \n김승완  임도현  최건희\n김수빈  김민지  우서윤'}
+          </p>
         </div>
       </div>
     </footer>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+import DUfontlogo from '../../assets/DUfontlogo.svg';
+
+type HeaderProps = {
+  title?: ReactNode;
+  left?: ReactNode;
+  right?: ReactNode;
+};
+
+export function Header({ title, left, right }: HeaderProps) {
+  return (
+    <header className="relative h-[34px] w-full min-w-[320px] text-[#111111]">
+      <div className="absolute top-1/2 left-[37px] flex size-[34px] -translate-x-1/2 -translate-y-1/2 items-center justify-center">
+        {left}
+      </div>
+      <div className="absolute top-1/2 left-1/2 m-0 flex h-[34px] -translate-x-1/2 -translate-y-1/2 items-center justify-center text-center text-[20px] leading-[30px] font-extrabold tracking-normal text-[#06032d]">
+        {title ?? <img alt="DISPLAYU" className="h-[34px] w-[57px]" src={DUfontlogo} />}
+      </div>
+      <div className="absolute top-1/2 right-[37px] flex size-[34px] translate-x-1/2 -translate-y-1/2 items-center justify-center">
+        {right}
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/HeaderProvider.tsx
+++ b/src/components/layout/HeaderProvider.tsx
@@ -1,0 +1,19 @@
+import { type ReactNode, useState } from 'react';
+
+import { type HeaderConfig, HeaderContext } from './headerContext';
+
+type HeaderProviderProps = {
+  children: ReactNode;
+};
+
+export function HeaderProvider({ children }: HeaderProviderProps) {
+  const [header, setHeaderState] = useState<HeaderConfig>({});
+
+  const value = {
+    header,
+    resetHeader: () => setHeaderState({}),
+    setHeader: setHeaderState,
+  };
+
+  return <HeaderContext.Provider value={value}>{children}</HeaderContext.Provider>;
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useLocation } from 'react-router-dom';
 
 import { FNB } from './FNB';
+import { HeaderProvider } from './HeaderProvider';
 import { Navbar } from './Navbar';
 
 function LayoutContent() {
@@ -9,22 +10,24 @@ function LayoutContent() {
   const shouldHideNavbar = hideNavbarPaths.some((path) => location.pathname.startsWith(path));
 
   return (
-    <div className="min-h-screen flex flex-col justify-between">
-      <main className="flex-1 pb-6 md:pb-8">
+    <>
+      <main>
         <Outlet />
       </main>
-      <FNB />
       {!shouldHideNavbar && (
-        <div className="fixed right-0 bottom-4 sm:bottom-6 md:bottom-8 left-0 z-50 flex justify-center px-4 pointer-events-none">
-          <div className="pointer-events-auto">
-            <Navbar />
-          </div>
+        <div className="fixed right-0 bottom-[34px] left-0 z-50 flex justify-center px-4">
+          <Navbar />
         </div>
       )}
-    </div>
+      <FNB />
+    </>
   );
 }
 
 export function Layout() {
-  return <LayoutContent />;
+  return (
+    <HeaderProvider>
+      <LayoutContent />
+    </HeaderProvider>
+  );
 }

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -50,7 +50,7 @@ const NAV_ITEMS = [
 
 export function Navbar() {
   return (
-    <div className="relative rounded-[250px] px-3 py-1 sm:px-5 sm:py-1.5 shadow-[2px_8px_18px_0px_rgba(4,0,250,0.06)] overflow-hidden transition-all duration-300">
+    <div className="relative overflow-hidden rounded-[250px] px-5 py-1.5 shadow-[2px_8px_18px_0px_rgba(4,0,250,0.06)]">
       <div
         aria-hidden
         className="absolute inset-0 rounded-[250px] backdrop-blur-[10px] pointer-events-none"
@@ -68,23 +68,23 @@ export function Navbar() {
         }}
       />
 
-      <div className="relative flex items-center justify-center gap-1 sm:gap-2">
+      <div className="relative flex items-center justify-center">
         {NAV_ITEMS.map(({ activeIcon, icon, id, label, path }) => {
           return (
             <NavLink
               key={id}
               end={path === '/'}
-              className="flex flex-col items-center justify-center w-16 sm:w-20 lg:w-24 h-[52px] sm:h-[60px] lg:h-[64px] cursor-pointer rounded-[24px] border-0 bg-transparent outline-none transition-transform duration-150 hover:scale-105 active:scale-95 focus-visible:ring-2 focus-visible:ring-[#fcfcfc] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+              className="flex h-[60px] w-20 cursor-pointer flex-col items-center justify-center rounded-[24px] border-0 bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-[#fcfcfc] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
               to={path}
             >
               {({ isActive }) => (
-                <div className="flex flex-col items-center gap-0.5 sm:gap-1">
-                  <img
-                    alt=""
-                    className="h-4.5 w-4.5 sm:h-5 sm:w-5 lg:h-6 lg:w-6 transition-transform duration-200"
-                    src={isActive ? activeIcon : icon}
-                  />
-                  <span className="whitespace-nowrap transition-colors duration-150 typo-body-xs-regular sm:typo-body-sm-regular text-white">
+                <div className="flex flex-col items-center gap-1">
+                  <img alt="" className="h-5 w-5" src={isActive ? activeIcon : icon} />
+                  <span
+                    className={`text-[12px] leading-[1.4] tracking-[-0.36px] whitespace-nowrap transition-colors duration-150 ${
+                      isActive ? 'font-bold text-[#fcfcfc]' : 'font-normal text-[#e5e5e5]'
+                    }`}
+                  >
                     {label}
                   </span>
                 </div>

--- a/src/components/layout/headerContext.ts
+++ b/src/components/layout/headerContext.ts
@@ -1,0 +1,25 @@
+import { createContext, type ReactNode, useContext } from 'react';
+
+export type HeaderConfig = {
+  title?: ReactNode;
+  left?: ReactNode;
+  right?: ReactNode;
+};
+
+export type HeaderContextValue = {
+  header: HeaderConfig;
+  resetHeader: () => void;
+  setHeader: (header: HeaderConfig) => void;
+};
+
+export const HeaderContext = createContext<HeaderContextValue | null>(null);
+
+export function useHeaderContext() {
+  const context = useContext(HeaderContext);
+
+  if (!context) {
+    throw new Error('useHeaderContext must be used within HeaderProvider.');
+  }
+
+  return context;
+}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,3 +1,7 @@
 export { FNB } from './FNB';
+export { Header } from './Header';
+export type { HeaderConfig } from './headerContext';
+export { useHeaderContext } from './headerContext';
+export { HeaderProvider } from './HeaderProvider';
 export { Layout } from './Layout';
 export { Navbar } from './Navbar';

--- a/src/pages/ArchivePage.tsx
+++ b/src/pages/ArchivePage.tsx
@@ -1,0 +1,521 @@
+import { useState } from 'react';
+
+// SVG Icon imports
+import { ChevronRight, type LucideIcon, Pencil, Trash2, Users } from 'lucide-react';
+
+import BookmarkIcon from '../assets/bookmark.svg';
+
+/* ------------------------------------------------------------------ */
+/* 타입 & 목데이터                                                       */
+/* ------------------------------------------------------------------ */
+
+type TabKey = 'exhibition' | 'artwork' | 'artist';
+
+interface ExhibitionItem {
+  id: string;
+  status: string;
+  title: string;
+  org: string;
+  period: string;
+  place: string;
+  thumbnail: string;
+  memo?: string;
+}
+
+interface ArtworkItem {
+  id: string;
+  title: string;
+  artist: string;
+  thumbnail: string;
+  memo?: string;
+}
+
+interface ArtistItem {
+  id: string;
+  name: string;
+  field: string;
+  registeration: string;
+  exhibition: string;
+  thumbnail: string;
+  memo?: string;
+}
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'exhibition', label: '전시' },
+  { key: 'artwork', label: '작품' },
+  { key: 'artist', label: '작가' },
+];
+
+const EXHIBITIONS: ExhibitionItem[] = [
+  {
+    id: '1',
+    status: '전시 중',
+    title: '형태의 침묵',
+    org: '중앙대학교 디자인학부',
+    period: '05.28 – 06.05',
+    place: '중앙대학교 310관 갤러리',
+    thumbnail: 'https://placehold.co/112x140',
+    memo: '',
+  },
+  {
+    id: '2',
+    status: '전시 중',
+    title: '형태의 침묵',
+    org: '중앙대학교 디자인학부',
+    period: '05.28 – 06.05',
+    place: '중앙대학교 310관 갤러리',
+    thumbnail: 'https://placehold.co/112x140',
+    memo: '공간이 조용해서 작품의 재료감이 더 잘 보였다. 작품 설명보다 전시 동선...',
+  },
+  {
+    id: '3',
+    status: '전시 중',
+    title: '감각의 표면',
+    org: '홍익대학교 회화과',
+    period: '06.23 – 06.27',
+    place: '홍익대학교 현대미술관',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+];
+
+const ARTWORKS: ArtworkItem[] = [
+  {
+    id: '1',
+    title: 'FROM 2026',
+    artist: '고상준',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+  {
+    id: '2',
+    title: 'VISUAL WAVE',
+    artist: '최유성',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+  {
+    id: '3',
+    title: 'FROM 2026',
+    artist: '고상준',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+  {
+    id: '4',
+    title: 'VISUAL WAVE',
+    artist: '최유성',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+];
+
+const ARTISTS: ArtistItem[] = [
+  {
+    id: '1',
+    name: '작가 닉네임',
+    field: '분야',
+    registeration: '3',
+    exhibition: '8',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+  {
+    id: '2',
+    name: '작가 닉네임',
+    field: '분야',
+    registeration: '3',
+    exhibition: '8',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+  {
+    id: '3',
+    name: '작가 닉네임',
+    field: '분야',
+    registeration: '3',
+    exhibition: '8',
+    thumbnail: 'https://placehold.co/112x140',
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/* 헤더(타이틀) + 탭                                                     */
+/* ------------------------------------------------------------------ */
+
+function ArchiveHeader({
+  activeTab,
+  onTabChange,
+  onOpenSettings,
+}: {
+  activeTab: TabKey;
+  onTabChange: (key: TabKey) => void;
+  onOpenSettings: () => void;
+}) {
+  return (
+    <header className="shrink-0 bg-white">
+      <div className="px-5 pt-2 pb-5 flex justify-between items-start">
+        <div className="flex flex-col items-start">
+          <h1 className="text-slate-900 text-3xl font-['Aldrich'] leading-10">Archive</h1>
+          <p className="pt-1 text-neutral-500 text-xs font-normal font-['Pretendard'] leading-4">
+            저장한 전시와 작품, 작가를 다시 꺼내보세요.
+          </p>
+        </div>
+        <button
+          type="button"
+          aria-label="설정"
+          onClick={onOpenSettings}
+          className="shrink-0 p-1 text-neutral-700"
+        >
+          <svg
+            className="size-6"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.8}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+        </button>
+      </div>
+
+      <nav className="px-5 border-b-2 border-zinc-300 flex items-center gap-24 shadow-[0px_0px_18px_0px_rgba(67,0,209,0.04)]">
+        {TABS.map((tab) => {
+          const isActive = tab.key === activeTab;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => onTabChange(tab.key)}
+              className={`w- h-11 -mb-0.5 border-b-2 text-sm font-['Pretendard'] leading-5 ${
+                isActive
+                  ? 'border-neutral-900 text-neutral-900 font-bold'
+                  : 'border-transparent text-neutral-400 font-normal'
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </nav>
+    </header>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* 전시 카드                                                            */
+/* ------------------------------------------------------------------ */
+
+function ExhibitionCard({ item }: { item: ExhibitionItem }) {
+  const hasMemo = Boolean(item.memo);
+
+  return (
+    <article className="shrink-0 w-full bg-white rounded-2xl outline-1 -outline-offset-1 outline-zinc-100 flex flex-col overflow-hidden font-['Pretendard']">
+      <div className="p-3.5 flex justify-start items-start gap-3.5">
+        <div className="w-28 h-36 rounded-lg overflow-hidden bg-zinc-100 shrink-0">
+          <img className="w-full h-full object-cover" src={item.thumbnail} alt={item.title} />
+        </div>
+
+        <div className="flex-1 flex flex-col justify-start items-start min-w-0">
+          <div className="self-stretch flex justify-between items-start gap-2">
+            <div className="px-2 py-0.5 bg-indigo-500 rounded-lg shrink-0">
+              <span className="text-neutral-50 text-[10px] font-normal font-['Pretendard'] leading-3">
+                {item.status}
+              </span>
+            </div>
+            <button type="button" aria-label="북마크" className="shrink-0">
+              <img src={BookmarkIcon} alt="" className="size-5" />
+            </button>
+          </div>
+
+          <div className="self-stretch pt-2">
+            <div className="text-neutral-900 text-base font-bold leading-5 truncate">
+              {item.title}
+            </div>
+          </div>
+          <div className="self-stretch pt-1.5">
+            <div className="text-neutral-700 text-xs font-normal leading-4 truncate">
+              {item.org}
+            </div>
+          </div>
+          <div className="pt-1.5">
+            <div className="text-zinc-500 text-xs font-normal leading-4">{item.period}</div>
+          </div>
+          <div className="self-stretch pt-1.5">
+            <div className="text-neutral-400 text-xs font-normal leading-4 truncate">
+              {item.place}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <section className="px-4 py-2 bg-gray-200 flex flex-col justify-start items-start gap-1.5">
+        <div className="self-stretch flex justify-between items-center">
+          <div className="flex justify-start items-center gap-1.5">
+            <Pencil className="size-2.5 shrink-0" aria-hidden />
+            <span className="text-neutral-400 text-xs font-semibold font-['Pretendard'] leading-4">
+              내 메모
+            </span>
+          </div>
+          {hasMemo && (
+            <button
+              type="button"
+              className="text-neutral-400 text-xs font-normal font-['Pretendard'] underline leading-4 shrink-0"
+            >
+              확인
+            </button>
+          )}
+        </div>
+
+        {hasMemo ? (
+          <p className="self-stretch text-neutral-400 text-xs font-normal font-['Pretendard'] leading-4">
+            {item.memo}
+          </p>
+        ) : (
+          <button
+            type="button"
+            className="self-stretch text-left text-stone-300 text-xs font-normal font-['Pretendard'] underline leading-4"
+          >
+            메모 작성하기
+          </button>
+        )}
+      </section>
+    </article>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* 작품 카드 (2열 그리드)                                                */
+/* ------------------------------------------------------------------ */
+
+function ArtworkCard({ item }: { item: ArtworkItem }) {
+  return (
+    <article className="bg-[#FCFCFC] rounded-lg outline-1 -outline-offset-1 outline-[#E5E5E5] flex flex-col overflow-hidden font-['Pretendard']">
+      {/* 카드 안쪽 패딩 6px, 썸네일 176px */}
+      <div className="p-1.5 pb-0">
+        <div className="relative rounded-lg overflow-hidden">
+          <div className="w-full h-44 bg-zinc-100">
+            <img className="w-full h-full object-cover" src={item.thumbnail} alt={item.title} />
+          </div>
+          <button type="button" aria-label="북마크" className="absolute bottom-2 right-2">
+            <img src={BookmarkIcon} alt="" className="size-5" />
+          </button>
+        </div>
+      </div>
+
+      <div className="px-2.5 pt-2 pb-3 flex flex-col gap-1">
+        <div className="text-neutral-900 text-sm font-bold font-['Pretendard'] leading-5 truncate">
+          {item.title}
+        </div>
+        <div className="text-neutral-900 text-xs font-normal font-['Pretendard'] leading-4 truncate">
+          {item.artist}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* 작가 카드                                                           */
+/* ------------------------------------------------------------------ */
+
+function ArtistCard({ item }: { item: ArtistItem }) {
+  return (
+    <article className="w-full bg-[#FCFCFC] rounded-[20px] outline-1 -outline-offset-1 outline-[#D9D9D9] overflow-hidden font-['Pretendard']">
+      <div className="flex items-center gap-3.5 px-3 py-3.5">
+        <div className="size-12 rounded-full bg-[#E5E5E5] overflow-hidden shrink-0">
+          <img className="w-full h-full object-cover" src={item.thumbnail} alt={item.name} />
+        </div>
+
+        <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+          <div className="text-gray-900 text-sm font-bold font-['Pretendard'] leading-5 truncate">
+            {item.name}
+          </div>
+          <div className="text-gray-500 text-xs font-normal font-['Pretendard'] leading-4 truncate">
+            {item.field} · 등록 작품 수 {item.registeration} · (전시 수 {item.exhibition})
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 shrink-0">
+          <button type="button" aria-label="북마크">
+            <img src={BookmarkIcon} alt="" className="size-5" />
+          </button>
+          <svg
+            className="size-4 text-gray-400"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="9 6 15 12 9 18" />
+          </svg>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* 설정 바텀시트                                                         */
+/* ------------------------------------------------------------------ */
+
+interface SettingsMenu {
+  key: string;
+  icon: LucideIcon;
+  iconWrapClass: string;
+  title: string;
+  titleClass: string;
+  description: string;
+  descriptionClass: string;
+}
+
+const SETTINGS_MENUS: SettingsMenu[] = [
+  {
+    key: 'edit',
+    icon: Pencil,
+    iconWrapClass: 'bg-[#f8fafb] border border-[#e9eced]',
+    title: '동호회 정보 수정',
+    titleClass: 'text-[#202020]',
+    description: '이름, 소개, 사진, 카테고리 등',
+    descriptionClass: 'text-[#636970]',
+  },
+  {
+    key: 'member',
+    icon: Users,
+    iconWrapClass: 'bg-[#f8fafb] border border-[#e9eced]',
+    title: '멤버 관리',
+    titleClass: 'text-[#202020]',
+    description: '멤버 목록, 가입 신청, 강제 퇴장',
+    descriptionClass: 'text-[#636970]',
+  },
+  {
+    key: 'delete',
+    icon: Trash2,
+    iconWrapClass: 'bg-[#f03f40]/10',
+    title: '동호회 삭제',
+    titleClass: 'text-[#f03f40]',
+    description: '삭제 후 복구가 불가능해요',
+    descriptionClass: 'text-[#f03f40]/50',
+  },
+];
+
+function SettingsSheet({
+  open,
+  onClose,
+  onSelect,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (key: SettingsMenu['key']) => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-center">
+      <div className="w-full max-w-md relative">
+        {/* 딤 배경 */}
+        <button
+          type="button"
+          aria-label="닫기"
+          onClick={onClose}
+          className="absolute inset-0 bg-black/50"
+        />
+
+        {/* 바텀시트 */}
+        <div className="absolute bottom-0 inset-x-0 bg-white rounded-t-[20px] pb-12 flex flex-col items-center font-['Pretendard']">
+          {/* 핸들 */}
+          <div className="w-full pt-6 pb-3 flex justify-center">
+            <div className="w-11 h-1 rounded-full bg-[#dee3e5]" />
+          </div>
+
+          <ul className="w-full px-5">
+            {SETTINGS_MENUS.map((menu, index) => (
+              <li key={menu.key}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(menu.key)}
+                  className={`w-full h-17 flex items-center gap-3 py-2 ${
+                    index < SETTINGS_MENUS.length - 1 ? 'border-b border-[#e9eced]' : ''
+                  }`}
+                >
+                  <span
+                    className={`shrink-0 flex items-center justify-center p-3 rounded-xl ${menu.iconWrapClass}`}
+                  >
+                    <menu.icon className="size-7" aria-hidden />
+                  </span>
+                  <span className="flex-1 min-w-0 flex flex-col gap-1 items-start text-left">
+                    <span
+                      className={`text-lg font-semibold leading-tight truncate ${menu.titleClass}`}
+                    >
+                      {menu.title}
+                    </span>
+                    <span
+                      className={`text-sm font-medium leading-5 truncate ${menu.descriptionClass}`}
+                    >
+                      {menu.description}
+                    </span>
+                  </span>
+                  <ChevronRight color="#99A1AF" className="size-6 shrink-0" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* 화면 전체 조립                                                        */
+/* ------------------------------------------------------------------ */
+
+export function ArchivePage() {
+  const [activeTab, setActiveTab] = useState<TabKey>('exhibition');
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+
+  const handleSelectSetting = () => {
+    // TODO: 각 메뉴(정보 수정/멤버 관리/삭제) 라우팅·동작 연결
+    setIsSettingsOpen(false);
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto h-dvh bg-white flex flex-col">
+      <ArchiveHeader
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        onOpenSettings={() => setIsSettingsOpen(true)}
+      />
+
+      <main className="flex-1 min-h-0 overflow-y-auto px-4 py-3.5">
+        {activeTab === 'exhibition' && (
+          <div className="flex flex-col gap-3">
+            {EXHIBITIONS.map((item) => (
+              <ExhibitionCard key={item.id} item={item} />
+            ))}
+          </div>
+        )}
+
+        {activeTab === 'artwork' && (
+          <div className="grid grid-cols-2 gap-x-1.5 gap-y-3">
+            {ARTWORKS.map((item) => (
+              <ArtworkCard key={item.id} item={item} />
+            ))}
+          </div>
+        )}
+
+        {activeTab === 'artist' && (
+          <div className="flex flex-col gap-3">
+            {ARTISTS.map((item) => (
+              <ArtistCard key={item.id} item={item} />
+            ))}
+          </div>
+        )}
+      </main>
+
+      <SettingsSheet
+        open={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
+        onSelect={handleSelectSetting}
+      />
+    </div>
+  );
+}

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
+import { useHeaderContext } from '@/components/layout/headerContext';
 import { ArtworkCard, ExhibitionCard, SettingsSheet } from '@/components/mypage';
 import { AuthPageHeader } from '@/components/mypage/AuthPageHeader';
 import { AUTH_PAGE_PROFILE } from '@/mocks/authPage';
@@ -12,6 +13,14 @@ export function AuthPage() {
   const [activeTab, setActiveTab] = useState<TabKey>('exhibition');
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const navigate = useNavigate();
+
+  const { setHeader, resetHeader } = useHeaderContext();
+
+  useEffect(() => {
+    setHeader({ title: '' });
+    return () => resetHeader();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSelectSetting = () => {
     setIsSettingsOpen(false);

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
+import { useHeaderContext } from '@/components/layout/headerContext';
 import {
   ArtistCard,
   ArtworkCard,
@@ -22,7 +23,14 @@ export function MyPage() {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isArtistView, setIsArtistView] = useState(true);
 
+  const { setHeader, resetHeader } = useHeaderContext();
   const { data: userData, isLoading, error } = useUserProfile();
+
+  useEffect(() => {
+    setHeader({ title: '' });
+    return () => resetHeader();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSelectSetting = () => {
     setIsSettingsOpen(false);


### PR DESCRIPTION
## 📝 작업 내용

- 어떤 기능을 개발/수정했는지 요약해주세요.

FNB와 냅바의 반응형 디자인제거
FNB 디자인 수정

## 🔍 관련 이슈

- close #113

## 🖼️ 스크린샷

- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.
<img width="294" height="544" alt="스크린샷 2026-07-24 오후 6 39 27" src="https://github.com/user-attachments/assets/5c8ece43-b865-4336-a3c6-304f6ff78559" />

## 🧪 테스트 결과

- [x] 정상 작동 확인

## 💬 기타 참고 사항

- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 전시·작품·작가를 탭으로 확인할 수 있는 아카이브 페이지를 추가했습니다.
  - 아카이브 설정 메뉴와 전시 메모 확인·작성 UI를 제공합니다.
  - 페이지별 제목과 좌우 영역을 지원하는 공통 헤더를 추가했습니다.

- **개선**
  - 하단 및 상단 내비게이션의 레이아웃과 활성 상태 표시를 개선했습니다.
  - 홈 배너의 로고 표시를 새 디자인으로 변경했습니다.
  - 마이페이지와 인증 페이지에서 헤더 상태가 자연스럽게 전환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->