### PR TITLE
feat: 지도 api 연동 완료

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "globals": "^17.7.0",
     "husky": "^9",
+    "kakao.maps.d.ts": "^0.1.40",
     "lint-staged": "^16.4.0",
     "msw": "^2.15.0",
     "prettier": "^3.8.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "pretendard": "^1.3.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-kakao-maps-sdk": "^1.2.1",
     "react-router-dom": "^7.18.1",
     "tailwind-merge": "^3.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-kakao-maps-sdk:
+        specifier: ^1.2.1
+        version: 1.2.1(kakao.maps.d.ts@0.1.40)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
         specifier: ^7.18.1
         version: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -96,6 +99,9 @@ importers:
       husky:
         specifier: ^9
         version: 9.1.7
+      kakao.maps.d.ts:
+        specifier: ^0.1.40
+        version: 0.1.40
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
@@ -174,6 +180,10 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -1869,6 +1879,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  kakao.maps.d.ts@0.1.40:
+    resolution: {integrity: sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2181,6 +2194,13 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-kakao-maps-sdk@1.2.1:
+    resolution: {integrity: sha512-qvdt+82D/MxTxmgF9tXaqa6eNqMUiFOeEdn+PyU0u9EHoxeD9WMJeHkum/GWrbP62MR0qWPtZ/G4iM9f2/1TPQ==}
+    peerDependencies:
+      kakao.maps.d.ts: ^0.1.40
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-router-dom@7.18.1:
     resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
@@ -2500,6 +2520,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2675,6 +2700,8 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
     dependencies:
@@ -4398,6 +4425,8 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  kakao.maps.d.ts@0.1.40: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -4702,6 +4731,14 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@16.13.1: {}
+
+  react-kakao-maps-sdk@1.2.1(kakao.maps.d.ts@0.1.40)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      kakao.maps.d.ts: 0.1.40
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
 
   react-router-dom@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -5104,6 +5141,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0):
     dependencies:

--- a/src/api/queryKeys.ts
+++ b/src/api/queryKeys.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/api/dto/display.dto';
 import type { GetArtworkPreviewRequestDto } from '@/api/dto/displayArtwork.dto';
 import type { GetLoungePostsRequestDto } from '@/api/dto/lounge.dto';
+import type { NearbyParams } from '@/hooks/useNearbyDisplays';
 
 type ListParams = Record<string, unknown>;
 
