### PR TITLE
feat: 임시 온보딩 페이지(백엔드 요청으로 머지)

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, Navigate } from 'react-router-dom';
 
 import { Layout } from './components/layout';
 import { AuthPage } from './pages/AuthPage';
@@ -11,6 +11,7 @@ import { LoungePage } from './pages/LoungePage';
 import { MyActivityPage } from './pages/MyActivityPage';
 import { MyPage } from './pages/MyPage';
 import { NotFound } from './pages/NotFound';
+import { OnboardingPage } from './pages/OnboardingPage';
 import { SearchPage } from './pages/SearchPage';
 
 export const router = createBrowserRouter([
@@ -18,7 +19,8 @@ export const router = createBrowserRouter([
     path: '/',
     element: <Layout />,
     children: [
-      { index: true, element: <Homepage /> },
+      { index: true, element: <Navigate to="/onboarding" replace /> },
+      { path: 'home', element: <Homepage /> },
       { path: 'search', element: <SearchPage /> },
       { path: 'my', element: <MyPage /> },
       { path: 'auth', element: <AuthPage /> },
@@ -31,6 +33,11 @@ export const router = createBrowserRouter([
       // 새 페이지 여기에 추가
       // { path: 'about', element: <About /> },
     ],
+  },
+
+  {
+    path: '/onboarding',
+    element: <OnboardingPage />,
   },
 
   {

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -22,7 +22,7 @@ export class ApiError extends Error {
 const getAccessToken = () => localStorage.getItem('accessToken');
 
 export const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL ?? '',
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 10000,
   withCredentials: true,
 });

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -22,8 +22,9 @@ export class ApiError extends Error {
 const getAccessToken = () => localStorage.getItem('accessToken');
 
 export const axiosInstance = axios.create({
-  baseURL: '',
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? '',
   timeout: 10000,
+  withCredentials: true,
 });
 
 axiosInstance.interceptors.request.use((config) => {

--- a/src/api/dto/auth.dto.ts
+++ b/src/api/dto/auth.dto.ts
@@ -16,6 +16,10 @@ export interface LoginRequestDto {
   idToken: string;
 }
 
+export interface OAuthAuthorizationUrlResponseDto {
+  authorizationUrl: string;
+}
+
 //기존 사용자 응답
 export interface ExistingUserLoginResponseDataDto {
   isNewUser: false;
@@ -50,14 +54,10 @@ export interface SignupRequestDto {
 export interface SignupResponseDataDto {
   user: AuthUserDto;
   accessToken: string;
-  refreshToken: string;
+  refreshToken?: string;
 }
 
 export type SignupResponseDto = ApiResponseDto<SignupResponseDataDto>;
-
-export interface RefreshTokenRequestDto {
-  refreshToken: string;
-}
 
 export interface RefreshTokenResponseDataDto {
   accessToken: string;
@@ -66,7 +66,7 @@ export interface RefreshTokenResponseDataDto {
 export type RefreshTokenResponseDto = ApiResponseDto<RefreshTokenResponseDataDto>;
 
 export interface LogoutRequestDto {
-  refreshToken: string;
+  refreshToken?: string;
 }
 
 export type LogoutResponseDto = ApiResponseDto<null>;

--- a/src/api/endpoints/auth.ts
+++ b/src/api/endpoints/auth.ts
@@ -2,7 +2,7 @@ import type {
   LoginRequestDto,
   LoginResponseDataDto,
   LogoutRequestDto,
-  RefreshTokenRequestDto,
+  OAuthAuthorizationUrlResponseDto,
   RefreshTokenResponseDataDto,
   SignupRequestDto,
   SignupResponseDataDto,
@@ -14,14 +14,24 @@ import { apiRequest } from '../client';
 export const login = async (body: LoginRequestDto): Promise<LoginResponseDataDto> =>
   apiRequest('/v1/auth/login', { method: 'POST', body });
 
+// GET /auth/kakao/login-url
+export const getKakaoAuthorizationUrl = async (): Promise<OAuthAuthorizationUrlResponseDto> =>
+  apiRequest('/auth/kakao/login-url');
+
+// GET /auth/google/login-url
+export const getGoogleAuthorizationUrl = async (): Promise<OAuthAuthorizationUrlResponseDto> =>
+  apiRequest('/auth/google/login-url');
+
 // POST /v1/auth/signup
 export const signup = async (body: SignupRequestDto): Promise<SignupResponseDataDto> =>
-  apiRequest('/v1/auth/signup', { method: 'POST', body });
+  apiRequest('/v1/auth/signup', {
+    method: 'POST',
+    body,
+  });
 
 // POST /v1/auth/refresh
-export const refreshToken = async (
-  body: RefreshTokenRequestDto,
-): Promise<RefreshTokenResponseDataDto> => apiRequest('/v1/auth/refresh', { method: 'POST', body });
+export const refreshToken = async (): Promise<RefreshTokenResponseDataDto> =>
+  apiRequest('/v1/auth/refresh', { method: 'POST' });
 
 // POST /v1/auth/logout
 export const logout = async (body: LogoutRequestDto): Promise<null> =>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -17,7 +17,7 @@ const NAV_ITEMS = [
     icon: homeIcon,
     id: 'home',
     label: '홈',
-    path: '/',
+    path: '/home',
   },
   {
     activeIcon: searchIconActive,
@@ -73,7 +73,7 @@ export function Navbar() {
           return (
             <NavLink
               key={id}
-              end={path === '/'}
+              end={path === '/home'}
               className="flex flex-col items-center justify-center w-16 sm:w-20 lg:w-24 h-[52px] sm:h-[60px] lg:h-[64px] cursor-pointer rounded-[24px] border-0 bg-transparent outline-none transition-transform duration-150 hover:scale-105 active:scale-95 focus-visible:ring-2 focus-visible:ring-[#fcfcfc] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
               to={path}
             >

--- a/src/hooks/queries/useAuth.ts
+++ b/src/hooks/queries/useAuth.ts
@@ -1,7 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { LoginRequestDto, LogoutRequestDto, SignupRequestDto } from '@/api/dto';
-import { login, logout, signup } from '@/api/endpoints';
+import {
+  getGoogleAuthorizationUrl,
+  getKakaoAuthorizationUrl,
+  login,
+  logout,
+  refreshToken,
+  signup,
+} from '@/api/endpoints';
 import { queryKeys } from '@/api/queryKeys';
 
 export const useLogin = () => {
@@ -25,6 +32,21 @@ export const useSignup = () => {
     },
   });
 };
+
+export const useRefreshToken = () =>
+  useMutation({
+    mutationFn: () => refreshToken(),
+  });
+
+export const useKakaoAuthorizationUrl = () =>
+  useMutation({
+    mutationFn: () => getKakaoAuthorizationUrl(),
+  });
+
+export const useGoogleAuthorizationUrl = () =>
+  useMutation({
+    mutationFn: () => getGoogleAuthorizationUrl(),
+  });
 
 export const useLogout = () => {
   const queryClient = useQueryClient();

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { ArtworkPreviewMoreView } from '@/components/homepage/ArtworkPreviewMoreView';
 import { ArtworkPreviewSection } from '@/components/homepage/ArtworkPreviewSection';
 import { DuPickBanner } from '@/components/homepage/DuPickBanner';
 import { ExhibitionSection } from '@/components/homepage/ExhibitionSection';
 import { LoungeSection } from '@/components/homepage/LoungeSection';
+import { useRefreshToken } from '@/hooks/queries/useAuth';
 import {
   useClosingSoonDisplays,
   useDuPicks,
@@ -15,6 +16,8 @@ import {
 
 export const Homepage = () => {
   const [isArtworkPreviewOpen, setIsArtworkPreviewOpen] = useState(false);
+  const hasTriedRefresh = useRef(false);
+  const { mutateAsync: refreshAccessToken } = useRefreshToken();
   const { data: duPicksData } = useDuPicks();
   const { data: graduationExhibitions = [] } = useGraduationDisplays();
   const { data: closingSoonData } = useClosingSoonDisplays({ size: 3 });
@@ -22,6 +25,22 @@ export const Homepage = () => {
   const { data: loungePostsData } = useHomeLoungePosts();
   const closingSoonExhibitions = closingSoonData?.exhibitions ?? [];
   const artworkPreviewItems = artworkPreviewData?.artworks ?? [];
+
+  useEffect(() => {
+    if (hasTriedRefresh.current) {
+      return;
+    }
+
+    hasTriedRefresh.current = true;
+
+    refreshAccessToken()
+      .then(({ accessToken }) => {
+        localStorage.setItem('accessToken', accessToken);
+      })
+      .catch(() => {
+        localStorage.removeItem('accessToken');
+      });
+  }, [refreshAccessToken]);
 
   if (isArtworkPreviewOpen) {
     return <ArtworkPreviewMoreView items={artworkPreviewItems} />;

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,0 +1,527 @@
+import { useState } from 'react';
+
+import { Check, ChevronRight, Info, X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+import { useCheckNickname } from '@/hooks/queries/useUserProfile';
+
+type Screen = 'login' | 'terms' | 'nickname' | 'complete';
+type NicknameCheckStatus = 'idle' | 'available' | 'unavailable' | 'error';
+
+type TermsState = {
+  all: boolean;
+  service: boolean;
+  privacy: boolean;
+  marketing: boolean;
+};
+
+function ArrowLeft() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+      <path
+        d="M12.5 15.8333L6.66667 10L12.5 4.16667"
+        stroke="#3D3D3D"
+        strokeWidth="1.66667"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M15.8333 10H4.16667"
+        stroke="#3D3D3D"
+        strokeWidth="1.66667"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function AppBar({ title, onBack }: { title: string; onBack?: () => void }) {
+  return (
+    <div className="relative flex h-14 w-full shrink-0 items-center border-b border-[#e8eaed] px-5">
+      {onBack ? (
+        <button type="button" onClick={onBack} className="absolute left-[14px] -ml-1.5 p-1.5">
+          <ArrowLeft />
+        </button>
+      ) : null}
+      <span className="absolute left-1/2 -translate-x-1/2 text-[16px] font-semibold leading-6 tracking-[-0.32px] text-[#0d0d0d]">
+        {title}
+      </span>
+    </div>
+  );
+}
+
+function PrimaryButton({
+  label,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="flex h-[54px] w-full items-center justify-center rounded-xl text-[15px] font-semibold tracking-[-0.15px] text-white transition-opacity disabled:cursor-not-allowed"
+      style={{ background: disabled ? '#d1d5db' : '#0d0d0d' }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function KakaoIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M10 3C6.134 3 3 5.463 3 8.5c0 1.951 1.268 3.667 3.178 4.685l-.81 3.01c-.072.267.235.48.467.322L9.59 14.18c.134.01.27.02.41.02 3.866 0 7-2.463 7-5.5S13.866 3 10 3z"
+        fill="#191600"
+      />
+    </svg>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+      <path
+        d="M19.6 10.23c0-.68-.06-1.36-.17-2H10v3.79h5.38a4.6 4.6 0 01-2 3.02v2.5h3.23c1.9-1.75 3-4.33 3-7.31z"
+        fill="#4285F4"
+      />
+      <path
+        d="M10 20c2.7 0 4.96-.9 6.61-2.43l-3.23-2.5c-.9.6-2.05.96-3.38.96-2.6 0-4.8-1.75-5.58-4.11H1.1v2.58A10 10 0 0010 20z"
+        fill="#34A853"
+      />
+      <path
+        d="M4.42 11.92A6.01 6.01 0 014.1 10c0-.67.12-1.32.32-1.92V5.5H1.1A10 10 0 000 10c0 1.6.38 3.12 1.1 4.5l3.32-2.58z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M10 3.96c1.47 0 2.79.5 3.83 1.49l2.86-2.86C14.96.9 12.7 0 10 0A10 10 0 001.1 5.5l3.32 2.58C5.2 5.71 7.4 3.96 10 3.96z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}
+
+function LoginScreen({ onNext, onGuest }: { onNext: () => void; onGuest: () => void }) {
+  return (
+    <div className="flex h-full flex-col bg-white">
+      <div className="h-14 shrink-0 border-b border-[#e8eaed]" />
+
+      <div className="flex flex-1 flex-col overflow-auto px-6">
+        <div className="flex items-end justify-center pb-12 pt-14">
+          <span className="text-[26px] font-extrabold leading-[39px] tracking-[-1.04px] text-[#0d0d0d]">
+            display
+          </span>
+          <div className="relative">
+            <span className="text-[26px] font-extrabold leading-[39px] tracking-[-1.04px] text-[#0d0d0d]">
+              U
+            </span>
+            <div className="absolute bottom-0 left-0 right-0 border-b-[3px] border-[#0d0d0d]" />
+          </div>
+        </div>
+
+        <div className="h-[42px]" />
+
+        <div className="mb-7 flex flex-col gap-2.5">
+          <button
+            type="button"
+            onClick={onNext}
+            className="flex h-[54px] w-full items-center justify-center gap-[9px] rounded-xl bg-[#fee500]"
+          >
+            <KakaoIcon />
+            <span className="text-[15px] font-bold tracking-[-0.15px] text-[#191600]">
+              카카오로 시작하기
+            </span>
+          </button>
+
+          <button
+            type="button"
+            onClick={onNext}
+            className="flex h-[54px] w-full items-center justify-center gap-[9px] rounded-xl border-[1.5px] border-[#d1d5db] bg-white"
+          >
+            <GoogleIcon />
+            <span className="text-[15px] font-medium tracking-[-0.15px] text-[#3d3d3d]">
+              Google로 시작하기
+            </span>
+          </button>
+        </div>
+
+        <div className="flex items-center gap-2.5 rounded-xl bg-[#f2f3f5] px-4 py-[14px]">
+          <div className="mt-px shrink-0">
+            <div className="h-1 w-1 rounded-sm bg-[#a0a5af]" />
+          </div>
+          <p className="text-[12px] font-normal text-[#6b7280]">
+            비회원은 전시와 작품 감상까지 이용할 수 있어요.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={onGuest}
+          className="mt-0 flex h-11 items-center justify-center"
+        >
+          <span className="text-[14px] font-medium tracking-[-0.14px] text-[#6b7280]">
+            비회원으로 감상하기
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RoundCheckbox({ checked, onChange }: { checked: boolean; onChange: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onChange}
+      className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full transition-colors"
+      style={{
+        background: checked ? '#0d0d0d' : 'transparent',
+        border: checked ? 'none' : '1.5px solid #d1d5db',
+      }}
+    >
+      {checked ? (
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+          <path
+            d="M2 6L5 9L10 3"
+            stroke="white"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : null}
+    </button>
+  );
+}
+
+function Badge({ type }: { type: '필수' | '선택' }) {
+  const required = type === '필수';
+
+  return (
+    <div
+      className="flex h-[21px] items-center rounded px-[7px]"
+      style={{
+        background: required ? '#efefef' : '#f5f5f5',
+        border: required ? '1px solid #d0d0d0' : '1px solid #e8eaed',
+      }}
+    >
+      <span
+        className="text-[10px] font-bold tracking-[0.3px]"
+        style={{ color: required ? '#0d0d0d' : '#a0a5af' }}
+      >
+        {type}
+      </span>
+    </div>
+  );
+}
+
+function TermsScreen({ onBack, onNext }: { onBack: () => void; onNext: () => void }) {
+  const [terms, setTerms] = useState<TermsState>({
+    all: false,
+    service: false,
+    privacy: false,
+    marketing: false,
+  });
+
+  const toggle = (key: keyof TermsState) => {
+    if (key === 'all') {
+      const next = !terms.all;
+      setTerms({ all: next, service: next, privacy: next, marketing: next });
+      return;
+    }
+
+    const next = { ...terms, [key]: !terms[key] };
+    next.all = next.service && next.privacy && next.marketing;
+    setTerms(next);
+  };
+
+  const canProceed = terms.service && terms.privacy;
+
+  return (
+    <div className="flex h-full flex-col bg-white">
+      <AppBar title="약관 동의" onBack={onBack} />
+
+      <div className="flex flex-1 flex-col overflow-auto px-6 py-8">
+        <div className="mb-8">
+          <div className="text-[22px] font-bold leading-[29.7px] tracking-[-0.66px] text-[#0d0d0d]">
+            <p>서비스 이용을 위해</p>
+            <p>동의가 필요해요</p>
+          </div>
+          <p className="mt-2.5 text-[13px] font-normal leading-[21.45px] text-[#6b7280]">
+            필수 약관에 동의한 뒤 다음 단계로 진행할 수 있어요.
+          </p>
+        </div>
+
+        <div className="mb-3.5 overflow-hidden rounded-2xl border border-[#e8eaed]">
+          <button
+            type="button"
+            onClick={() => toggle('all')}
+            className="flex w-full items-center gap-3 border-b border-[#e8eaed] bg-[#f2f3f5] px-[18px] py-4 text-left"
+          >
+            <RoundCheckbox checked={terms.all} onChange={() => toggle('all')} />
+            <div>
+              <p className="text-[15px] font-bold leading-[22.5px] text-[#0d0d0d]">전체 동의</p>
+              <p className="text-[12px] font-normal leading-[18px] text-[#6b7280]">
+                아래 약관에 모두 동의합니다.
+              </p>
+            </div>
+          </button>
+
+          {[
+            ['service', '필수', '서비스 이용약관 동의'],
+            ['privacy', '필수', '개인정보 처리방침 동의'],
+            ['marketing', '선택', '마케팅 정보 수신 동의'],
+          ].map(([key, type, label], index) => (
+            <div key={key} className={index < 2 ? 'border-b border-[#e8eaed]' : ''}>
+              <div className="flex items-center gap-3 px-[18px] py-[14px]">
+                <RoundCheckbox
+                  checked={terms[key as keyof TermsState]}
+                  onChange={() => toggle(key as keyof TermsState)}
+                />
+                <Badge type={type as '필수' | '선택'} />
+                <span className="min-w-0 flex-1 text-[13px] font-normal leading-[19.5px] text-[#3d3d3d]">
+                  {label}
+                </span>
+                <ChevronRight size={16} color="#A0A5AF" strokeWidth={1.5} />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex-1" />
+
+        <PrimaryButton label="동의하고 계속하기" onClick={onNext} disabled={!canProceed} />
+      </div>
+    </div>
+  );
+}
+
+function NicknameScreen({ onBack, onNext }: { onBack: () => void; onNext: () => void }) {
+  const [nickname, setNickname] = useState('displayu디유');
+  const [checkStatus, setCheckStatus] = useState<NicknameCheckStatus>('idle');
+  const maxLen = 15;
+  const { refetch: checkNickname, isFetching: isCheckingNickname } = useCheckNickname(
+    { nickname },
+    false,
+  );
+
+  const handleChange = (value: string) => {
+    setNickname(value.slice(0, maxLen));
+    setCheckStatus('idle');
+  };
+
+  const handleCheck = async () => {
+    if (nickname.length < 5 || isCheckingNickname) {
+      return;
+    }
+
+    const result = await checkNickname();
+    const isAvailable = result.data?.isAvailable;
+    setCheckStatus(
+      typeof isAvailable === 'boolean' ? (isAvailable ? 'available' : 'unavailable') : 'error',
+    );
+  };
+
+  const isValid = checkStatus === 'available' && nickname.length >= 5;
+
+  return (
+    <div className="flex h-full flex-col bg-white">
+      <AppBar title="닉네임 설정" onBack={onBack} />
+
+      <div className="flex flex-1 flex-col overflow-auto px-6 py-8">
+        <div className="mb-9">
+          <div className="text-[22px] font-bold leading-[29.7px] tracking-[-0.66px] text-[#0d0d0d]">
+            <p>디유에서 사용할</p>
+            <p>닉네임을 정해주세요</p>
+          </div>
+          <p className="mt-2.5 text-[13px] font-normal leading-[21.45px] text-[#6b7280]">
+            방명록, 게시판, 프로필에서 표시되는 이름이에요.
+          </p>
+        </div>
+
+        <p className="mb-2 text-[12px] font-semibold leading-[18px] tracking-[0.36px] text-[#6b7280]">
+          닉네임
+        </p>
+
+        <div className="flex h-[52px] w-full items-center gap-2.5 rounded-xl border-[1.5px] border-[#0d0d0d] bg-white px-[15.5px]">
+          <input
+            className="min-w-0 flex-1 bg-transparent text-[15px] font-normal tracking-[-0.15px] text-[#0d0d0d] outline-none"
+            value={nickname}
+            onChange={(event) => handleChange(event.target.value)}
+          />
+          {nickname ? (
+            <button
+              type="button"
+              onClick={() => {
+                setNickname('');
+                setCheckStatus('idle');
+              }}
+              className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[10px] bg-[#d1d5db]"
+            >
+              <X size={11} color="white" strokeWidth={1.5} />
+            </button>
+          ) : null}
+          <div className="h-[18px] w-px shrink-0 bg-[#e8eaed]" />
+          <button
+            type="button"
+            onClick={handleCheck}
+            disabled={nickname.length < 5 || isCheckingNickname}
+            className="flex h-8 shrink-0 items-center justify-center rounded-lg border-[1.5px] border-[#0d0d0d] bg-white px-3 disabled:opacity-40"
+          >
+            <span className="text-[12px] font-semibold text-[#0d0d0d]">
+              {isCheckingNickname ? '확인 중' : '중복 확인'}
+            </span>
+          </button>
+        </div>
+
+        <div className="mt-2 flex items-center justify-between">
+          {checkStatus === 'available' ? (
+            <div className="flex items-center gap-1">
+              <Check size={14} color="#16a34a" strokeWidth={1.5} />
+              <span className="text-[12px] font-medium text-[#16a34a]">
+                사용 가능한 닉네임이에요.
+              </span>
+            </div>
+          ) : checkStatus === 'unavailable' ? (
+            <span className="text-[12px] font-normal text-[#ef4444]">
+              이미 사용 중인 닉네임이에요.
+            </span>
+          ) : checkStatus === 'error' ? (
+            <span className="text-[12px] font-normal text-[#ef4444]">
+              중복 확인에 실패했어요. 다시 시도해주세요.
+            </span>
+          ) : (
+            <span className="text-[12px] font-normal text-[#a0a5af]">중복 확인을 해주세요.</span>
+          )}
+          <span className="text-[11px] font-normal text-[#a0a5af]">
+            {nickname.length} / {maxLen}
+          </span>
+        </div>
+
+        <div className="mt-5 flex flex-wrap gap-1.5">
+          {['한글 · 영문 · 숫자', '5 ~ 15자', '특수문자 불가', '공백 불가'].map((rule) => (
+            <div
+              key={rule}
+              className="flex h-[26.5px] items-center rounded-full border border-[#e8eaed] bg-[#f2f3f5] px-2.5"
+            >
+              <span className="text-[11px] font-normal text-[#6b7280]">{rule}</span>
+            </div>
+          ))}
+        </div>
+
+        <p className="mt-5 text-center text-[12px] font-normal text-[#a0a5af]">
+          닉네임은 이후 마이페이지에서 변경할 수 있어요.
+        </p>
+
+        <div className="flex-1" />
+
+        <PrimaryButton label="가입 완료하기" onClick={onNext} disabled={!isValid} />
+      </div>
+    </div>
+  );
+}
+
+function CompleteScreen({
+  onContinue,
+  onLogout,
+  onWithdraw,
+}: {
+  onContinue: () => void;
+  onLogout: () => void;
+  onWithdraw: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center bg-white px-6 pb-10 pt-14">
+      <div className="mb-8 flex h-[76px] w-[76px] items-center justify-center rounded-[38px] border border-[#e8eaed] bg-[#f2f3f5]">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#0d0d0d]">
+          <Check size={24} color="white" strokeWidth={2.8} />
+        </div>
+      </div>
+
+      <h2 className="mb-4 text-[24px] font-extrabold leading-[31.2px] tracking-[-0.96px] text-[#0d0d0d]">
+        가입이 완료되었어요
+      </h2>
+
+      <p className="mb-2.5 text-center text-[14px] font-normal leading-[24.5px] tracking-[-0.14px] text-[#6b7280]">
+        이제 댓글, 저장, 기록 기능을
+        <br />
+        이용할 수 있어요.
+      </p>
+
+      <div className="mb-8 mt-0 w-full max-w-[327px]">
+        <div className="h-px w-full bg-[#e8eaed]" />
+      </div>
+
+      <div className="mb-5 flex w-full max-w-[327px] flex-col gap-2.5">
+        <button
+          type="button"
+          onClick={onContinue}
+          className="flex h-[54px] w-full items-center justify-center rounded-xl bg-[#0d0d0d]"
+        >
+          <span className="text-[15px] font-bold tracking-[-0.3px] text-white">
+            이어서 이용하기
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={onLogout}
+          className="flex h-[54px] w-full items-center justify-center rounded-xl border-[1.5px] border-[#d1d5db] bg-white"
+        >
+          <span className="text-[15px] font-medium tracking-[-0.3px] text-[#3a3a3a]">로그아웃</span>
+        </button>
+        <button
+          type="button"
+          onClick={onWithdraw}
+          className="flex h-[54px] w-full items-center justify-center rounded-xl border-[1.5px] border-[#d1d5db] bg-white"
+        >
+          <span className="text-[15px] font-medium tracking-[-0.3px] text-[#3a3a3a]">탈퇴하기</span>
+        </button>
+      </div>
+
+      <div className="flex w-full max-w-[327px] items-start gap-1.5 rounded-lg border border-[#e8eaed] bg-[#fafafa] px-[15px] py-[13px]">
+        <div className="mt-px shrink-0">
+          <Info size={13} color="#A0A5AF" strokeWidth={1.2} />
+        </div>
+        <p className="text-[11px] font-normal leading-[18.15px] tracking-[-0.11px] text-[#a0a5af]">
+          전시 등록과 작품 등록은 대학생 인증 후 이용할 수 있어요.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function OnboardingPage() {
+  const [screen, setScreen] = useState<Screen>('login');
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex min-h-dvh w-full items-center justify-center bg-[#f0f0f0] font-[Pretendard,sans-serif]">
+      <div className="relative h-dvh w-full max-w-[375px] overflow-hidden bg-white">
+        {screen === 'login' ? (
+          <LoginScreen onNext={() => setScreen('terms')} onGuest={() => navigate('/home')} />
+        ) : null}
+        {screen === 'terms' ? (
+          <TermsScreen onBack={() => setScreen('login')} onNext={() => setScreen('nickname')} />
+        ) : null}
+        {screen === 'nickname' ? (
+          <NicknameScreen onBack={() => setScreen('terms')} onNext={() => setScreen('complete')} />
+        ) : null}
+        {screen === 'complete' ? (
+          <CompleteScreen
+            onContinue={() => navigate('/home')}
+            onLogout={() => setScreen('login')}
+            onWithdraw={() => setScreen('login')}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -3,6 +3,11 @@ import { useState } from 'react';
 import { Check, ChevronRight, Info, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
+import {
+  useGoogleAuthorizationUrl,
+  useKakaoAuthorizationUrl,
+  useSignup,
+} from '@/hooks/queries/useAuth';
 import { useCheckNickname } from '@/hooks/queries/useUserProfile';
 
 type Screen = 'login' | 'terms' | 'nickname' | 'complete';
@@ -109,7 +114,17 @@ function GoogleIcon() {
   );
 }
 
-function LoginScreen({ onNext, onGuest }: { onNext: () => void; onGuest: () => void }) {
+function LoginScreen({
+  onGoogle,
+  onGuest,
+  onKakao,
+  disabled,
+}: {
+  onGoogle: () => void;
+  onGuest: () => void;
+  onKakao: () => void;
+  disabled: boolean;
+}) {
   return (
     <div className="flex h-full flex-col bg-white">
       <div className="h-14 shrink-0 border-b border-[#e8eaed]" />
@@ -132,8 +147,9 @@ function LoginScreen({ onNext, onGuest }: { onNext: () => void; onGuest: () => v
         <div className="mb-7 flex flex-col gap-2.5">
           <button
             type="button"
-            onClick={onNext}
-            className="flex h-[54px] w-full items-center justify-center gap-[9px] rounded-xl bg-[#fee500]"
+            onClick={onKakao}
+            disabled={disabled}
+            className="flex h-[54px] w-full items-center justify-center gap-[9px] rounded-xl bg-[#fee500] disabled:opacity-50"
           >
             <KakaoIcon />
             <span className="text-[15px] font-bold tracking-[-0.15px] text-[#191600]">
@@ -143,8 +159,9 @@ function LoginScreen({ onNext, onGuest }: { onNext: () => void; onGuest: () => v
 
           <button
             type="button"
-            onClick={onNext}
-            className="flex h-[54px] w-full items-center justify-center gap-[9px] rounded-xl border-[1.5px] border-[#d1d5db] bg-white"
+            onClick={onGoogle}
+            disabled={disabled}
+            className="flex h-[54px] w-full items-center justify-center gap-[9px] rounded-xl border-[1.5px] border-[#d1d5db] bg-white disabled:opacity-50"
           >
             <GoogleIcon />
             <span className="text-[15px] font-medium tracking-[-0.15px] text-[#3d3d3d]">
@@ -223,7 +240,13 @@ function Badge({ type }: { type: '필수' | '선택' }) {
   );
 }
 
-function TermsScreen({ onBack, onNext }: { onBack: () => void; onNext: () => void }) {
+function TermsScreen({
+  onBack,
+  onNext,
+}: {
+  onBack: () => void;
+  onNext: (terms: TermsState) => void;
+}) {
   const [terms, setTerms] = useState<TermsState>({
     all: false,
     service: false,
@@ -298,13 +321,25 @@ function TermsScreen({ onBack, onNext }: { onBack: () => void; onNext: () => voi
 
         <div className="flex-1" />
 
-        <PrimaryButton label="동의하고 계속하기" onClick={onNext} disabled={!canProceed} />
+        <PrimaryButton
+          label="동의하고 계속하기"
+          onClick={() => onNext(terms)}
+          disabled={!canProceed}
+        />
       </div>
     </div>
   );
 }
 
-function NicknameScreen({ onBack, onNext }: { onBack: () => void; onNext: () => void }) {
+function NicknameScreen({
+  onBack,
+  onNext,
+  isSubmitting,
+}: {
+  onBack: () => void;
+  onNext: (nickname: string) => void;
+  isSubmitting: boolean;
+}) {
   const [nickname, setNickname] = useState('displayu디유');
   const [checkStatus, setCheckStatus] = useState<NicknameCheckStatus>('idle');
   const maxLen = 15;
@@ -323,11 +358,15 @@ function NicknameScreen({ onBack, onNext }: { onBack: () => void; onNext: () => 
       return;
     }
 
-    const result = await checkNickname();
-    const isAvailable = result.data?.isAvailable;
-    setCheckStatus(
-      typeof isAvailable === 'boolean' ? (isAvailable ? 'available' : 'unavailable') : 'error',
-    );
+    try {
+      const result = await checkNickname();
+      const isAvailable = result.data?.isAvailable;
+      setCheckStatus(
+        typeof isAvailable === 'boolean' ? (isAvailable ? 'available' : 'unavailable') : 'error',
+      );
+    } catch {
+      setCheckStatus('error');
+    }
   };
 
   const isValid = checkStatus === 'available' && nickname.length >= 5;
@@ -423,7 +462,11 @@ function NicknameScreen({ onBack, onNext }: { onBack: () => void; onNext: () => 
 
         <div className="flex-1" />
 
-        <PrimaryButton label="가입 완료하기" onClick={onNext} disabled={!isValid} />
+        <PrimaryButton
+          label={isSubmitting ? '가입 중' : '가입 완료하기'}
+          onClick={() => onNext(nickname)}
+          disabled={!isValid || isSubmitting}
+        />
       </div>
     </div>
   );
@@ -500,19 +543,86 @@ function CompleteScreen({
 
 export function OnboardingPage() {
   const [screen, setScreen] = useState<Screen>('login');
+  const [authError, setAuthError] = useState('');
+  const [agreedTerms, setAgreedTerms] = useState<TermsState>({
+    all: false,
+    service: true,
+    privacy: true,
+    marketing: false,
+  });
   const navigate = useNavigate();
+  const kakaoAuthorizationUrlMutation = useKakaoAuthorizationUrl();
+  const googleAuthorizationUrlMutation = useGoogleAuthorizationUrl();
+  const signupMutation = useSignup();
+
+  const startOAuthLogin = async (provider: 'kakao' | 'google') => {
+    setAuthError('');
+
+    try {
+      const { authorizationUrl } =
+        provider === 'kakao'
+          ? await kakaoAuthorizationUrlMutation.mutateAsync()
+          : await googleAuthorizationUrlMutation.mutateAsync();
+
+      window.location.href = authorizationUrl;
+    } catch {
+      setAuthError('로그인 연결에 실패했어요. 잠시 후 다시 시도해주세요.');
+    }
+  };
+
+  const completeSignup = async (nickname: string) => {
+    setAuthError('');
+
+    try {
+      const result = await signupMutation.mutateAsync({
+        nickname,
+        agreements: [
+          { agreeId: 1, isAgreed: true },
+          { agreeId: 2, isAgreed: true },
+          { agreeId: 3, isAgreed: agreedTerms.marketing },
+        ],
+      });
+
+      localStorage.setItem('accessToken', result.accessToken);
+      setScreen('complete');
+    } catch {
+      setAuthError('가입 완료에 실패했어요. 다시 시도해주세요.');
+    }
+  };
+
+  const isStartingOAuth =
+    kakaoAuthorizationUrlMutation.isPending || googleAuthorizationUrlMutation.isPending;
 
   return (
     <div className="flex min-h-dvh w-full items-center justify-center bg-[#f0f0f0] font-[Pretendard,sans-serif]">
       <div className="relative h-dvh w-full max-w-[375px] overflow-hidden bg-white">
         {screen === 'login' ? (
-          <LoginScreen onNext={() => setScreen('terms')} onGuest={() => navigate('/home')} />
+          <LoginScreen
+            onKakao={() => {
+              void startOAuthLogin('kakao');
+            }}
+            onGoogle={() => {
+              void startOAuthLogin('google');
+            }}
+            onGuest={() => navigate('/home')}
+            disabled={isStartingOAuth}
+          />
         ) : null}
         {screen === 'terms' ? (
-          <TermsScreen onBack={() => setScreen('login')} onNext={() => setScreen('nickname')} />
+          <TermsScreen
+            onBack={() => setScreen('login')}
+            onNext={(terms) => {
+              setAgreedTerms(terms);
+              setScreen('nickname');
+            }}
+          />
         ) : null}
         {screen === 'nickname' ? (
-          <NicknameScreen onBack={() => setScreen('terms')} onNext={() => setScreen('complete')} />
+          <NicknameScreen
+            onBack={() => setScreen('terms')}
+            onNext={completeSignup}
+            isSubmitting={signupMutation.isPending}
+          />
         ) : null}
         {screen === 'complete' ? (
           <CompleteScreen
@@ -520,6 +630,11 @@ export function OnboardingPage() {
             onLogout={() => setScreen('login')}
             onWithdraw={() => setScreen('login')}
           />
+        ) : null}
+        {authError ? (
+          <div className="absolute bottom-5 left-6 right-6 rounded-lg bg-[#fee2e2] px-4 py-3 text-center text-[12px] font-medium text-[#b91c1c]">
+            {authError}
+          </div>
         ) : null}
       </div>
     </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
   },
   server: {
     proxy: {
+      '/auth': {
+        target: 'https://api.displayu.co.kr',
+        changeOrigin: true,
+        rewrite: (path) => `/api${path}`,
+      },
       '/v1': {
         target: 'https://api.displayu.co.kr',
         changeOrigin: true,


### PR DESCRIPTION
## 📝 작업 내용

- 어떤 기능을 개발/수정했는지 요약해주세요.

임시 온보딩 페이지 + 로그인 api 연동했습니다!
로그인 테스트를 실패해서 백엔드에서 급하게 머지해달라고 요청했습니다!!
머지하고 바로 revert 해서 다시 작업 들어갈게요!

## 🔍 관련 이슈

- close #104

## 🖼️ 스크린샷

- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.

<img width="1386" height="1059" alt="스크린샷 2026-07-25 오후 10 27 49" src="https://github.com/user-attachments/assets/6eab02c0-ac14-4c0a-94ab-7d0b3d98fa38" />


## 🧪 테스트 결과

- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 카카오·구글 소셜 로그인과 신규 온보딩 흐름을 추가했습니다.
  * 약관 동의, 닉네임 중복 확인, 회원가입 완료 화면을 제공합니다.
  * 기본 접속 시 온보딩 화면으로 이동합니다.
  * 비회원은 홈 화면으로 바로 진입할 수 있습니다.

* **개선 사항**
  * 로그인 상태 유지를 위한 토큰 갱신을 지원합니다.
  * 인증 요청 및 외부 API 연동 처리를 개선했습니다.
  * 홈 메뉴 경로를 `/home`으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->