### PR TITLE
refactor: 인증/비회원 예외 처리 및 라우팅 버그 수정

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -58,9 +58,12 @@ axiosInstance.interceptors.response.use(
   },
   (error: AxiosError<ApiResponseDto<unknown>>) => {
     const data = error.response?.data;
-
-    // 비로그인 상태로 로그인이 필요한 요청을 보내면 로그인 페이지로 이동
-    if (error.response?.status === 401 && window.location.pathname !== '/login') {
+    const isRefreshRequest = error.config?.url?.includes('/v1/auth/refresh');
+    if (
+      error.response?.status === 401 &&
+      window.location.pathname !== '/login' &&
+      !isRefreshRequest
+    ) {
       window.location.href = '/login';
     }
 

--- a/src/components/exhibition-register/ExhibitionHeader.tsx
+++ b/src/components/exhibition-register/ExhibitionHeader.tsx
@@ -12,7 +12,7 @@ export function ExhibitionHeader({ title = '전시 기본 정보' }: ExhibitionH
     <div className="relative flex items-center justify-center px-5 py-4 flex-shrink-0">
       <button
         type="button"
-        onClick={() => navigate('/my')}
+        onClick={() => navigate(-1)}
         className="cursor-pointer absolute left-5"
         aria-label="뒤로가기"
       >

--- a/src/components/homepage/DuPickBanner.tsx
+++ b/src/components/homepage/DuPickBanner.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 
 import type { DuPickDto } from '@/api/dto';
 import { useSwipeSlider } from '@/hooks/useSwipeSlider';
+import { useAuthStore } from '@/stores/authStore';
 import type { DuPickItem } from '@/types/exhibition';
 import { cn } from '@/utils/cn';
 
@@ -17,6 +18,7 @@ type Props = {
 
 export function DuPickBanner({ items, className }: Props) {
   const navigate = useNavigate();
+  const accessToken = useAuthStore((state) => state.accessToken);
   const { activeIndex, setActiveIndex, dragOffset, isDragging, handlers } = useSwipeSlider({
     itemCount: items.length,
   });
@@ -40,7 +42,13 @@ export function DuPickBanner({ items, className }: Props) {
         <button
           type="button"
           aria-label="전시 등록 버튼"
-          onClick={() => navigate('/exhibition-register')}
+          onClick={() => {
+            if (!accessToken) {
+              navigate('/login');
+            } else {
+              navigate('/exhibition-register');
+            }
+          }}
           className="cursor-pointer border-none bg-transparent p-0"
         >
           <Plus strokeWidth={1.5} className="size-8" />

--- a/src/pages/ExhibitionRegister.tsx
+++ b/src/pages/ExhibitionRegister.tsx
@@ -14,12 +14,14 @@ import {
 } from '@/constants/exhibition';
 import { useMyArtistProfile } from '@/hooks/queries/useUserProfile';
 import { useImageUpload } from '@/hooks/useImageUpload';
+import { useAuthStore } from '@/stores/authStore';
 
 const INPUT_CLASS =
   'w-full px-3 py-2.5 bg-transparent border-b border-input-border typo-body-xs-regular text-main placeholder:text-input-placeholder outline-none';
 
 export function ExhibitionRegister() {
-  const { data: artistProfile } = useMyArtistProfile();
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const { data: artistProfile } = useMyArtistProfile({ enabled: !!accessToken });
   const imageUpload = useImageUpload({ domain: 'display' });
 
   const [title, setTitle] = useState('');

--- a/src/pages/Settingpage.tsx
+++ b/src/pages/Settingpage.tsx
@@ -2,9 +2,22 @@ import { ChevronRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { SettingHeader, SettingRow, SettingSection } from '@/components/setting';
+import { useLogout } from '@/hooks/queries/useAuth';
 
 export function SettingPage() {
   const navigate = useNavigate();
+  const logoutMutation = useLogout();
+
+  const handleLogout = () => {
+    logoutMutation.mutate(
+      {},
+      {
+        onSuccess: () => {
+          navigate('/login', { replace: true });
+        },
+      },
+    );
+  };
 
   const handleBack = () => {
     navigate('/my');
@@ -89,8 +102,10 @@ export function SettingPage() {
           <button
             type="button"
             className="typo-body-md-semibold h-14 w-full rounded-2xl bg-card text-main"
+            onClick={handleLogout}
+            disabled={logoutMutation.isPending}
           >
-            로그아웃
+            {logoutMutation.isPending ? '로그아웃 중...' : '로그아웃'}
           </button>
           <button
             type="button"


### PR DESCRIPTION
## 📝 작업 내용

### 비회원 접근 가드 (`DuPickBanner.tsx`, `ExhibitionRegister.tsx`)
- 홈 화면 + 버튼(전시 등록) 클릭 시 비회원이면 로그인 페이지로 이동
- `ExhibitionRegister` 페이지 진입 시 비회원이면 `GET /v1/users/me/artist-profile` 쿼리 실행 차단 (404 에러 방지)
### 전시 등록 페이지 뒤로가기 수정 (`ExhibitionHeader.tsx`)
- `navigate('/my')` 하드코딩 → `navigate(-1)`으로 변경하여 항상 이전 화면으로 이동
### Axios Interceptor 비회원 silent refresh 처리 (`axios.ts`)
- `POST /v1/auth/refresh` 401 응답 시 로그인 리다이렉트 제외 처리 (비회원 홈 진입 시 루프 방지)
### 로그아웃 API 연동 (`Settingpage.tsx`)
- 설정 페이지 로그아웃 버튼에 `POST /v1/auth/logout` API 연결
- 로그아웃 성공 시 로그인 페이지로 이동

## 🔍 관련 이슈

- close #163 

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- `axios.ts`에서 develop 브랜치에 먼저 들어온 silent refresh(자동 재발급) 로직과 merge 충돌이 있었습니다. develop 코드가 이미 refresh 엔드포인트 제외 조건을 포함하고 있어 develop 브랜치걸로 병합했습니다.
- 작업할 때 로그아웃 기능이 필요해서 일단 연동해두었습니다. 다들 작업하실 때 마이페이지 설정에 있는 로그아웃 사용해주시면 됩니다.