### PR TITLE
refactor: Footer, Navbar 숨김 페이지 숨김 적용

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -11,71 +11,38 @@ function LayoutContent() {
   const matches = useMatches();
   const [manualFooterHidden, setManualFooterHidden] = useState(false);
 
-  // 하단 네비게이션 바(Navbar) 숨김 경로
-  const hideNavbarPaths = [
-    '/display/',
-    '/artwork/',
-    '/artworks-manage',
-    '/artworks-register',
-    '/exhibition/',
-    '/artist-verification',
-    '/exhibition-register',
-    '/team/manage',
-    '/lounge/review/post',
-    '/auth',
-    '/setting',
-    '/edit-basic-info',
-    '/edit-artist-profile',
-    '/answer-questions',
-    '/invitations/'
-  ];
-  const shouldHideNavbar = hideNavbarPaths.some((path) => location.pathname.startsWith(path));
+  // 하단 네비게이션 바(Navbar) 표시 경로 (화이트리스트)
+  const showNavbarPaths = ['/home', '/search', '/lounge', '/my'];
+  const shouldShowNavbar = showNavbarPaths.some((path) => location.pathname.startsWith(path));
 
-  // Footer(FNB) 선택적 숨김 경로 (기본값: Footer 표시, 안 보일 특수 페이지 등록 가능)
-  const defaultHideFooterPaths = [
-    '/artist-verification',
-    '/lounge/review/post',
-    '/exhibition/manage',
-    '/exhibition/visibility',
-    '/exhibition/register-complete',
-    '/team/manage',
-    '/setting',
-    '/edit-basic-info',
-    '/edit-artist-profile',
-    '/display/manage',
-    '/answer-questions',
-    '/invitations/',
-    '/my-review',
-    '/my-questions',
-    '/policy',
-  ];
-  const isPathFooterHidden = defaultHideFooterPaths.some((path) =>
-    location.pathname.startsWith(path),
-  );
+  // Footer(FNB) 표시 경로 (화이트리스트)
+  const showFooterPaths = ['/home', '/search', '/lounge', '/my'];
+  const isPathFooterShown = showFooterPaths.some((path) => location.pathname.startsWith(path));
 
   // Router handle ({ hideFooter: true }) 기반 숨김
   const isRouteHandleFooterHidden = matches.some(
     (match) => (match.handle as { hideFooter?: boolean })?.hideFooter,
   );
 
-  const shouldHideFooter = manualFooterHidden || isPathFooterHidden || isRouteHandleFooterHidden;
+  const shouldShowFooter = isPathFooterShown && !manualFooterHidden && !isRouteHandleFooterHidden;
 
   return (
     <FooterContext.Provider
       value={{
-        isFooterHidden: shouldHideFooter,
+        isFooterHidden: !shouldShowFooter,
         setFooterHidden: setManualFooterHidden,
       }}
     >
       <div className="min-h-screen flex flex-col justify-between">
-        <main className={`flex-1 ${shouldHideNavbar ? '' : 'pb-3'}`}>
+        <main className={`flex-1 ${shouldShowNavbar ? 'pb-3' : ''}`}>
           <Outlet />
         </main>
 
-        {/* 기본적으로 Footer(FNB) 노출, 선택적으로 안보이도록 설정 가능 */}
-        {!shouldHideFooter && <FNB hasFixedBottomBar={shouldHideNavbar} />}
+        {/* Footer(FNB)는 홈/탐색/라운지/마이에서만 표시 */}
+        {shouldShowFooter && <FNB hasFixedBottomBar={shouldShowNavbar} />}
 
-        {!shouldHideNavbar && (
+        {/* Navbar는 홈/탐색/라운지/마이에서만 표시 */}
+        {shouldShowNavbar && (
           <div className="fixed right-0 bottom-4 left-0 z-50 flex justify-center px-4 pointer-events-none">
             <div className="pointer-events-auto w-full max-w-96 flex justify-center">
               <Navbar />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -12,7 +12,7 @@ function LayoutContent() {
   const [manualFooterHidden, setManualFooterHidden] = useState(false);
 
   // 하단 네비게이션 바(Navbar) 표시 경로 (화이트리스트)
-  const showNavbarPaths = ['/home', '/search', '/lounge', '/my'];
+  const showNavbarPaths = ['/home', '/search', '/lounge', '/my', '/policy', '/invitation-request'];
   const shouldShowNavbar = showNavbarPaths.some((path) => location.pathname.startsWith(path));
 
   // Footer(FNB) 표시 경로 (화이트리스트)

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -12,12 +12,24 @@ function LayoutContent() {
   const [manualFooterHidden, setManualFooterHidden] = useState(false);
 
   // 하단 네비게이션 바(Navbar) 표시 경로 (화이트리스트)
-  const showNavbarPaths = ['/home', '/search', '/lounge', '/my', '/policy', '/invitation-request'];
-  const shouldShowNavbar = showNavbarPaths.some((path) => location.pathname.startsWith(path));
+  const showNavbarPaths = ['/home', '/search', '/lounge'];
+  const exactNavbarPaths = ['/my']; // 정확히 일치해야 하는 경로
+  const hideNavbarPaths = ['/lounge/my-questions']; // 예외: startsWith로 매칭되지만 숨김
+
+  const shouldShowNavbar =
+    (showNavbarPaths.some((path) => location.pathname.startsWith(path)) ||
+      exactNavbarPaths.some((path) => location.pathname === path)) &&
+    !hideNavbarPaths.some((path) => location.pathname.startsWith(path));
 
   // Footer(FNB) 표시 경로 (화이트리스트)
-  const showFooterPaths = ['/home', '/search', '/lounge', '/my'];
-  const isPathFooterShown = showFooterPaths.some((path) => location.pathname.startsWith(path));
+  const showFooterPaths = ['/home', '/search', '/lounge'];
+  const exactFooterPaths = ['/my']; // 정확히 일치해야 하는 경로
+  const hideFooterPaths = ['/lounge/my-questions']; // 예외: startsWith로 매칭되지만 숨김
+
+  const isPathFooterShown =
+    (showFooterPaths.some((path) => location.pathname.startsWith(path)) ||
+      exactFooterPaths.some((path) => location.pathname === path)) &&
+    !hideFooterPaths.some((path) => location.pathname.startsWith(path));
 
   // Router handle ({ hideFooter: true }) 기반 숨김
   const isRouteHandleFooterHidden = matches.some(

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -19,17 +19,35 @@ function LayoutContent() {
     '/artworks-register',
     '/exhibition/',
     '/artist-verification',
-    '/exhibition-register/',
+    '/exhibition-register',
     '/team/manage',
     '/lounge/review/post',
+    '/auth',
+    '/setting',
+    '/edit-basic-info',
+    '/edit-artist-profile',
+    '/answer-questions',
+    '/invitations/'
   ];
   const shouldHideNavbar = hideNavbarPaths.some((path) => location.pathname.startsWith(path));
 
   // Footer(FNB) 선택적 숨김 경로 (기본값: Footer 표시, 안 보일 특수 페이지 등록 가능)
   const defaultHideFooterPaths = [
     '/artist-verification',
-    '/exhibition-register/',
     '/lounge/review/post',
+    '/exhibition/manage',
+    '/exhibition/visibility',
+    '/exhibition/register-complete',
+    '/team/manage',
+    '/setting',
+    '/edit-basic-info',
+    '/edit-artist-profile',
+    '/display/manage',
+    '/answer-questions',
+    '/invitations/',
+    '/my-review',
+    '/my-questions',
+    '/policy',
   ];
   const isPathFooterHidden = defaultHideFooterPaths.some((path) =>
     location.pathname.startsWith(path),


### PR DESCRIPTION
## 📝 작업 내용

- 페이지 별로 Footer, Navbar 숨길 페이지 Layout.tsx의 함수에 적용함 

## 🔍 관련 이슈

- close #157 

## 🧪 테스트 결과

- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 혹시라도 제가 빼먹은게 있다면 적어주시면 감사드리겠습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 홈, 검색, 라운지, 마이 화면에서만 내비게이션 바와 푸터가 표시되도록 정리했습니다.
  * 그 외 화면에서는 내비게이션 바와 푸터가 숨겨져 콘텐츠 영역과 하단 고정 메뉴가 더 일관되게 표시됩니다.
  * 푸터 수동 숨김 설정과 화면별 표시 조건을 함께 적용해 레이아웃 동작을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->