@@ -36,6 +37,8 @@ export const queryKeys = {
       [...queryKeys.displays.lists(), 'search', params] as const,
     map: (params: GetDisplayMapRequestDto) =>
       [...queryKeys.displays.lists(), 'map', params] as const,
+    nearby: (params: NearbyParams | null) =>
+      [...queryKeys.displays.lists(), 'nearby', params] as const,
     closingSoon: (params?: GetClosingSoonDisplaysRequestDto) =>
       [...queryKeys.displays.lists(), 'closing-soon', params ?? {}] as const,
     graduation: (params?: { size?: number }) =>

--- a/src/components/search/ExhibitionCard.tsx
+++ b/src/components/search/ExhibitionCard.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 import type { Exhibition } from './types';
 
 type ExhibitionCardProps = {
@@ -23,7 +25,10 @@ const formatDateRange = (startedAt: string, endedAt: string) => {
 
 export function ExhibitionCard({ exhibition }: ExhibitionCardProps) {
   return (
-    <div className="flex flex-col overflow-hidden rounded-[10px] bg-neutral-50">
+    <Link
+      to={`/display/${exhibition.displayId}`}
+      className="flex flex-col overflow-hidden rounded-[10px] bg-neutral-50 no-underline"
+    >
       <div className="flex flex-col items-start gap-2.5 px-2 py-3 shadow-[0px_4px_18px_0px_rgba(67,0,209,0.04)]">
         <img
           alt=""
@@ -43,6 +48,6 @@ export function ExhibitionCard({ exhibition }: ExhibitionCardProps) {
           </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/src/components/search/ExhibitionMap.tsx
+++ b/src/components/search/ExhibitionMap.tsx
@@ -30,13 +30,6 @@ export function ExhibitionMap({
 }: ExhibitionMapProps) {
   const appkey = import.meta.env.VITE_KAKAO_MAP_KEY;
 
-  // 디버깅: 환경변수 확인
-  if (!appkey) {
-    console.error('VITE_KAKAO_MAP_KEY is not defined');
-  } else {
-    console.log('Kakao Map Key loaded:', appkey.substring(0, 8) + '...');
-  }
-
   const [loading, error] = useKakaoLoader({
     appkey,
     libraries: ['services'],
@@ -90,7 +83,6 @@ export function ExhibitionMap({
       }
 
       setIsLocating(false);
-      console.log('위치 추적 종료');
     };
 
     watchIdRef.current = navigator.geolocation.watchPosition(
@@ -99,10 +91,6 @@ export function ExhibitionMap({
 
         const { latitude, longitude, accuracy } = position.coords;
         attemptsRef.current++;
-
-        console.log(
-          `위치 시도 ${attemptsRef.current}: 정확도 ${Math.round(accuracy)}m, 좌표 (${latitude.toFixed(6)}, ${longitude.toFixed(6)})`,
-        );
 
         // 첫 번째 위치는 무조건 사용 (사용자가 바로 피드백을 받도록)
         const shouldUsePosition =
@@ -117,22 +105,15 @@ export function ExhibitionMap({
             const moveLatLon = new kakao.maps.LatLng(latitude, longitude);
             mapRef.current.setCenter(moveLatLon);
             mapRef.current.setLevel(5);
-            console.log('지도 이동 완료');
-          } else {
-            console.error('mapRef.current가 null입니다');
           }
         }
 
         // 종료 조건: 충분히 정확하거나 최대 시도 횟수 도달
         if (accuracy < 100 || attemptsRef.current >= maxAttempts) {
-          console.log(
-            `최종 위치: 정확도 ${Math.round(accuracy)}m (${attemptsRef.current}번 시도)`,
-          );
           stopLocating();
         }
       },
       (error) => {
-        console.error('위치 가져오기 실패:', error);
         let message = '위치를 가져올 수 없습니다.';
 
         switch (error.code) {
@@ -159,7 +140,6 @@ export function ExhibitionMap({
 
     // 타임아웃: 5초 후 무조건 종료
     timeoutIdRef.current = setTimeout(() => {
-      console.log('타임아웃으로 위치 추적 종료');
       stopLocating();
     }, 5000);
   }, []); // 의존성 배열 비움 - ref만 사용하므로 안전

--- a/src/components/search/ExhibitionMap.tsx
+++ b/src/components/search/ExhibitionMap.tsx
@@ -1,13 +1,14 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
+import { useMutation } from '@tanstack/react-query';
 import { LocateFixed } from 'lucide-react';
 import { CustomOverlayMap, Map, useKakaoLoader } from 'react-kakao-maps-sdk';
 
-import {
-  getDistanceMeters,
-  type NearbyDisplay,
-  type NearbyParams,
-} from '../../hooks/useNearbyDisplays';
+import type { NearbyDisplay, NearbyParams } from '@/hooks/useNearbyDisplays';
+import { getDistanceMeters } from '@/utils/geo';
+import { getAccurateUserLocation, getGeolocationErrorMessage } from '@/utils/geolocation';
+
+import { ExhibitionMapMarker } from './ExhibitionMapMarker';
 
 // 서울시청. 실제로는 사용자 위치나 마지막 위치로 대체 가능.
 const DEFAULT_CENTER = { lat: 37.5665, lng: 126.978 };
@@ -37,112 +38,19 @@ export function ExhibitionMap({
 
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const mapRef = useRef<kakao.maps.Map | null>(null);
-  const watchIdRef = useRef<number | null>(null);
-  const timeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const bestAccuracyRef = useRef<number>(Infinity);
-  const attemptsRef = useRef<number>(0);
-  const hasStoppedRef = useRef<boolean>(false);
-  const [isLocating, setIsLocating] = useState(false);
 
-  const handleLocateUser = useCallback(() => {
-    if (!navigator.geolocation) {
-      alert('위치 서비스를 지원하지 않는 브라우저입니다.');
-      return;
-    }
-
-    // 이미 실행 중이면 무시
-    if (watchIdRef.current !== null) {
-      return;
-    }
-
-    // 상태 초기화
-    setIsLocating(true);
-    bestAccuracyRef.current = Infinity;
-    attemptsRef.current = 0;
-    hasStoppedRef.current = false;
-
-    const maxAttempts = 3;
-
-    const stopLocating = () => {
-      // 이미 정리되었으면 중복 실행 방지
-      if (hasStoppedRef.current) {
-        return;
-      }
-      hasStoppedRef.current = true;
-
-      // watchPosition 정리
-      if (watchIdRef.current !== null) {
-        navigator.geolocation.clearWatch(watchIdRef.current);
-        watchIdRef.current = null;
-      }
-
-      // timeout 정리
-      if (timeoutIdRef.current !== null) {
-        clearTimeout(timeoutIdRef.current);
-        timeoutIdRef.current = null;
-      }
-
-      setIsLocating(false);
-    };
-
-    watchIdRef.current = navigator.geolocation.watchPosition(
-      (position) => {
-        if (hasStoppedRef.current) return;
-
-        const { latitude, longitude, accuracy } = position.coords;
-        attemptsRef.current++;
-
-        // 첫 번째 위치는 무조건 사용 (사용자가 바로 피드백을 받도록)
-        const shouldUsePosition =
-          attemptsRef.current === 1 ||
-          accuracy < bestAccuracyRef.current ||
-          accuracy < 100;
-
-        if (shouldUsePosition) {
-          bestAccuracyRef.current = Math.min(bestAccuracyRef.current, accuracy);
-
-          if (mapRef.current) {
-            const moveLatLon = new kakao.maps.LatLng(latitude, longitude);
-            mapRef.current.setCenter(moveLatLon);
-            mapRef.current.setLevel(5);
-          }
-        }
-
-        // 종료 조건: 충분히 정확하거나 최대 시도 횟수 도달
-        if (accuracy < 100 || attemptsRef.current >= maxAttempts) {
-          stopLocating();
-        }
-      },
-      (error) => {
-        let message = '위치를 가져올 수 없습니다.';
-
-        switch (error.code) {
-          case error.PERMISSION_DENIED:
-            message = '위치 권한이 거부되었습니다. 브라우저 설정에서 위치 권한을 허용해주세요.';
-            break;
-          case error.POSITION_UNAVAILABLE:
-            message = '위치 정보를 사용할 수 없습니다.';
-            break;
-          case error.TIMEOUT:
-            message = '위치 요청 시간이 초과되었습니다. WiFi나 GPS가 켜져있는지 확인해주세요.';
-            break;
-        }
-
-        alert(message);
-        stopLocating();
-      },
-      {
-        enableHighAccuracy: true,
-        timeout: 5000,
-        maximumAge: 0,
-      },
-    );
-
-    // 타임아웃: 5초 후 무조건 종료
-    timeoutIdRef.current = setTimeout(() => {
-      stopLocating();
-    }, 5000);
-  }, []); // 의존성 배열 비움 - ref만 사용하므로 안전
+  const { mutate: moveToMyLocation, isPending: isLocating } = useMutation({
+    mutationFn: getAccurateUserLocation,
+    onSuccess: (position) => {
+      if (!mapRef.current) return;
+      const { latitude, longitude } = position.coords;
+      mapRef.current.setCenter(new kakao.maps.LatLng(latitude, longitude));
+      mapRef.current.setLevel(5);
+    },
+    onError: (error) => {
+      alert(getGeolocationErrorMessage(error));
+    },
+  });
 
   const handleIdle = useCallback(
     (map: kakao.maps.Map) => {
@@ -151,12 +59,7 @@ export function ExhibitionMap({
       const ne = bounds.getNorthEast();
       // 화면에 보이는 영역 = 중심에서 북동쪽 모서리까지 거리를 반경으로.
       // 줌 레벨에 따라 반경이 자동으로 커지고 작아진다.
-      const radius = getDistanceMeters(
-        center.getLat(),
-        center.getLng(),
-        ne.getLat(),
-        ne.getLng(),
-      );
+      const radius = getDistanceMeters(center.getLat(), center.getLng(), ne.getLat(), ne.getLng());
 
       clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => {
@@ -173,16 +76,6 @@ export function ExhibitionMap({
   // 컴포넌트 언마운트 시 정리
   useEffect(() => {
     return () => {
-      // watchPosition 정리
-      if (watchIdRef.current !== null) {
-        navigator.geolocation.clearWatch(watchIdRef.current);
-        watchIdRef.current = null;
-      }
-      // timeout 정리
-      if (timeoutIdRef.current !== null) {
-        clearTimeout(timeoutIdRef.current);
-        timeoutIdRef.current = null;
-      }
       // debounce 정리
       if (debounceRef.current) {
         clearTimeout(debounceRef.current);
@@ -191,10 +84,18 @@ export function ExhibitionMap({
   }, []);
 
   if (error) {
-    return <MapFallback>지도를 불러오지 못했습니다</MapFallback>;
+    return (
+      <div className="flex size-full items-center justify-center bg-box100">
+        <p className="typo-body-sm-regular text-faint">지도를 불러오지 못했습니다</p>
+      </div>
+    );
   }
   if (loading) {
-    return <MapFallback>지도를 불러오는 중...</MapFallback>;
+    return (
+      <div className="flex size-full items-center justify-center bg-box100">
+        <p className="typo-body-sm-regular text-faint">지도를 불러오는 중...</p>
+      </div>
+    );
   }
 
   return (
@@ -215,7 +116,7 @@ export function ExhibitionMap({
             yAnchor={1}
             zIndex={ex.displayId === selectedId ? 10 : 1}
           >
-            <MarkerPin
+            <ExhibitionMapMarker
               title={ex.title}
               selected={ex.displayId === selectedId}
               onClick={() => onSelect(ex.displayId)}
@@ -227,88 +128,13 @@ export function ExhibitionMap({
       {/* 현재 위치로 이동 버튼 */}
       <button
         type="button"
-        onClick={handleLocateUser}
+        onClick={() => moveToMyLocation()}
         disabled={isLocating}
         aria-label="내 위치로 이동"
         className="absolute bottom-4 right-4 z-10 flex size-12 items-center justify-center rounded-full bg-white shadow-lg transition-all hover:shadow-xl disabled:opacity-50"
       >
-        <LocateFixed
-          className={`size-6 text-neutral-700 ${isLocating ? 'animate-pulse' : ''}`}
-        />
+        <LocateFixed className={`size-6 text-neutral-700 ${isLocating ? 'animate-pulse' : ''}`} />
       </button>
     </div>
-  );
-}
-
-function MapFallback({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="flex size-full items-center justify-center bg-box100">
-      <p className="typo-body-sm-regular text-faint">{children}</p>
-    </div>
-  );
-}
-
-interface MarkerPinProps {
-  title: string;
-  selected: boolean;
-  onClick: () => void;
-}
-
-/**
- * 지도 위 핀. Figma 기준:
- *  - 선택됨: 어두운 알약 + 흰 글자 + 큰 점
- *  - 기본:  흰 알약 + 위치 아이콘 + 회색 글자 + 작은 점
- * 알약 아래 점이 실제 좌표를 가리키므로 yAnchor=1.
- */
-function MarkerPin({ title, selected, onClick }: MarkerPinProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex -translate-y-1 flex-col items-center focus:outline-none"
-    >
-      {selected ? (
-        <span className="rounded-2xl bg-dark px-2.5 py-1.5 shadow-lg">
-          <span className="typo-body-xxs-semibold whitespace-nowrap text-white">
-            {title}
-          </span>
-        </span>
-      ) : (
-        <span className="flex items-center gap-1 rounded-[10px] bg-card px-2 py-1 shadow-[0px_1px_3px_0px_rgba(0,0,0,0.10)] outline outline-1 -outline-offset-1 outline-line-soft">
-          <PinIcon />
-          <span className="typo-body-xxs-regular whitespace-nowrap text-sub700">
-            {title}
-          </span>
-        </span>
-      )}
-      <span
-        className={
-          selected
-            ? 'mt-[3px] size-2.5 rounded-full bg-dark'
-            : 'mt-[3px] size-2 rounded-full bg-faint'
-        }
-      />
-    </button>
-  );
-}
-
-function PinIcon() {
-  return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden>
-      <path
-        d="M5 1.25c1.5 0 2.5 1.1 2.5 2.4C7.5 5.4 5 8.3 5 8.3S2.5 5.4 2.5 3.65C2.5 2.35 3.5 1.25 5 1.25Z"
-        stroke="currentColor"
-        strokeWidth="0.83"
-        className="text-hint"
-      />
-      <circle
-        cx="5"
-        cy="3.75"
-        r="0.9"
-        stroke="currentColor"
-        strokeWidth="0.83"
-        className="text-hint"
-      />
-    </svg>
   );
 }

--- a/src/components/search/ExhibitionMap.tsx
+++ b/src/components/search/ExhibitionMap.tsx
@@ -1,0 +1,175 @@
+import { useCallback, useRef } from 'react';
+
+import { CustomOverlayMap, Map, useKakaoLoader } from 'react-kakao-maps-sdk';
+
+import {
+  getDistanceMeters,
+  type NearbyDisplay,
+  type NearbyParams,
+} from '../../hooks/useNearbyDisplays';
+
+// 서울시청. 실제로는 사용자 위치나 마지막 위치로 대체 가능.
+const DEFAULT_CENTER = { lat: 37.5665, lng: 126.978 };
+const DEFAULT_LEVEL = 6;
+const IDLE_DEBOUNCE_MS = 250;
+
+interface ExhibitionMapProps {
+  exhibitions: NearbyDisplay[];
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+  /** 지도가 멈출 때마다 중심 좌표 + 반경(m)을 상위로 올려보낸다. */
+  onBoundsChange: (params: NearbyParams) => void;
+}
+
+export function ExhibitionMap({
+  exhibitions,
+  selectedId,
+  onSelect,
+  onBoundsChange,
+}: ExhibitionMapProps) {
+  const appkey = import.meta.env.VITE_KAKAO_MAP_KEY;
+
+  // 디버깅: 환경변수 확인
+  if (!appkey) {
+    console.error('VITE_KAKAO_MAP_KEY is not defined');
+  } else {
+    console.log('Kakao Map Key loaded:', appkey.substring(0, 8) + '...');
+  }
+
+  const [loading, error] = useKakaoLoader({
+    appkey,
+    libraries: ['services'],
+  });
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const handleIdle = useCallback(
+    (map: kakao.maps.Map) => {
+      const center = map.getCenter();
+      const bounds = map.getBounds();
+      const ne = bounds.getNorthEast();
+      // 화면에 보이는 영역 = 중심에서 북동쪽 모서리까지 거리를 반경으로.
+      // 줌 레벨에 따라 반경이 자동으로 커지고 작아진다.
+      const radius = getDistanceMeters(
+        center.getLat(),
+        center.getLng(),
+        ne.getLat(),
+        ne.getLng(),
+      );
+
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        onBoundsChange({
+          lat: center.getLat(),
+          lng: center.getLng(),
+          radius,
+        });
+      }, IDLE_DEBOUNCE_MS);
+    },
+    [onBoundsChange],
+  );
+
+  if (error) {
+    return <MapFallback>지도를 불러오지 못했습니다</MapFallback>;
+  }
+  if (loading) {
+    return <MapFallback>지도를 불러오는 중...</MapFallback>;
+  }
+
+  return (
+    <Map
+      center={DEFAULT_CENTER}
+      level={DEFAULT_LEVEL}
+      style={{ width: '100%', height: '100%' }}
+      onIdle={handleIdle}
+    >
+      {exhibitions.map((ex) => (
+        <CustomOverlayMap
+          key={ex.displayId}
+          position={{ lat: ex.latitude, lng: ex.longitude }}
+          yAnchor={1}
+          zIndex={ex.displayId === selectedId ? 10 : 1}
+        >
+          <MarkerPin
+            title={ex.title}
+            selected={ex.displayId === selectedId}
+            onClick={() => onSelect(ex.displayId)}
+          />
+        </CustomOverlayMap>
+      ))}
+    </Map>
+  );
+}
+
+function MapFallback({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex size-full items-center justify-center bg-box100">
+      <p className="typo-body-sm-regular text-faint">{children}</p>
+    </div>
+  );
+}
+
+interface MarkerPinProps {
+  title: string;
+  selected: boolean;
+  onClick: () => void;
+}
+
+/**
+ * 지도 위 핀. Figma 기준:
+ *  - 선택됨: 어두운 알약 + 흰 글자 + 큰 점
+ *  - 기본:  흰 알약 + 위치 아이콘 + 회색 글자 + 작은 점
+ * 알약 아래 점이 실제 좌표를 가리키므로 yAnchor=1.
+ */
+function MarkerPin({ title, selected, onClick }: MarkerPinProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex -translate-y-1 flex-col items-center focus:outline-none"
+    >
+      {selected ? (
+        <span className="rounded-2xl bg-dark px-2.5 py-1.5 shadow-lg">
+          <span className="typo-body-xxs-semibold whitespace-nowrap text-white">
+            {title}
+          </span>
+        </span>
+      ) : (
+        <span className="flex items-center gap-1 rounded-[10px] bg-card px-2 py-1 shadow-[0px_1px_3px_0px_rgba(0,0,0,0.10)] outline outline-1 -outline-offset-1 outline-line-soft">
+          <PinIcon />
+          <span className="typo-body-xxs-regular whitespace-nowrap text-sub700">
+            {title}
+          </span>
+        </span>
+      )}
+      <span
+        className={
+          selected
+            ? 'mt-[3px] size-2.5 rounded-full bg-dark'
+            : 'mt-[3px] size-2 rounded-full bg-faint'
+        }
+      />
+    </button>
+  );
+}
+
+function PinIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden>
+      <path
+        d="M5 1.25c1.5 0 2.5 1.1 2.5 2.4C7.5 5.4 5 8.3 5 8.3S2.5 5.4 2.5 3.65C2.5 2.35 3.5 1.25 5 1.25Z"
+        stroke="currentColor"
+        strokeWidth="0.83"
+        className="text-hint"
+      />
+      <circle
+        cx="5"
+        cy="3.75"
+        r="0.9"
+        stroke="currentColor"
+        strokeWidth="0.83"
+        className="text-hint"
+      />
+    </svg>
+  );
+}

--- a/src/components/search/ExhibitionMap.tsx
+++ b/src/components/search/ExhibitionMap.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { LocateFixed } from 'lucide-react';
 import { CustomOverlayMap, Map, useKakaoLoader } from 'react-kakao-maps-sdk';
 
 import {
@@ -42,6 +43,126 @@ export function ExhibitionMap({
   });
 
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const mapRef = useRef<kakao.maps.Map | null>(null);
+  const watchIdRef = useRef<number | null>(null);
+  const timeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const bestAccuracyRef = useRef<number>(Infinity);
+  const attemptsRef = useRef<number>(0);
+  const hasStoppedRef = useRef<boolean>(false);
+  const [isLocating, setIsLocating] = useState(false);
+
+  const handleLocateUser = useCallback(() => {
+    if (!navigator.geolocation) {
+      alert('위치 서비스를 지원하지 않는 브라우저입니다.');
+      return;
+    }
+
+    // 이미 실행 중이면 무시
+    if (watchIdRef.current !== null) {
+      return;
+    }
+
+    // 상태 초기화
+    setIsLocating(true);
+    bestAccuracyRef.current = Infinity;
+    attemptsRef.current = 0;
+    hasStoppedRef.current = false;
+
+    const maxAttempts = 3;
+
+    const stopLocating = () => {
+      // 이미 정리되었으면 중복 실행 방지
+      if (hasStoppedRef.current) {
+        return;
+      }
+      hasStoppedRef.current = true;
+
+      // watchPosition 정리
+      if (watchIdRef.current !== null) {
+        navigator.geolocation.clearWatch(watchIdRef.current);
+        watchIdRef.current = null;
+      }
+
+      // timeout 정리
+      if (timeoutIdRef.current !== null) {
+        clearTimeout(timeoutIdRef.current);
+        timeoutIdRef.current = null;
+      }
+
+      setIsLocating(false);
+      console.log('위치 추적 종료');
+    };
+
+    watchIdRef.current = navigator.geolocation.watchPosition(
+      (position) => {
+        if (hasStoppedRef.current) return;
+
+        const { latitude, longitude, accuracy } = position.coords;
+        attemptsRef.current++;
+
+        console.log(
+          `위치 시도 ${attemptsRef.current}: 정확도 ${Math.round(accuracy)}m, 좌표 (${latitude.toFixed(6)}, ${longitude.toFixed(6)})`,
+        );
+
+        // 첫 번째 위치는 무조건 사용 (사용자가 바로 피드백을 받도록)
+        const shouldUsePosition =
+          attemptsRef.current === 1 ||
+          accuracy < bestAccuracyRef.current ||
+          accuracy < 100;
+
+        if (shouldUsePosition) {
+          bestAccuracyRef.current = Math.min(bestAccuracyRef.current, accuracy);
+
+          if (mapRef.current) {
+            const moveLatLon = new kakao.maps.LatLng(latitude, longitude);
+            mapRef.current.setCenter(moveLatLon);
+            mapRef.current.setLevel(5);
+            console.log('지도 이동 완료');
+          } else {
+            console.error('mapRef.current가 null입니다');
+          }
+        }
+
+        // 종료 조건: 충분히 정확하거나 최대 시도 횟수 도달
+        if (accuracy < 100 || attemptsRef.current >= maxAttempts) {
+          console.log(
+            `최종 위치: 정확도 ${Math.round(accuracy)}m (${attemptsRef.current}번 시도)`,
+          );
+          stopLocating();
+        }
+      },
+      (error) => {
+        console.error('위치 가져오기 실패:', error);
+        let message = '위치를 가져올 수 없습니다.';
+
+        switch (error.code) {
+          case error.PERMISSION_DENIED:
+            message = '위치 권한이 거부되었습니다. 브라우저 설정에서 위치 권한을 허용해주세요.';
+            break;
+          case error.POSITION_UNAVAILABLE:
+            message = '위치 정보를 사용할 수 없습니다.';
+            break;
+          case error.TIMEOUT:
+            message = '위치 요청 시간이 초과되었습니다. WiFi나 GPS가 켜져있는지 확인해주세요.';
+            break;
+        }
+
+        alert(message);
+        stopLocating();
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: 5000,
+        maximumAge: 0,
+      },
+    );
+
+    // 타임아웃: 5초 후 무조건 종료
+    timeoutIdRef.current = setTimeout(() => {
+      console.log('타임아웃으로 위치 추적 종료');
+      stopLocating();
+    }, 5000);
+  }, []); // 의존성 배열 비움 - ref만 사용하므로 안전
 
   const handleIdle = useCallback(
     (map: kakao.maps.Map) => {
@@ -69,6 +190,26 @@ export function ExhibitionMap({
     [onBoundsChange],
   );
 
+  // 컴포넌트 언마운트 시 정리
+  useEffect(() => {
+    return () => {
+      // watchPosition 정리
+      if (watchIdRef.current !== null) {
+        navigator.geolocation.clearWatch(watchIdRef.current);
+        watchIdRef.current = null;
+      }
+      // timeout 정리
+      if (timeoutIdRef.current !== null) {
+        clearTimeout(timeoutIdRef.current);
+        timeoutIdRef.current = null;
+      }
+      // debounce 정리
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
   if (error) {
     return <MapFallback>지도를 불러오지 못했습니다</MapFallback>;
   }
@@ -77,27 +218,45 @@ export function ExhibitionMap({
   }
 
   return (
-    <Map
-      center={DEFAULT_CENTER}
-      level={DEFAULT_LEVEL}
-      style={{ width: '100%', height: '100%' }}
-      onIdle={handleIdle}
-    >
-      {exhibitions.map((ex) => (
-        <CustomOverlayMap
-          key={ex.displayId}
-          position={{ lat: ex.latitude, lng: ex.longitude }}
-          yAnchor={1}
-          zIndex={ex.displayId === selectedId ? 10 : 1}
-        >
-          <MarkerPin
-            title={ex.title}
-            selected={ex.displayId === selectedId}
-            onClick={() => onSelect(ex.displayId)}
-          />
-        </CustomOverlayMap>
-      ))}
-    </Map>
+    <div className="relative size-full">
+      <Map
+        center={DEFAULT_CENTER}
+        level={DEFAULT_LEVEL}
+        style={{ width: '100%', height: '100%' }}
+        onIdle={handleIdle}
+        onCreate={(map) => {
+          mapRef.current = map;
+        }}
+      >
+        {exhibitions.map((ex) => (
+          <CustomOverlayMap
+            key={ex.displayId}
+            position={{ lat: ex.latitude, lng: ex.longitude }}
+            yAnchor={1}
+            zIndex={ex.displayId === selectedId ? 10 : 1}
+          >
+            <MarkerPin
+              title={ex.title}
+              selected={ex.displayId === selectedId}
+              onClick={() => onSelect(ex.displayId)}
+            />
+          </CustomOverlayMap>
+        ))}
+      </Map>
+
+      {/* 현재 위치로 이동 버튼 */}
+      <button
+        type="button"
+        onClick={handleLocateUser}
+        disabled={isLocating}
+        aria-label="내 위치로 이동"
+        className="absolute bottom-4 right-4 z-10 flex size-12 items-center justify-center rounded-full bg-white shadow-lg transition-all hover:shadow-xl disabled:opacity-50"
+      >
+        <LocateFixed
+          className={`size-6 text-neutral-700 ${isLocating ? 'animate-pulse' : ''}`}
+        />
+      </button>
+    </div>
   );
 }
 

--- a/src/components/search/ExhibitionMapCard.tsx
+++ b/src/components/search/ExhibitionMapCard.tsx
@@ -12,15 +12,7 @@ interface ExhibitionMapCardProps {
   onToggleBookmark?: () => void;
 }
 
-/**
- * 지도 탭 하단에 쌓이는 가로형 카드.
- * 선택된 카드(지도 핀과 동기화)는 outline 으로 강조.
- * 색/타이포는 전부 디자인 토큰만 사용.
- *
- * 클릭 동작:
- * - 싱글클릭: 지도 핀 선택
- * - 더블클릭: 상세 페이지 이동
- */
+
 export function ExhibitionMapCard({
   exhibition,
   selected = false,

--- a/src/components/search/ExhibitionMapCard.tsx
+++ b/src/components/search/ExhibitionMapCard.tsx
@@ -1,0 +1,115 @@
+import type { NearbyDisplay } from '../../hooks/useNearbyDisplays';
+
+interface ExhibitionMapCardProps {
+  exhibition: NearbyDisplay;
+  selected?: boolean;
+  onClick?: () => void;
+  onToggleBookmark?: () => void;
+}
+
+/**
+ * 지도 탭 하단에 쌓이는 가로형 카드.
+ * 선택된 카드(지도 핀과 동기화)는 outline 으로 강조.
+ * 색/타이포는 전부 디자인 토큰만 사용.
+ */
+export function ExhibitionMapCard({
+  exhibition,
+  selected = false,
+  onClick,
+  onToggleBookmark,
+}: ExhibitionMapCardProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
+      className={`flex w-full cursor-pointer items-start gap-3 rounded-2xl p-3.5 text-left shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04),inset_1px_1px_4px_0px_rgba(1,8,21,0.20),inset_-2px_-2px_2px_0px_rgba(255,255,255,0.90)] ${
+        selected ? 'bg-box outline outline-1 -outline-offset-1 outline-line' : 'bg-box100'
+      }`}
+    >
+      <img
+        src={exhibition.posterImageUrl}
+        alt=""
+        className="h-32 w-24 shrink-0 rounded-xl bg-box200 object-cover"
+      />
+
+      <div className="flex flex-1 flex-col gap-4">
+        <span className="w-fit rounded-sm bg-box200 px-2 py-0.5">
+          <span className="typo-body-xxs-regular text-main">{exhibition.status}</span>
+        </span>
+
+        <div className="flex flex-col gap-2.5">
+          <h3 className="typo-body-md-bold text-main">{exhibition.title}</h3>
+
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col">
+              <span className="typo-body-xs-regular text-sub700">
+                {exhibition.hostName}
+              </span>
+              <span className="typo-body-xs-regular text-hint">{exhibition.period}</span>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <LocationIcon />
+              <span className="typo-body-xxs-regular text-faint">
+                {exhibition.placeName}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        aria-label={exhibition.isBookmarked ? '북마크 해제' : '북마크'}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleBookmark?.();
+        }}
+        className="shrink-0 focus:outline-none focus:ring-2 focus:ring-main focus:ring-offset-2"
+      >
+        <BookmarkIcon filled={exhibition.isBookmarked} />
+      </button>
+    </div>
+  );
+}
+
+function LocationIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden>
+      <path
+        d="M5 1.25c1.5 0 2.5 1.1 2.5 2.4C7.5 5.4 5 8.3 5 8.3S2.5 5.4 2.5 3.65C2.5 2.35 3.5 1.25 5 1.25Z"
+        stroke="currentColor"
+        strokeWidth="0.83"
+        className="text-faint"
+      />
+      <circle
+        cx="5"
+        cy="3.75"
+        r="0.9"
+        stroke="currentColor"
+        strokeWidth="0.83"
+        className="text-faint"
+      />
+    </svg>
+  );
+}
+
+function BookmarkIcon({ filled }: { filled: boolean }) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path
+        d="M4 2.5h8a.5.5 0 0 1 .5.5v10.5L8 11.2l-4.5 2.3V3a.5.5 0 0 1 .5-.5Z"
+        className={filled ? 'fill-main stroke-main' : 'stroke-faint'}
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/search/ExhibitionMapCard.tsx
+++ b/src/components/search/ExhibitionMapCard.tsx
@@ -1,3 +1,6 @@
+import { useRef } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
 import type { NearbyDisplay } from '../../hooks/useNearbyDisplays';
 
 interface ExhibitionMapCardProps {
@@ -11,6 +14,10 @@ interface ExhibitionMapCardProps {
  * 지도 탭 하단에 쌓이는 가로형 카드.
  * 선택된 카드(지도 핀과 동기화)는 outline 으로 강조.
  * 색/타이포는 전부 디자인 토큰만 사용.
+ *
+ * 클릭 동작:
+ * - 싱글클릭: 지도 핀 선택
+ * - 더블클릭: 상세 페이지 이동
  */
 export function ExhibitionMapCard({
   exhibition,
@@ -18,18 +25,45 @@ export function ExhibitionMapCard({
   onClick,
   onToggleBookmark,
 }: ExhibitionMapCardProps) {
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onClick?.();
+  const navigate = useNavigate();
+  const clickTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clickCountRef = useRef<number>(0);
+
+  const handleCardClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    // 북마크 버튼 클릭은 무시
+    if ((e.target as HTMLElement).closest('button')) {
+      return;
+    }
+
+    e.preventDefault();
+
+    clickCountRef.current++;
+
+    if (clickCountRef.current === 1) {
+      // 첫 번째 클릭: 300ms 대기
+      clickTimeoutRef.current = setTimeout(() => {
+        // 싱글클릭: 지도 핀 선택
+        if (onClick) {
+          onClick();
         }
-      }}
-      className={`flex w-full cursor-pointer items-start gap-3 rounded-2xl p-3.5 text-left shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04),inset_1px_1px_4px_0px_rgba(1,8,21,0.20),inset_-2px_-2px_2px_0px_rgba(255,255,255,0.90)] ${
+        clickCountRef.current = 0;
+      }, 300);
+    } else if (clickCountRef.current === 2) {
+      // 두 번째 클릭: 타이머 취소하고 페이지 이동
+      if (clickTimeoutRef.current) {
+        clearTimeout(clickTimeoutRef.current);
+        clickTimeoutRef.current = null;
+      }
+      clickCountRef.current = 0;
+      navigate(`/display/${exhibition.displayId}`);
+    }
+  };
+
+  return (
+    <Link
+      to={`/display/${exhibition.displayId}`}
+      onClick={handleCardClick}
+      className={`flex w-full cursor-pointer items-start gap-3 rounded-2xl p-3.5 text-left no-underline shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04),inset_1px_1px_4px_0px_rgba(1,8,21,0.20),inset_-2px_-2px_2px_0px_rgba(255,255,255,0.90)] ${
         selected ? 'bg-box outline outline-1 -outline-offset-1 outline-line' : 'bg-box100'
       }`}
     >
@@ -69,6 +103,7 @@ export function ExhibitionMapCard({
         type="button"
         aria-label={exhibition.isBookmarked ? '북마크 해제' : '북마크'}
         onClick={(e) => {
+          e.preventDefault();
           e.stopPropagation();
           onToggleBookmark?.();
         }}
@@ -76,7 +111,7 @@ export function ExhibitionMapCard({
       >
         <BookmarkIcon filled={exhibition.isBookmarked} />
       </button>
-    </div>
+    </Link>
   );
 }
 

--- a/src/components/search/ExhibitionMapCard.tsx
+++ b/src/components/search/ExhibitionMapCard.tsx
@@ -1,4 +1,6 @@
 import { useRef } from 'react';
+
+import { Bookmark, MapPin } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import type { NearbyDisplay } from '../../hooks/useNearbyDisplays';
@@ -83,17 +85,13 @@ export function ExhibitionMapCard({
 
           <div className="flex flex-col gap-4">
             <div className="flex flex-col">
-              <span className="typo-body-xs-regular text-sub700">
-                {exhibition.hostName}
-              </span>
+              <span className="typo-body-xs-regular text-sub700">{exhibition.hostName}</span>
               <span className="typo-body-xs-regular text-hint">{exhibition.period}</span>
             </div>
 
             <div className="flex items-center gap-1">
-              <LocationIcon />
-              <span className="typo-body-xxs-regular text-faint">
-                {exhibition.placeName}
-              </span>
+              <MapPin className="size-2.5 text-faint" strokeWidth={1.7} aria-hidden />
+              <span className="typo-body-xxs-regular text-faint">{exhibition.placeName}</span>
             </div>
           </div>
         </div>
@@ -109,42 +107,12 @@ export function ExhibitionMapCard({
         }}
         className="shrink-0 focus:outline-none focus:ring-2 focus:ring-main focus:ring-offset-2"
       >
-        <BookmarkIcon filled={exhibition.isBookmarked} />
+        <Bookmark
+          className={exhibition.isBookmarked ? 'size-4 fill-main text-main' : 'size-4 text-faint'}
+          strokeWidth={1.2}
+          aria-hidden
+        />
       </button>
     </Link>
-  );
-}
-
-function LocationIcon() {
-  return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden>
-      <path
-        d="M5 1.25c1.5 0 2.5 1.1 2.5 2.4C7.5 5.4 5 8.3 5 8.3S2.5 5.4 2.5 3.65C2.5 2.35 3.5 1.25 5 1.25Z"
-        stroke="currentColor"
-        strokeWidth="0.83"
-        className="text-faint"
-      />
-      <circle
-        cx="5"
-        cy="3.75"
-        r="0.9"
-        stroke="currentColor"
-        strokeWidth="0.83"
-        className="text-faint"
-      />
-    </svg>
-  );
-}
-
-function BookmarkIcon({ filled }: { filled: boolean }) {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
-      <path
-        d="M4 2.5h8a.5.5 0 0 1 .5.5v10.5L8 11.2l-4.5 2.3V3a.5.5 0 0 1 .5-.5Z"
-        className={filled ? 'fill-main stroke-main' : 'stroke-faint'}
-        strokeWidth="1.2"
-        strokeLinejoin="round"
-      />
-    </svg>
   );
 }

--- a/src/components/search/ExhibitionMapMarker.tsx
+++ b/src/components/search/ExhibitionMapMarker.tsx
@@ -1,0 +1,41 @@
+import { MapPin } from 'lucide-react';
+
+interface ExhibitionMapMarkerProps {
+  title: string;
+  selected: boolean;
+  onClick: () => void;
+}
+
+/**
+ * 지도 위 핀. Figma 기준:
+ *  - 선택됨: 어두운 알약 + 흰 글자 + 큰 점
+ *  - 기본:  흰 알약 + 위치 아이콘 + 회색 글자 + 작은 점
+ * 알약 아래 점이 실제 좌표를 가리키므로 yAnchor=1.
+ */
+export function ExhibitionMapMarker({ title, selected, onClick }: ExhibitionMapMarkerProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex -translate-y-1 flex-col items-center focus:outline-none"
+    >
+      {selected ? (
+        <span className="rounded-2xl bg-dark px-2.5 py-1.5 shadow-lg">
+          <span className="typo-body-xxs-semibold whitespace-nowrap text-white">{title}</span>
+        </span>
+      ) : (
+        <span className="flex items-center gap-1 rounded-[10px] bg-card px-2 py-1 shadow-[0px_1px_3px_0px_rgba(0,0,0,0.10)] outline outline-1 -outline-offset-1 outline-line-soft">
+          <MapPin className="size-2.5 text-hint" aria-hidden />
+          <span className="typo-body-xxs-regular whitespace-nowrap text-sub700">{title}</span>
+        </span>
+      )}
+      <span
+        className={
+          selected
+            ? 'mt-[3px] size-2.5 rounded-full bg-dark'
+            : 'mt-[3px] size-2 rounded-full bg-faint'
+        }
+      />
+    </button>
+  );
+}

--- a/src/hooks/useNearbyDisplays.ts
+++ b/src/hooks/useNearbyDisplays.ts
@@ -123,3 +123,4 @@ export function useNearbyDisplays(params: NearbyParams | null) {
   });
 }
 
+

--- a/src/hooks/useNearbyDisplays.ts
+++ b/src/hooks/useNearbyDisplays.ts
@@ -3,6 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import type { GetDisplayMapRequestDto } from '@/api/dto';
 import { getDisplayMap } from '@/api/endpoints';
 import { queryKeys } from '@/api/queryKeys';
+import { formatDate } from '@/utils/date';
+import { calculateBounds } from '@/utils/geo';
 
 /**
  * 지도 중심 좌표 + 반경으로 주변 전시를 조회하는 훅.
@@ -27,51 +29,6 @@ export interface NearbyParams {
   lng: number;
   radius: number; // meters - API의 bounds 계산에 사용
   searchWord?: string | null;
-}
-
-/**
- * 두 좌표 사이 거리(m). 반경 계산에 사용.
- * Haversine formula로 지구 곡률을 고려한 정확한 거리 계산.
- */
-export function getDistanceMeters(
-  lat1: number,
-  lng1: number,
-  lat2: number,
-  lng2: number,
-): number {
-  const R = 6371000;
-  const toRad = (deg: number) => (deg * Math.PI) / 180;
-  const dLat = toRad(lat2 - lat1);
-  const dLng = toRad(lng2 - lng1);
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
-  return 2 * R * Math.asin(Math.sqrt(a));
-}
-
-/**
- * 중심 좌표와 반경(m)으로 bounding box 계산
- */
-function calculateBounds(lat: number, lng: number, radiusMeters: number) {
-  const latDelta = (radiusMeters / 6371000) * (180 / Math.PI);
-  const lngDelta = (radiusMeters / 6371000) * (180 / Math.PI) / Math.cos((lat * Math.PI) / 180);
-
-  return {
-    southLatitude: lat - latDelta,
-    westLongitude: lng - lngDelta,
-    northLatitude: lat + latDelta,
-    eastLongitude: lng + lngDelta,
-  };
-}
-
-/**
- * 날짜 문자열을 'MM.DD' 형식으로 변환
- */
-function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${month}.${day}`;
 }
 
 /**
@@ -122,4 +79,3 @@ export function useNearbyDisplays(params: NearbyParams | null) {
     staleTime: 10_000,
   });
 }
-

--- a/src/hooks/useNearbyDisplays.ts
+++ b/src/hooks/useNearbyDisplays.ts
@@ -123,4 +123,3 @@ export function useNearbyDisplays(params: NearbyParams | null) {
   });
 }
 
-

--- a/src/hooks/useNearbyDisplays.ts
+++ b/src/hooks/useNearbyDisplays.ts
@@ -1,0 +1,125 @@
+import { useQuery } from '@tanstack/react-query';
+
+import type { GetDisplayMapRequestDto } from '@/api/dto';
+import { getDisplayMap } from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
+
+/**
+ * 지도 중심 좌표 + 반경으로 주변 전시를 조회하는 훅.
+ * 실제 API (/v1/display/map)를 사용합니다.
+ */
+
+export interface NearbyDisplay {
+  displayId: number;
+  title: string;
+  posterImageUrl: string;
+  status: string; // 예: '전시 중' - startDate/endDate로 계산
+  hostName: string; // locationName 사용
+  period: string; // startDate ~ endDate 포맷
+  placeName: string;
+  latitude: number;
+  longitude: number;
+  isBookmarked: boolean; // 현재 API에 없음, 추후 추가 필요
+}
+
+export interface NearbyParams {
+  lat: number;
+  lng: number;
+  radius: number; // meters - API의 bounds 계산에 사용
+  searchWord?: string | null;
+}
+
+/**
+ * 두 좌표 사이 거리(m). 반경 계산에 사용.
+ * Haversine formula로 지구 곡률을 고려한 정확한 거리 계산.
+ */
+export function getDistanceMeters(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+): number {
+  const R = 6371000;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
+}
+
+/**
+ * 중심 좌표와 반경(m)으로 bounding box 계산
+ */
+function calculateBounds(lat: number, lng: number, radiusMeters: number) {
+  const latDelta = (radiusMeters / 6371000) * (180 / Math.PI);
+  const lngDelta = (radiusMeters / 6371000) * (180 / Math.PI) / Math.cos((lat * Math.PI) / 180);
+
+  return {
+    southLatitude: lat - latDelta,
+    westLongitude: lng - lngDelta,
+    northLatitude: lat + latDelta,
+    eastLongitude: lng + lngDelta,
+  };
+}
+
+/**
+ * 날짜 문자열을 'MM.DD' 형식으로 변환
+ */
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${month}.${day}`;
+}
+
+/**
+ * 전시 상태 판단 (시작일/종료일 기준)
+ */
+function getDisplayStatus(startDate: string, endDate: string): string {
+  const now = new Date();
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  if (now < start) return '전시 예정';
+  if (now > end) return '전시 종료';
+  return '전시 중';
+}
+
+async function fetchNearbyDisplays(params: NearbyParams): Promise<NearbyDisplay[]> {
+  const bounds = calculateBounds(params.lat, params.lng, params.radius);
+
+  const requestDto: GetDisplayMapRequestDto = {
+    ...bounds,
+    searchWord: params.searchWord || undefined,
+    // cursor와 size는 optional이므로 제거해봄
+  };
+
+  const response = await getDisplayMap(requestDto);
+
+  // API 응답(DisplayMapMarkerDto)을 NearbyDisplay 형태로 변환
+  return response.markers.map((marker) => ({
+    displayId: marker.displayId,
+    title: marker.title,
+    posterImageUrl: marker.posterImageUrl,
+    status: getDisplayStatus(marker.startDate, marker.endDate),
+    hostName: marker.locationName, // API에 hostName이 없으므로 locationName 사용
+    period: `${formatDate(marker.startDate)} - ${formatDate(marker.endDate)}`,
+    placeName: marker.locationName,
+    latitude: marker.latitude,
+    longitude: marker.longitude,
+    isBookmarked: false, // TODO: 북마크 API 연동 필요
+  }));
+}
+
+export function useNearbyDisplays(params: NearbyParams | null) {
+  return useQuery({
+    queryKey: queryKeys.displays.nearby(params),
+    queryFn: () => fetchNearbyDisplays(params!),
+    enabled: params !== null, // 지도 첫 idle 전에는 호출 안 함
+    placeholderData: (prev) => prev, // 지도 이동 중 목록이 깜빡이지 않게 이전 값 유지
+    staleTime: 10_000,
+  });
+}
+

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -88,10 +88,7 @@ export function SearchPage() {
   const exhibitions = data?.exhibitions ?? [];
 
   const nearbyParamsWithSearch = useMemo(
-    () =>
-      nearbyParams
-        ? { ...nearbyParams, searchWord: query.trim() || null }
-        : null,
+    () => (nearbyParams ? { ...nearbyParams, searchWord: query.trim() || null } : null),
     [nearbyParams, query],
   );
   const { data: nearbyData } = useNearbyDisplays(nearbyParamsWithSearch);

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -19,7 +19,10 @@ import {
   type FilterTab,
   getFilterOptionValue,
 } from '../components/search';
+import { ExhibitionMap } from '../components/search/ExhibitionMap';
+import { ExhibitionMapCard } from '../components/search/ExhibitionMapCard';
 import { useSearchDisplays } from '../hooks/queries/useDisplayBrowse';
+import { type NearbyParams, useNearbyDisplays } from '../hooks/useNearbyDisplays';
 
 type ExploreTab = 'list' | 'map';
 
@@ -44,6 +47,8 @@ export function SearchPage() {
 
   const [query, setQuery] = useState('');
   const [activeTab, setActiveTab] = useState<ExploreTab>('list');
+  const [selectedMapId, setSelectedMapId] = useState<number | null>(null);
+  const [nearbyParams, setNearbyParams] = useState<NearbyParams | null>(null);
 
   const paramType = urlSearchParams.get('type');
   const paramStatus = urlSearchParams.get('status');
@@ -81,6 +86,16 @@ export function SearchPage() {
 
   const { data, isError, isLoading } = useSearchDisplays(searchDisplayParams);
   const exhibitions = data?.exhibitions ?? [];
+
+  const nearbyParamsWithSearch = useMemo(
+    () =>
+      nearbyParams
+        ? { ...nearbyParams, searchWord: query.trim() || null }
+        : null,
+    [nearbyParams, query],
+  );
+  const { data: nearbyData } = useNearbyDisplays(nearbyParamsWithSearch);
+  const nearbyExhibitions = nearbyData ?? [];
 
   const activeFilterEntries = (Object.entries(filters) as Array<[FilterTab, string]>).filter(
     ([, value]) => value !== '전체',
@@ -213,7 +228,37 @@ export function SearchPage() {
             )}
           </div>
         </div>
-      ) : null}
+      ) : (
+        <div className="relative flex flex-1 flex-col">
+          <div className="h-[400px] w-full">
+            <ExhibitionMap
+              exhibitions={nearbyExhibitions}
+              onBoundsChange={setNearbyParams}
+              onSelect={setSelectedMapId}
+              selectedId={selectedMapId}
+            />
+          </div>
+
+          <div className="flex-1 overflow-y-auto bg-gray-100 px-5 pt-4 pb-24">
+            {nearbyExhibitions.length === 0 ? (
+              <p className="flex items-center justify-center py-8 text-center text-sm text-neutral-400">
+                이 지역에 전시가 없습니다
+              </p>
+            ) : (
+              <div className="flex flex-col gap-3">
+                {nearbyExhibitions.map((exhibition) => (
+                  <ExhibitionMapCard
+                    exhibition={exhibition}
+                    key={exhibition.displayId}
+                    onClick={() => setSelectedMapId(exhibition.displayId)}
+                    selected={selectedMapId === exhibition.displayId}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       {modalOpen ? (
         <FilterModal

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,9 @@
+/**
+ * 날짜 문자열을 'MM.DD' 형식으로 변환
+ */
+export function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${month}.${day}`;
+}

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,0 +1,29 @@
+/**
+ * 두 좌표 사이 거리(m). 반경 계산에 사용.
+ * Haversine formula로 지구 곡률을 고려한 정확한 거리 계산.
+ */
+export function getDistanceMeters(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371000;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
+}
+
+/**
+ * 중심 좌표와 반경(m)으로 bounding box 계산
+ */
+export function calculateBounds(lat: number, lng: number, radiusMeters: number) {
+  const latDelta = (radiusMeters / 6371000) * (180 / Math.PI);
+  const lngDelta = ((radiusMeters / 6371000) * (180 / Math.PI)) / Math.cos((lat * Math.PI) / 180);
+
+  return {
+    southLatitude: lat - latDelta,
+    westLongitude: lng - lngDelta,
+    northLatitude: lat + latDelta,
+    eastLongitude: lng + lngDelta,
+  };
+}

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -1,0 +1,101 @@
+const MAX_ATTEMPTS = 3;
+const ACCURACY_THRESHOLD_METERS = 100;
+const TIMEOUT_MS = 5000;
+
+export class GeolocationUnsupportedError extends Error {
+  constructor() {
+    super('위치 서비스를 지원하지 않는 브라우저입니다.');
+    this.name = 'GeolocationUnsupportedError';
+  }
+}
+
+/**
+ * 사용자 위치를 반복 측정해 정확도가 가장 좋은 좌표를 반환한다.
+ * - 첫 측정값은 즉시 피드백을 위해 무조건 채택
+ * - 이후 측정값은 이전보다 정확하거나(accuracy 낮음) 100m 이내면 채택
+ * - 정확도가 100m 이내이거나 최대 3회 측정, 또는 5초가 지나면 종료
+ */
+export function getAccurateUserLocation(): Promise<GeolocationPosition> {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) {
+      reject(new GeolocationUnsupportedError());
+      return;
+    }
+
+    let bestAccuracy = Infinity;
+    let bestPosition: GeolocationPosition | null = null;
+    let attempts = 0;
+    let hasSettled = false;
+
+    const settle = (fn: () => void) => {
+      if (hasSettled) return;
+      hasSettled = true;
+      navigator.geolocation.clearWatch(watchId);
+      clearTimeout(timeoutId);
+      fn();
+    };
+
+    const watchId = navigator.geolocation.watchPosition(
+      (position) => {
+        if (hasSettled) return;
+
+        attempts += 1;
+        const { accuracy } = position.coords;
+        const shouldUsePosition =
+          attempts === 1 || accuracy < bestAccuracy || accuracy < ACCURACY_THRESHOLD_METERS;
+
+        if (shouldUsePosition) {
+          bestAccuracy = Math.min(bestAccuracy, accuracy);
+          bestPosition = position;
+        }
+
+        if (accuracy < ACCURACY_THRESHOLD_METERS || attempts >= MAX_ATTEMPTS) {
+          settle(() => resolve(bestPosition ?? position));
+        }
+      },
+      (error) => {
+        settle(() => reject(error));
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: TIMEOUT_MS,
+        maximumAge: 0,
+      },
+    );
+
+    const timeoutId = setTimeout(() => {
+      settle(() => {
+        if (bestPosition) {
+          resolve(bestPosition);
+        } else {
+          reject(
+            new Error('위치 요청 시간이 초과되었습니다. WiFi나 GPS가 켜져있는지 확인해주세요.'),
+          );
+        }
+      });
+    }, TIMEOUT_MS);
+  });
+}
+
+/** GeolocationPositionError를 사용자에게 보여줄 메시지로 변환 */
+export function getGeolocationErrorMessage(error: unknown): string {
+  if (error instanceof GeolocationUnsupportedError) {
+    return error.message;
+  }
+
+  if (error instanceof Error && !('code' in error)) {
+    return error.message;
+  }
+
+  const geoError = error as GeolocationPositionError;
+  switch (geoError.code) {
+    case geoError.PERMISSION_DENIED:
+      return '위치 권한이 거부되었습니다. 브라우저 설정에서 위치 권한을 허용해주세요.';
+    case geoError.POSITION_UNAVAILABLE:
+      return '위치 정보를 사용할 수 없습니다.';
+    case geoError.TIMEOUT:
+      return '위치 요청 시간이 초과되었습니다. WiFi나 GPS가 켜져있는지 확인해주세요.';
+    default:
+      return '위치를 가져올 수 없습니다.';
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -17,7 +17,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["kakao.maps.d.ts"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## 📝 작업 내용

- 지도 api 연결
- 지도 탭의 전시 목록 더블 클릭 시 해당 전시 페이지로 이동
- locate 아이콘 클릭 시 본인 위치로 이동
## 🔍 관련 이슈

- close #123 

## 🖼️ 스크린샷

<img width="296" height="642" alt="image" src="https://github.com/user-attachments/assets/cd729ec9-649d-4307-a33e-1c024a83fec7" />

## 🧪 테스트 결과

- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 본인 위치로 이동하는게 오차가 좀 되는 것 같다. 오차를 줄 일 방법을 생각해봐야겠다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 카카오 지도 탭에서 지도 중심/반경과 검색어를 기준으로 주변 전시를 조회해 자동 갱신합니다.
  - 지도에 전시 마커(선택 상태 표시)와 하단 전시 카드(상세 이동/선택)가 함께 제공됩니다.
  - “내 위치로 이동”으로 지도 중심을 현재 위치로 옮기고 주변 전시를 다시 불러옵니다.
- **개선**
  - 지도 영역 갱신이 안정적으로 동작하도록 경계 변경에 디바운싱을 적용했습니다.
  - 전시 카드 클릭 동작(단/더블 클릭)과 북마크 전환을 더 매끄럽게 처리합니다.
- **Chores**
  - 카카오 지도 연동 패키지 및 타입 정의를 추가하고 TypeScript 컴파일에 포함했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->