### PR TITLE
feat: Zustand로 accessToken 상태 관리 전환

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-dom": "^18.3.1",
     "react-kakao-maps-sdk": "^1.2.1",
     "react-router-dom": "^7.18.1",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
+      zustand:
+        specifier: ^5.0.14
+        version: 5.0.14(@types/react@18.3.31)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.5.3
@@ -2621,6 +2624,24 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -5240,3 +5261,9 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zustand@5.0.14(@types/react@18.3.31)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
+    optionalDependencies:
+      '@types/react': 18.3.31
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from 'axios';
 
 import type { ApiResponseDto } from '@/api/dto';
+import { useAuthStore } from '@/stores/authStore';
 
 export class ApiError extends Error {
   code?: string;
@@ -19,8 +20,6 @@ export class ApiError extends Error {
   }
 }
 
-const getAccessToken = () => localStorage.getItem('accessToken');
-
 export const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 10000,
@@ -30,9 +29,10 @@ export const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use((config) => {
   config.headers.set('Accept', 'application/json');
 
-  const accessToken = getAccessToken();
+  const accessToken = useAuthStore.getState().accessToken;
+  const isSignupRequest = config.url?.includes('/v1/auth/signup');
 
-  if (accessToken && !config.headers.has('Authorization')) {
+  if (accessToken && !isSignupRequest && !config.headers.has('Authorization')) {
     config.headers.set('Authorization', `Bearer ${accessToken}`);
   }
 

--- a/src/hooks/queries/useAuth.ts
+++ b/src/hooks/queries/useAuth.ts
@@ -9,6 +9,7 @@ import {
   signup,
 } from '@/api/endpoints';
 import { queryKeys } from '@/api/queryKeys';
+import { useAuthStore } from '@/stores/authStore';
 
 export const useLogin = () => {
   const queryClient = useQueryClient();
@@ -48,7 +49,7 @@ export const useLogout = () => {
   return useMutation({
     mutationFn: (body: LogoutRequestDto) => logout(body),
     onSettled: () => {
-      localStorage.removeItem('accessToken');
+      useAuthStore.getState().clearAccessToken();
       queryClient.clear();
     },
   });

--- a/src/hooks/queries/useUserProfile.ts
+++ b/src/hooks/queries/useUserProfile.ts
@@ -15,6 +15,7 @@ import {
   updateNickname,
 } from '@/api/endpoints';
 import { queryKeys } from '@/api/queryKeys';
+import { useAuthStore } from '@/stores/authStore';
 
 export const useUserMe = () =>
   useQuery({
@@ -68,7 +69,7 @@ export const useDeleteUserMe = () => {
   return useMutation({
     mutationFn: deleteUserMe,
     onSuccess: () => {
-      localStorage.removeItem('accessToken');
+      useAuthStore.getState().clearAccessToken();
       queryClient.clear();
     },
   });

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -15,11 +15,14 @@ import {
   useHomeArtworkPreview,
   useHomeLoungePosts,
 } from '@/hooks/queries/useHome';
+import { useAuthStore } from '@/stores/authStore';
 
 export const Homepage = () => {
   const [isArtworkPreviewOpen, setIsArtworkPreviewOpen] = useState(false);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const { data: duPicksData } = useDuPicks();
   const { data: graduationExhibitions = [] } = useGraduationDisplays();
   const { data: closingSoonData } = useClosingSoonDisplays({ size: 3 });
@@ -32,26 +35,26 @@ export const Homepage = () => {
     const accessToken = searchParams.get('accessToken');
 
     if (accessToken) {
-      localStorage.setItem('accessToken', accessToken);
+      setAccessToken(accessToken);
       navigate('/home', { replace: true });
     }
-  }, [navigate, searchParams]);
+  }, [navigate, searchParams, setAccessToken]);
 
   // OAuth 콜백 이후 refreshToken 쿠키만 있고 accessToken이 없는 상태(기존 회원)일 수 있어서,
   // 홈 진입 시 accessToken이 없으면 1회 재발급을 시도한다.
   useEffect(() => {
-    if (localStorage.getItem('accessToken')) {
+    if (accessToken) {
       return;
     }
 
     void refreshToken()
       .then(({ accessToken }) => {
-        localStorage.setItem('accessToken', accessToken);
+        setAccessToken(accessToken);
       })
       .catch(() => {
         // 비회원/게스트일 수 있으므로 조용히 무시 (refresh token 쿠키 자체가 없는 경우)
       });
-  }, []);
+  }, [accessToken, setAccessToken]);
 
   if (isArtworkPreviewOpen) {
     return <ArtworkPreviewMoreView items={artworkPreviewItems} />;

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -879,9 +879,6 @@ export function OnboardingPage() {
       });
 
       setAccessToken(result.accessToken);
-      if (result.refreshToken) {
-        localStorage.setItem('refreshToken', result.refreshToken);
-      }
       setStep('done');
     } catch (err) {
       setError(err instanceof ApiError ? err.message : '가입 완료에 실패했어요.');

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -9,6 +9,7 @@ import type { AgreementDto } from '@/api/dto';
 import { useAgreements } from '@/hooks/queries/useAgreements';
 import { useSignup } from '@/hooks/queries/useAuth';
 import { useCheckNickname } from '@/hooks/queries/useUserProfile';
+import { useAuthStore } from '@/stores/authStore';
 
 type Step = 'terms' | 'termsDetail' | 'nickname' | 'done';
 type TermKey = 'over14' | 'service' | 'privacy' | 'location';
@@ -829,6 +830,7 @@ export function OnboardingPage() {
   const navigate = useNavigate();
   const agreementsQuery = useAgreements();
   const signup = useSignup();
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
 
   const findAgreement = (key: Exclude<TermKey, 'over14'>): AgreementDto | undefined =>
     agreementsQuery.data?.find((agreement) => agreement.code === AGREEMENT_CODES[key]);
@@ -876,7 +878,7 @@ export function OnboardingPage() {
         isOver14: terms.over14,
       });
 
-      localStorage.setItem('accessToken', result.accessToken);
+      setAccessToken(result.accessToken);
       if (result.refreshToken) {
         localStorage.setItem('refreshToken', result.refreshToken);
       }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface AuthState {
+  accessToken: string | null;
+  setAccessToken: (token: string) => void;
+  clearAccessToken: () => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      accessToken: null,
+      setAccessToken: (token) => set({ accessToken: token }),
+      clearAccessToken: () => set({ accessToken: null }),
+    }),
+    {
+      name: 'auth-storage',
+      partialize: (state) => ({ accessToken: state.accessToken }),
+    },
+  ),
+);


### PR DESCRIPTION
## 📝 작업 내용

- Zustand를 도입해 accessToken 관리용 `authStore`를 추가했습니다.
- 기존 `localStorage` 직접 접근 로직을 `authStore` 기반으로 교체했습니다.
- axios 인터셉터가 `authStore`에서 accessToken을 읽어 Authorization 헤더를 붙이도록 수정했습니다.
- 회원가입 요청(`/v1/auth/signup`)에는 Authorization 헤더가 붙지 않도록 예외 처리했습니다.

## 🔍 관련 이슈

#141의 Draft PR입니다
- close #144 

## 🖼️ 스크린샷

- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.

<img width="880" height="680" alt="스크린샷 2026-07-31 오후 3 19 53" src="https://github.com/user-attachments/assets/f59d775e-a0ed-46c9-bc30-530511848955" />


## 🧪 테스트 결과

- [ ] 정상 작동 확인

## 💬 기타 참고 사항

구현하면서 추가된 내용

- axios 인터셉터에 /v1/auth/signup 요청은 Authorization 헤더를 안 붙이는 예외 처리를 같이 넣었습니다. 이슈 범위(#144)에 명시된 건 아니지만, accessToken을 authStore로 옮기는 김에 실제로 재현되던 "유효하지 않은 회원가입 토큰" 버그의 원인이라 같이 고쳤습니다.
- OnboardingPage.tsx의 refreshToken 관련 localStorage 저장 로직은 Swagger 확인 결과 실제 응답에 없는 필드라 죽은 코드였습니다. 