### PR TITLE
fix: footer & Navbar 반응형 제거

### DIFF
--- a/src/components/layout/FNB.tsx
+++ b/src/components/layout/FNB.tsx
@@ -1,9 +1,15 @@
 import DUfontlogo from '@/assets/DUfontlogo.svg';
+import { cn } from '@/utils/cn';
 
 interface DUMember {
   names: string[];
   role: string;
 }
+
+type FNBProps = {
+  hasFixedBottomBar?: boolean;
+  className?: string;
+};
 
 const credits: DUMember[] = [
   { role: 'PM', names: ['고상준'] },
@@ -12,9 +18,15 @@ const credits: DUMember[] = [
   { role: 'BackEnd', names: ['김승완  임도현  최건희', '김수빈  김민지  우서윤'] },
 ];
 
-export function FNB() {
+export function FNB({ hasFixedBottomBar = false, className }: FNBProps) {
   return (
-    <footer className="w-full max-w-md mx-auto bg-line-soft px-[30px] pt-[24px] pb-[32px] overflow-hidden">
+    <footer
+      className={cn(
+        'w-full max-w-md mx-auto bg-line-soft px-[30px] pt-[24px] overflow-hidden',
+        hasFixedBottomBar ? 'pb-28' : 'pb-[32px]',
+        className,
+      )}
+    >
       <div className="flex flex-col gap-6">
         {/* 로고 & 서브타이틀 */}
         <div className="flex flex-col items-start gap-3">

--- a/src/components/layout/FNB.tsx
+++ b/src/components/layout/FNB.tsx
@@ -1,4 +1,4 @@
-import DUfontlogo from '../../assets/DUfontlogo.svg';
+import DUfontlogo from '@/assets/DUfontlogo.svg';
 
 interface DUMember {
   names: string[];
@@ -6,33 +6,30 @@ interface DUMember {
 }
 
 const credits: DUMember[] = [
-  { names: ['고상준'], role: 'PM' },
-  { names: ['최유성'], role: 'DESIGN' },
-  { names: ['안재인', '이승철', '서현민', '정아람'], role: 'FrontEnd' },
-  { names: ['임도현', '최건희', '김승완', '김수빈', '김민지', '우서윤'], role: 'BackEnd' },
+  { role: 'PM', names: ['고상준'] },
+  { role: 'DESIGN', names: ['최유성'] },
+  { role: 'FrontEnd', names: ['이승철  서현민', '안재인  정아람'] },
+  { role: 'BackEnd', names: ['김승완  임도현  최건희', '김수빈  김민지  우서윤'] },
 ];
 
 export function FNB() {
   return (
-    <footer className="w-full bg-line-soft py-8 px-6 md:py-10 md:px-10 lg:py-12 lg:px-16">
-      <div className="mx-auto flex flex-col md:flex-row md:items-start md:justify-between gap-8 lg:gap-16 max-w-7xl">
-        <div className="flex flex-col items-start gap-2.5 md:gap-3 shrink-0">
-          <img alt="DISPLAYU" className="h-6 md:h-7 lg:h-8 w-auto self-start" src={DUfontlogo} />
-          <p className="typo-body-xs-regular md:typo-body-sm-regular text-logo">전시공유 플랫폼</p>
+    <footer className="w-full max-w-md mx-auto bg-line-soft px-[30px] pt-[24px] pb-[32px] overflow-hidden">
+      <div className="flex flex-col gap-6">
+        {/* 로고 & 서브타이틀 */}
+        <div className="flex flex-col items-start gap-3">
+          <img alt="DISPLAYU" className="h-6 w-auto self-start" src={DUfontlogo} />
+          <p className="typo-body-xs-regular text-main">대학생 전시 플랫폼</p>
         </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 sm:gap-7 md:gap-8 lg:gap-12">
+        {/* 크레딧 목록 */}
+        <div className="flex items-start gap-7">
           {credits.map((item) => (
-            <div className="flex shrink-0 flex-col gap-0.5" key={item.role}>
-              <p className="typo-body-xs-semibold md:typo-body-sm-semibold text-sub600 whitespace-pre">
-                {item.role}
-              </p>
-              {item.names.map((name, idx) => (
-                <p
-                  className="typo-body-xs-regular md:typo-body-sm-regular text-hint whitespace-pre"
-                  key={idx}
-                >
-                  {name}
+            <div className="flex flex-col gap-0.5 shrink-0" key={item.role}>
+              <p className="typo-body-xs-regular text-hint">{item.role}</p>
+              {item.names.map((nameLine, idx) => (
+                <p className="typo-body-xs-regular text-hint whitespace-pre" key={idx}>
+                  {nameLine}
                 </p>
               ))}
             </div>

--- a/src/components/layout/FooterContext.tsx
+++ b/src/components/layout/FooterContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, useEffect } from 'react';
+
+type FooterContextType = {
+  isFooterHidden: boolean;
+  setFooterHidden: (hidden: boolean) => void;
+};
+
+export const FooterContext = createContext<FooterContextType | null>(null);
+
+export function useFooterContext() {
+  return useContext(FooterContext);
+}
+
+/**
+ * 특정 페이지 컴포넌트에서 선택적으로 Footer(FNB)를 숨기기 위해 호출하는 훅입니다.
+ */
+export function useHideFooter() {
+  const context = useContext(FooterContext);
+
+  useEffect(() => {
+    context?.setFooterHidden(true);
+    return () => {
+      context?.setFooterHidden(false);
+    };
+  }, [context]);
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -46,7 +46,7 @@ function LayoutContent() {
         </main>
 
         {/* 기본적으로 Footer(FNB) 노출, 선택적으로 안보이도록 설정 가능 */}
-        {!shouldHideFooter && <FNB />}
+        {!shouldHideFooter && <FNB hasFixedBottomBar={shouldHideNavbar} />}
 
         {!shouldHideNavbar && (
           <div className="fixed right-0 bottom-4 left-0 z-50 flex justify-center px-4 pointer-events-none">

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,32 +1,62 @@
-import { Outlet, useLocation } from 'react-router-dom';
+import { useState } from 'react';
+
+import { Outlet, useLocation, useMatches } from 'react-router-dom';
 
 import { FNB } from './FNB';
+import { FooterContext } from './FooterContext';
 import { Navbar } from './Navbar';
 
 function LayoutContent() {
   const location = useLocation();
-  const hideChromePaths = [
+  const matches = useMatches();
+  const [manualFooterHidden, setManualFooterHidden] = useState(false);
+
+  // 하단 네비게이션 바(Navbar) 숨김 경로
+  const hideNavbarPaths = [
     '/display/',
     '/artwork/',
     '/exhibition-register/',
     '/lounge/review/post',
   ];
-  const shouldHideChrome = hideChromePaths.some((path) => location.pathname.startsWith(path));
+  const shouldHideNavbar = hideNavbarPaths.some((path) => location.pathname.startsWith(path));
+
+  // Footer(FNB) 선택적 숨김 경로 (기본값: Footer 표시, 안 보일 특수 페이지 등록 가능)
+  const defaultHideFooterPaths = ['/exhibition-register/', '/lounge/review/post'];
+  const isPathFooterHidden = defaultHideFooterPaths.some((path) =>
+    location.pathname.startsWith(path),
+  );
+
+  // Router handle ({ hideFooter: true }) 기반 숨김
+  const isRouteHandleFooterHidden = matches.some(
+    (match) => (match.handle as { hideFooter?: boolean })?.hideFooter,
+  );
+
+  const shouldHideFooter = manualFooterHidden || isPathFooterHidden || isRouteHandleFooterHidden;
 
   return (
-    <div className="min-h-screen flex flex-col justify-between">
-      <main className={`flex-1 ${shouldHideChrome ? '' : 'pb-20 md:pb-24 lg:pb-28'}`}>
-        <Outlet />
-      </main>
-      {!shouldHideChrome && <FNB />}
-      {!shouldHideChrome && (
-        <div className="fixed right-0 bottom-4 sm:bottom-6 md:bottom-8 left-0 z-50 flex justify-center px-4 pointer-events-none">
-          <div className="pointer-events-auto">
-            <Navbar />
+    <FooterContext.Provider
+      value={{
+        isFooterHidden: shouldHideFooter,
+        setFooterHidden: setManualFooterHidden,
+      }}
+    >
+      <div className="min-h-screen flex flex-col justify-between">
+        <main className={`flex-1 ${shouldHideNavbar ? '' : 'pb-3'}`}>
+          <Outlet />
+        </main>
+
+        {/* 기본적으로 Footer(FNB) 노출, 선택적으로 안보이도록 설정 가능 */}
+        {!shouldHideFooter && <FNB />}
+
+        {!shouldHideNavbar && (
+          <div className="fixed right-0 bottom-4 left-0 z-50 flex justify-center px-4 pointer-events-none">
+            <div className="pointer-events-auto">
+              <Navbar />
+            </div>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </FooterContext.Provider>
   );
 }
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -8,6 +8,7 @@ import myIcon from '../../assets/MyIcon.svg';
 import myIconActive from '../../assets/MyIconActive.svg';
 import searchIcon from '../../assets/SearchIcon.svg';
 import searchIconActive from '../../assets/SearchIconActive.svg';
+import { cn } from '../../utils/cn';
 
 type NavId = 'home' | 'lounge' | 'my' | 'search';
 
@@ -50,10 +51,10 @@ const NAV_ITEMS = [
 
 export function Navbar() {
   return (
-    <div className="relative rounded-[250px] px-3 py-1 sm:px-5 sm:py-1.5 shadow-[2px_8px_18px_0px_rgba(4,0,250,0.06)] overflow-hidden transition-all duration-300">
+    <div className="relative w-96 px-5 py-1.5 rounded-[250px] shadow-[2px_8px_18px_0px_rgba(4,0,250,0.06)] overflow-hidden">
       <div
         aria-hidden
-        className="absolute inset-0 rounded-[250px] backdrop-blur-[10px] pointer-events-none"
+        className="absolute inset-0 rounded-[250px] backdrop-blur-[10px] pointer-events-none bg-zinc-400/20"
         style={{
           backgroundImage:
             'linear-gradient(90deg, rgba(182,178,178,0.2) 0%, rgba(182,178,178,0.2) 100%), linear-gradient(90deg, rgba(182,178,178,0.5) 0%, rgba(182,178,178,0.5) 100%)',
@@ -64,27 +65,32 @@ export function Navbar() {
         className="absolute inset-0 rounded-[inherit] pointer-events-none"
         style={{
           boxShadow:
-            'inset 2px 2px 4px -2px #f5f5f5, inset -2px -2px 4px -2px rgba(241,241,241,0.6)',
+            'inset 2px 2px 4px -2px rgba(245,245,245,1), inset -2px -2px 4px -2px rgba(241,241,241,0.6)',
         }}
       />
 
-      <div className="relative flex items-center justify-center gap-1 sm:gap-2">
+      <div className="relative flex items-center justify-center">
         {NAV_ITEMS.map(({ activeIcon, icon, id, label, path }) => {
           return (
             <NavLink
               key={id}
               end={path === '/home'}
-              className="flex flex-col items-center justify-center w-16 sm:w-20 lg:w-24 h-[52px] sm:h-[60px] lg:h-[64px] cursor-pointer rounded-[24px] border-0 bg-transparent outline-none transition-transform duration-150 hover:scale-105 active:scale-95 focus-visible:ring-2 focus-visible:ring-[#fcfcfc] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+              className="flex flex-col items-center justify-center w-20 h-14 cursor-pointer rounded-[24px] border-0 bg-transparent outline-none transition-transform duration-150 active:scale-95 focus-visible:ring-2 focus-visible:ring-[#fcfcfc]"
               to={path}
             >
               {({ isActive }) => (
-                <div className="flex flex-col items-center gap-0.5 sm:gap-1">
+                <div className="flex flex-col items-center justify-center gap-1">
                   <img
                     alt=""
-                    className="h-4.5 w-4.5 sm:h-5 sm:w-5 lg:h-6 lg:w-6 transition-transform duration-200"
+                    className="size-5 transition-transform duration-200"
                     src={isActive ? activeIcon : icon}
                   />
-                  <span className="whitespace-nowrap transition-colors duration-150 typo-body-xs-regular sm:typo-body-sm-regular text-white">
+                  <span
+                    className={cn(
+                      'whitespace-nowrap transition-colors duration-150 typo-body-xs-regular text-white',
+                      isActive && 'typo-body-xs-bold',
+                    )}
+                  >
                     {label}
                   </span>
                 </div>

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,3 +1,4 @@
 export { FNB } from './FNB';
+export { useFooterContext, useHideFooter } from './FooterContext';
 export { Layout } from './Layout';
 export { Navbar } from './Navbar';

--- a/src/pages/ArtworkDetailPage.tsx
+++ b/src/pages/ArtworkDetailPage.tsx
@@ -84,7 +84,7 @@ export function ArtworkDetailPage() {
   }
 
   return (
-    <div className="w-full max-w-md mx-auto min-h-dvh bg-page relative pb-24">
+    <div className="w-full max-w-md mx-auto min-h-dvh bg-page relative">
       {/* 히어로 이미지 */}
       <HeroSlider
         images={[artwork.images.find((img) => img.isThumbnail)?.imageUrl || '']}

--- a/src/pages/ArtworkDetailPage.tsx
+++ b/src/pages/ArtworkDetailPage.tsx
@@ -10,7 +10,6 @@ import { ArtworkTabNav } from '@/components/artworkdetailpage/ArtworkTabNav';
 import { GuestbookInputBar } from '@/components/artworkdetailpage/GuestbookInputBar';
 import { BottomFixedBar } from '@/components/displaydetailpage/BottomFixedBar';
 import { HeroSlider } from '@/components/displaydetailpage/HeroSlider';
-import { FNB } from '@/components/layout/FNB';
 import { ARTWORK_DETAILS, GUESTBOOK_QUESTIONS, GUESTBOOK_REVIEWS } from '@/mocks/exhibition';
 import type {
   ArtworkGuestbookTab as ArtworkGuestbookSubTabType,
@@ -110,9 +109,6 @@ export function ArtworkDetailPage() {
           onArtistViewChange={setIsArtistView}
         />
       )}
-
-      {/* 하단 푸터 (FNB) */}
-      <FNB />
 
       {/* 하단 고정 바: 소개 탭은 저장버튼, 방명록 탭은 글쓰기 입력 바 */}
       {activeTab === 'intro' ? (


### PR DESCRIPTION
## 📝 작업 내용

- 어떤 기능을 개발/수정했는지 요약해주세요.
- 반응형 디자인을 제거했습니다.
- 하단 고정 바가 footer를 가리던 문제를 해결했습니다.
## 🔍 관련 이슈

- close #113

## 🖼️ 스크린샷

- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.
<img width="1584" height="964" alt="image" src="https://github.com/user-attachments/assets/825c6db1-22d8-4f20-8945-accd83be6ac5" />

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 페이지별 설정에 따라 푸터와 하단 내비게이션을 개별적으로 표시하거나 숨길 수 있습니다.
  * 화면 구성 요소에서 푸터를 일시적으로 숨기는 기능이 추가되었습니다.

* **개선 사항**
  * 푸터 및 하단 내비게이션의 레이아웃과 스타일이 새 디자인에 맞게 개선되었습니다.
  * 활성화된 내비게이션 항목이 더 명확하게 표시됩니다.
  * 작품 상세 화면에서 불필요한 하단 푸터가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->