### PR TITLE
feat: 로딩 & 에러 공통 컴포넌트 분리 및 적용

### DIFF
--- a/src/components/common/AsyncBoundary.tsx
+++ b/src/components/common/AsyncBoundary.tsx
@@ -1,0 +1,72 @@
+import { Component, Suspense } from 'react';
+
+import type { ReactNode } from 'react';
+
+import { ErrorView } from './ErrorView';
+import { LoadingView } from './LoadingView';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode | ((error: Error, reset: () => void) => ReactNode);
+  onReset?: () => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  };
+
+  public static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  public reset = () => {
+    this.props.onReset?.();
+    this.setState({ hasError: false, error: null });
+  };
+
+  public render() {
+    if (this.state.hasError && this.state.error) {
+      if (typeof this.props.fallback === 'function') {
+        return this.props.fallback(this.state.error, this.reset);
+      }
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+      return <ErrorView message={this.state.error.message} onRetry={this.reset} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+interface AsyncBoundaryProps {
+  children: ReactNode;
+  loadingFallback?: ReactNode;
+  errorFallback?: ReactNode | ((error: Error, reset: () => void) => ReactNode);
+  onReset?: () => void;
+}
+
+export function AsyncBoundary({
+  children,
+  loadingFallback = <LoadingView />,
+  errorFallback,
+  onReset,
+}: AsyncBoundaryProps) {
+  return (
+    <ErrorBoundary fallback={errorFallback} onReset={onReset}>
+      <Suspense fallback={loadingFallback}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/src/components/common/ErrorView.tsx
+++ b/src/components/common/ErrorView.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/utils/cn';
+
+interface ErrorViewProps {
+  title?: string;
+  message?: string;
+  onRetry?: () => void;
+  retryLabel?: string;
+  className?: string;
+  fullScreen?: boolean;
+}
+
+export function ErrorView({
+  title,
+  message = '오류가 발생했습니다.',
+  onRetry,
+  retryLabel = '다시 시도',
+  className,
+  fullScreen = true,
+}: ErrorViewProps) {
+  const displayMessage = title || message;
+
+  return (
+    <div
+      className={cn(
+        'w-full max-w-md mx-auto flex flex-col items-center justify-center gap-3 p-6 bg-page text-center select-none font-[Pretendard,sans-serif]',
+        fullScreen ? 'h-dvh' : 'flex-1 my-auto min-h-60',
+        className,
+      )}
+    >
+      <p className="typo-body-sm-regular text-sub600 whitespace-pre-line">{displayMessage}</p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="typo-body-sm-regular text-faint underline cursor-pointer hover:text-sub600 transition-colors"
+        >
+          {retryLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/LoadingView.tsx
+++ b/src/components/common/LoadingView.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/utils/cn';
+
+interface LoadingViewProps {
+  message?: string;
+  className?: string;
+  fullScreen?: boolean;
+}
+
+export function LoadingView({
+  message = '로딩 중...',
+  className,
+  fullScreen = true,
+}: LoadingViewProps) {
+  return (
+    <div
+      className={cn(
+        'w-full max-w-md mx-auto flex flex-col items-center justify-center gap-3 p-6 bg-page text-center select-none font-[Pretendard,sans-serif]',
+        fullScreen ? 'h-dvh' : 'flex-1 my-auto min-h-50',
+        className,
+      )}
+    >
+      <div className="loader text-main" />
+      <p className="typo-body-sm-medium text-sub600">{message}</p>
+    </div>
+  );
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,0 +1,3 @@
+export { AsyncBoundary, ErrorBoundary } from './AsyncBoundary';
+export { ErrorView } from './ErrorView';
+export { LoadingView } from './LoadingView';

--- a/src/pages/AnswerPage.tsx
+++ b/src/pages/AnswerPage.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import { ChevronLeft, Eye, EyeOff } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
+import { ErrorView } from '@/components/common';
+
 type TabKey = 'pending' | 'done';
 
 interface Question {
@@ -155,16 +157,16 @@ export function AnswerPage() {
         <Tabs value={tab} onChange={setTab} />
       </div>
 
-      <section className="flex-1 min-h-0 overflow-y-auto px-5 py-5">
-        <div className="flex flex-col gap-[10px]">
-          {items.length === 0 ? (
-            <div className="py-20 text-center typo-body-sm-regular text-faint">
-              아직 항목이 없어요.
-            </div>
-          ) : (
-            items.map((item) => <QuestionCard key={item.id} item={item} />)
-          )}
-        </div>
+      <section className="flex-1 min-h-0 overflow-y-auto px-5 py-5 flex flex-col">
+        {items.length === 0 ? (
+          <ErrorView fullScreen={false} message="답변할 질문 항목이 없어요." />
+        ) : (
+          <div className="flex flex-col gap-[10px]">
+            {items.map((item) => (
+              <QuestionCard key={item.id} item={item} />
+            ))}
+          </div>
+        )}
       </section>
 
       <div className="bg-gradient-to-b from-transparent via-page/75 to-page px-5 pb-2 pt-3">

--- a/src/pages/ArtworkDetailPage.tsx
+++ b/src/pages/ArtworkDetailPage.tsx
@@ -8,6 +8,7 @@ import { ArtworkMeta } from '@/components/artworkdetailpage/ArtworkMeta';
 import { ArtworkSaveButton } from '@/components/artworkdetailpage/ArtworkSaveButton';
 import { ArtworkTabNav } from '@/components/artworkdetailpage/ArtworkTabNav';
 import { GuestbookInputBar } from '@/components/artworkdetailpage/GuestbookInputBar';
+import { ErrorView } from '@/components/common';
 import { BottomFixedBar } from '@/components/displaydetailpage/BottomFixedBar';
 import { HeroSlider } from '@/components/displaydetailpage/HeroSlider';
 import { ARTWORK_DETAILS, GUESTBOOK_QUESTIONS, GUESTBOOK_REVIEWS } from '@/mocks/exhibition';
@@ -70,16 +71,11 @@ export function ArtworkDetailPage() {
 
   if (!artwork) {
     return (
-      <div className="w-full max-w-md mx-auto min-h-dvh flex flex-col items-center justify-center gap-3 bg-page">
-        <p className="typo-body-sm-regular text-sub600">작품 정보를 찾을 수 없습니다.</p>
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          className="typo-body-sm-regular text-faint underline cursor-pointer"
-        >
-          돌아가기
-        </button>
-      </div>
+      <ErrorView
+        title="작품 정보를 찾을 수 없습니다"
+        message="요청하신 작품 정보가 존재하지 않거나 삭제되었습니다."
+        onRetry={() => navigate(-1)}
+      />
     );
   }
 

--- a/src/pages/DisplayContentsPage.tsx
+++ b/src/pages/DisplayContentsPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import type { DisplayContentCategoryDto } from '@/api/dto/display.dto';
 import DUfontlogo from '@/assets/DUfontlogo.svg';
+import { ErrorView, LoadingView } from '@/components/common';
 import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
 import { parseDisplayId } from '@/utils/parseDisplayId';
 
@@ -17,42 +18,17 @@ export function DisplayContentsPage() {
 
   const { data: display, isPending, isError } = useDisplayDetail(displayId ?? 0);
 
-  // 유효하지 않은 ID는 즉시 에러 상태로 처리
-  if (displayId === null) {
-    return (
-      <div className="w-full max-w-md mx-auto min-h-dvh flex flex-col items-center justify-center gap-3 bg-page">
-        <p className="typo-body-sm-regular text-sub600">전시 정보를 찾을 수 없습니다.</p>
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          className="typo-body-sm-regular text-faint underline cursor-pointer"
-        >
-          돌아가기
-        </button>
-      </div>
-    );
-  }
-
   if (isPending) {
-    return (
-      <div className="w-full max-w-md mx-auto min-h-dvh flex items-center justify-center bg-page">
-        <p className="typo-body-sm-regular text-faint">불러오는 중...</p>
-      </div>
-    );
+    return <LoadingView message="전시 콘텐츠를 불러오는 중..." />;
   }
 
-  if (isError || !display) {
+  if (isError || !display || displayId === null) {
     return (
-      <div className="w-full max-w-md mx-auto min-h-dvh flex flex-col items-center justify-center gap-3 bg-page">
-        <p className="typo-body-sm-regular text-sub600">전시 정보를 찾을 수 없습니다.</p>
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          className="typo-body-sm-regular text-faint underline cursor-pointer"
-        >
-          돌아가기
-        </button>
-      </div>
+      <ErrorView
+        title="전시 정보를 찾을 수 없습니다"
+        message="요청하신 전시 정보가 존재하지 않거나 삭제되었습니다."
+        onRetry={() => navigate(-1)}
+      />
     );
   }
 

--- a/src/pages/DisplayDetailPage.tsx
+++ b/src/pages/DisplayDetailPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { useNavigate, useParams } from 'react-router-dom';
 
+import { ErrorView, LoadingView } from '@/components/common';
 import {
   ArtworkTab,
   BottomFixedBar,
@@ -14,7 +15,6 @@ import {
 } from '@/components/displaydetailpage';
 import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
 import type { DetailTabKey } from '@/types/exhibition';
-import { cn } from '@/utils/cn';
 import { parseDisplayId } from '@/utils/parseDisplayId';
 
 export function DisplayDetailPage() {
@@ -26,45 +26,17 @@ export function DisplayDetailPage() {
 
   const { data: display, isPending, isError } = useDisplayDetail(displayId ?? 0);
 
-  const containerClassName =
-    'w-full max-w-md mx-auto min-h-dvh flex flex-col justify-center items-center';
-
-  // 유효하지 않은 ID (숫자가 아니거나 0 이하)는 즉시 에러 상태로 처리
-  if (displayId === null) {
-    return (
-      <div className={cn(containerClassName, 'gap-3 bg-page')}>
-        <p className="typo-body-sm-regular text-sub600">전시 정보를 찾을 수 없습니다.</p>
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          className="typo-body-sm-regular text-faint underline cursor-pointer"
-        >
-          돌아가기
-        </button>
-      </div>
-    );
-  }
-
   if (isPending) {
-    return (
-      <div className={cn(containerClassName, 'bg-page')}>
-        <p className="typo-body-sm-regular text-faint">불러오는 중...</p>
-      </div>
-    );
+    return <LoadingView message="전시 정보를 불러오는 중..." />;
   }
 
-  if (isError || !display) {
+  if (isError || !display || displayId === null) {
     return (
-      <div className={cn(containerClassName, 'gap-3 bg-page')}>
-        <p className="typo-body-sm-regular text-sub600">전시 정보를 찾을 수 없습니다.</p>
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          className="typo-body-sm-regular text-faint underline cursor-pointer"
-        >
-          돌아가기
-        </button>
-      </div>
+      <ErrorView
+        title="전시 정보를 찾을 수 없습니다"
+        message="요청하신 전시 정보가 존재하지 않거나 삭제되었습니다."
+        onRetry={() => navigate(-1)}
+      />
     );
   }
 

--- a/src/pages/LoungeBoardDetailPage.tsx
+++ b/src/pages/LoungeBoardDetailPage.tsx
@@ -1,5 +1,6 @@
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
+import { ErrorView } from '@/components/common';
 import {
   LoungeBoardActionBar,
   LoungeBoardCommentItem,
@@ -10,6 +11,7 @@ import { isLoungeCategoryKey, LOUNGE_CATEGORIES } from '@/constants/loungeCatego
 import { LOUNGE_BOARD_DETAILS } from '@/mocks/exhibition';
 
 export const LoungeBoardDetailPage = () => {
+  const navigate = useNavigate();
   const { category, id } = useParams<{ category: string; id: string }>();
   const isValidCategory = isLoungeCategoryKey(category);
   const review = id ? LOUNGE_BOARD_DETAILS[id] : undefined;
@@ -25,7 +27,7 @@ export const LoungeBoardDetailPage = () => {
 
       {isValidPost ? (
         <main className="flex-1 min-h-0 overflow-y-auto px-5 pt-5 pb-10">
-          <div className="flex flex-col items-center gap-[30px]">
+          <div className="flex flex-col items-center gap-7.5">
             <LoungeBoardPostDetail review={review} />
 
             <div className="w-full flex flex-col items-center gap-7">
@@ -44,7 +46,12 @@ export const LoungeBoardDetailPage = () => {
           </div>
         </main>
       ) : (
-        <p className="typo-body-sm-regular text-hint px-5 pt-5">게시글을 찾을 수 없습니다.</p>
+        <ErrorView
+          fullScreen={false}
+          title="게시글을 찾을 수 없습니다"
+          message="요청하신 게시글이 존재하지 않거나 삭제되었습니다."
+          onRetry={() => navigate(-1)}
+        />
       )}
     </div>
   );

--- a/src/pages/LoungeBoardPage.tsx
+++ b/src/pages/LoungeBoardPage.tsx
@@ -1,10 +1,12 @@
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
+import { ErrorView } from '@/components/common';
 import { LoungeBoardHeader, LoungeBoardPostCard } from '@/components/lounge-board';
 import { isLoungeCategoryKey, LOUNGE_CATEGORIES } from '@/constants/loungeCategories';
 import { LOUNGE_BOARD_POSTS } from '@/mocks/exhibition';
 
 export const LoungeBoardPage = () => {
+  const navigate = useNavigate();
   const { category } = useParams<{ category: string }>();
   const isValidCategory = isLoungeCategoryKey(category);
   const posts = isValidCategory
@@ -18,15 +20,25 @@ export const LoungeBoardPage = () => {
         className="px-5"
       />
 
-      <main className="flex-1 min-h-0 overflow-y-auto px-5 pt-5 pb-10">
-        {isValidCategory ? (
+      <main className="flex-1 min-h-0 overflow-y-auto px-5 pt-5 pb-10 flex flex-col">
+        {isValidCategory && posts.length > 0 ? (
           <div className="flex flex-col gap-3.5">
             {posts.map((post) => (
               <LoungeBoardPostCard key={post.id} post={post} />
             ))}
           </div>
         ) : (
-          <p className="typo-body-sm-regular text-hint">존재하지 않는 게시판입니다.</p>
+          <ErrorView
+            fullScreen={false}
+            title={isValidCategory ? '게시글이 없습니다' : '존재하지 않는 게시판입니다'}
+            message={
+              isValidCategory
+                ? '아직 등록된 게시글이 없어요.'
+                : '요청하신 라운지 게시판을 찾을 수 없습니다.'
+            }
+            onRetry={() => navigate(-1)}
+            retryLabel="돌아가기"
+          />
         )}
       </main>
     </div>

--- a/src/pages/MyActivityPage.tsx
+++ b/src/pages/MyActivityPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { useLocation } from 'react-router-dom';
 
+import { ErrorView } from '@/components/common';
 import { LoungeBoardHeader, LoungeBoardPostCard } from '@/components/lounge-board';
 import { MY_COMMENTED_POSTS, MY_SCRAPPED_POSTS, MY_WRITTEN_POSTS } from '@/mocks/exhibition';
 
@@ -70,12 +71,16 @@ export function MyActivityPage() {
         })}
       </nav>
 
-      <main className="flex-1 min-h-0 overflow-y-auto px-5 pt-5 pb-10">
-        <div className="flex flex-col gap-3.5">
-          {TAB_POSTS[activeTab].map((post) => (
-            <LoungeBoardPostCard key={post.id} post={post} tagLabel={activeTabLabel} />
-          ))}
-        </div>
+      <main className="flex-1 min-h-0 overflow-y-auto px-5 pt-5 pb-10 flex flex-col">
+        {TAB_POSTS[activeTab].length > 0 ? (
+          <div className="flex flex-col gap-3.5">
+            {TAB_POSTS[activeTab].map((post) => (
+              <LoungeBoardPostCard key={post.id} post={post} tagLabel={activeTabLabel} />
+            ))}
+          </div>
+        ) : (
+          <ErrorView fullScreen={false} message={`${activeTabLabel} 항목이 없어요.`} />
+        )}
       </main>
     </div>
   );

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { ErrorView, LoadingView } from '@/components/common';
 import {
   ArtistCard,
   ArtworkCard,
@@ -36,20 +37,15 @@ export function MyPage() {
   };
 
   if (isLoading) {
-    return (
-      <div className="w-full max-w-md mx-auto h-dvh bg-gray-100 flex items-center justify-center">
-        <div className="text-neutral-500 text-sm font-['Pretendard']">로딩 중...</div>
-      </div>
-    );
+    return <LoadingView message="프로필 로딩 중..." />;
   }
 
-  if (error || !userData) {
+  if (!error || !userData) {
     return (
-      <div className="w-full max-w-md mx-auto h-dvh bg-gray-100 flex items-center justify-center">
-        <div className="text-red-500 text-sm font-['Pretendard']">
-          프로필을 불러오는데 실패했습니다.
-        </div>
-      </div>
+      <ErrorView
+        message={error?.message || '프로필 정보를 불러오지 못했습니다.'}
+        onRetry={() => window.location.reload()}
+      />
     );
   }
 

--- a/src/pages/MyQuestionsPage.tsx
+++ b/src/pages/MyQuestionsPage.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import { ChevronLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
+import { ErrorView } from '@/components/common';
+
 const TABS = ['전시', '작품'];
 
 interface Question {
@@ -96,12 +98,16 @@ export function MyQuestionsPage() {
         })}
       </div>
 
-      <section className="flex-1 min-h-0 overflow-y-auto px-5 py-5">
-        <div className="flex flex-col gap-3.5">
-          {QUESTIONS.map((q, i) => (
-            <QuestionCard key={i} q={q} />
-          ))}
-        </div>
+      <section className="flex-1 min-h-0 overflow-y-auto px-5 py-5 flex flex-col">
+        {QUESTIONS.length > 0 ? (
+          <div className="flex flex-col gap-3.5">
+            {QUESTIONS.map((q, i) => (
+              <QuestionCard key={i} q={q} />
+            ))}
+          </div>
+        ) : (
+          <ErrorView fullScreen={false} message="등록된 질문이 없습니다." />
+        )}
       </section>
     </div>
   );

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -207,7 +207,7 @@ export function SearchPage() {
           <div className="flex flex-1 flex-col px-5 pt-4 pb-24">
             {isLoading ? (
               <LoadingView fullScreen={false} message="전시를 검색하는 중..." />
-            ) : !isError ? (
+            ) : isError ? (
               <ErrorView
                 fullScreen={false}
                 title="전시를 불러오지 못했습니다"

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 
 import type { SearchDisplaysRequestDto } from '@/api/dto';
+import { ErrorView, LoadingView } from '@/components/common';
 
 import cancelIcon from '../assets/cancel.svg';
 import filterIcon from '../assets/filter.svg';
@@ -205,13 +206,14 @@ export function SearchPage() {
 
           <div className="flex flex-1 flex-col px-5 pt-4 pb-24">
             {isLoading ? (
-              <p className="flex flex-1 items-center justify-center text-center text-xl text-neutral-400">
-                불러오는 중...
-              </p>
-            ) : isError ? (
-              <p className="flex flex-1 items-center justify-center text-center text-xl text-neutral-400">
-                전시를 불러오지 못했습니다
-              </p>
+              <LoadingView fullScreen={false} message="전시를 검색하는 중..." />
+            ) : !isError ? (
+              <ErrorView
+                fullScreen={false}
+                title="전시를 불러오지 못했습니다"
+                message="검색 결과를 가져오는 중 오류가 발생했습니다."
+                onRetry={() => window.location.reload()}
+              />
             ) : exhibitions.length === 0 ? (
               <p className="flex flex-1 items-center justify-center text-center text-xl text-neutral-400">
                 결과가 없습니다

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -5,3 +5,44 @@
 @import './tokens/semantic.css';
 @import './tokens/theme.css';
 @import './tokens/typography.css';
+
+/* Custom Loader */
+.loader {
+  width: 40px;
+  aspect-ratio: 1;
+  --c: no-repeat
+    linear-gradient(currentColor calc(50% - 10px), #0000 0 calc(50% + 10px), currentColor 0);
+  background:
+    var(--c) 0% 100%,
+    var(--c) 50% 100%,
+    var(--c) 100% 100%;
+  background-size: 19% calc(200% + 20px);
+  animation: l4 1s infinite linear;
+}
+
+@keyframes l4 {
+  33% {
+    background-position:
+      0% 50%,
+      50% 100%,
+      100% 100%;
+  }
+  50% {
+    background-position:
+      0% 0%,
+      50% 50%,
+      100% 100%;
+  }
+  66% {
+    background-position:
+      0% 0%,
+      50% 0%,
+      100% 50%;
+  }
+  100% {
+    background-position:
+      0% 0%,
+      50% 0%,
+      100% 0%;
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용

- 어떤 기능을 개발/수정했는지 요약해주세요.
- 로딩 스피너를 공통컴포넌트로 관리하여 적용했습니다.
- 에러 텍스트를 깔끔하게 분리하여 적용했습니다.

## 🔍 관련 이슈

- close #136

## 🖼️ 스크린샷

- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.
<img width="429" height="928" alt="image" src="https://github.com/user-attachments/assets/22911d50-ed4d-40b7-bff3-0c0e2edbf8df" />

<img width="428" height="929" alt="image" src="https://github.com/user-attachments/assets/83c00993-d7c5-48ff-828c-d49548b61044" />

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 추후 디자인 변경되면 금방 수정 가능합니다 공통 컴포넌트로 분리해둬서


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 공통 로딩 및 오류 화면을 추가했습니다.
  * 비동기 작업 중 로딩 상태와 오류를 일관된 화면으로 표시합니다.
  * 오류 화면에서 재시도 또는 이전 화면으로 이동할 수 있습니다.
  * 전체 화면 및 콘텐츠 영역에 맞춘 표시 옵션을 제공합니다.

* **개선**
  * 주요 페이지의 로딩, 오류, 빈 상태 표시를 통일했습니다.
  * 로딩 애니메이션과 오류 화면 스타일을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->