### PR TITLE
refactor: 메인페이지 북마크 및 라운지섹션 디자인 수정

### DIFF
--- a/.agents/workflows/optimistic-ui.md
+++ b/.agents/workflows/optimistic-ui.md
@@ -1,0 +1,47 @@
+---
+description: Update UI instantly before server confirms (Optimistic UI)
+---
+
+# Optimistic UI Pattern (React Query)
+
+Use this concise pattern to instantly update the UI (0ms delay) on user actions (e.g., bookmark, like, toggle) and automatically rollback on error.
+
+## 1. Setup Optimistic Mutation
+
+```tsx
+const useToggleItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: toggleItemApi,
+    onMutate: async (newItem) => {
+      // 1) Cancel ongoing queries to prevent overwriting optimistic update
+      await queryClient.cancelQueries({ queryKey: ['items'] });
+
+      // 2) Snapshot previous data for rollback
+      const previous = queryClient.getQueryData(['items']);
+
+      // 3) Instantly update cache (0ms UX reaction)
+      queryClient.setQueryData(['items'], (old: any) => [...(old ?? []), newItem]);
+
+      return { previous };
+    },
+    onError: (_err, _newItem, context) => {
+      // 4) Rollback to previous snapshot on error
+      if (context?.previous) {
+        queryClient.setQueryData(['items'], context.previous);
+      }
+    },
+    onSettled: () => {
+      // 5) Final background sync with server
+      queryClient.invalidateQueries({ queryKey: ['items'] });
+    },
+  });
+};
+```
+
+## 2. Key Rules
+
+- Keep `onMutate` concise (only insert/update the required ID/fields).
+- Always return `{ previous }` for rollback.
+- Invalidate queries in `onSettled` for final server sync.

--- a/.agents/workflows/optimistic-ui.md
+++ b/.agents/workflows/optimistic-ui.md
@@ -27,9 +27,11 @@ const useToggleItem = () => {
       return { previous };
     },
     onError: (_err, _newItem, context) => {
-      // 4) Rollback to previous snapshot on error
-      if (context?.previous) {
+      // 4) Rollback to previous snapshot on error (remove cache if no previous data existed)
+      if (context?.previous !== undefined) {
         queryClient.setQueryData(['items'], context.previous);
+      } else {
+        queryClient.removeQueries({ queryKey: ['items'] });
       }
     },
     onSettled: () => {
@@ -44,4 +46,5 @@ const useToggleItem = () => {
 
 - Keep `onMutate` concise (only insert/update the required ID/fields).
 - Always return `{ previous }` for rollback.
+- If no previous cache existed before mutation, remove the query cache in `onError` (`removeQueries`) to prevent leftover dirty optimistic data.
 - Invalidate queries in `onSettled` for final server sync.

--- a/src/api/dto/display.dto.ts
+++ b/src/api/dto/display.dto.ts
@@ -14,6 +14,7 @@ export interface HomeExhibitionDto {
   startedAt: string;
   endedAt: string;
   dayLeft?: number;
+  isArchived?: boolean;
 }
 
 export type ClosingSoonExhibitionDto = HomeExhibitionDto;
@@ -144,7 +145,7 @@ export interface DisplayDetailDto {
   displayFields: string[];
   region: string;
   likeCount: number;
-  isBookmarked?: boolean;
+  isArchived?: boolean;
   period: DisplayPeriodDto;
   artworkContentOpen: DisplayContentOpenType;
   exhibitionContentOpen: DisplayContentOpenType;

--- a/src/components/artworkdetailpage/ArtworkMeta.tsx
+++ b/src/components/artworkdetailpage/ArtworkMeta.tsx
@@ -22,8 +22,8 @@ export function ArtworkMeta({ artwork }: Props) {
   const archivePolicy = useArchivePolicy();
 
   /* 좋아요 상태와 개수는 작품 상세 응답을 그대로 씁니다. */
-  const liked = artwork.isBookmarked ?? false;
-  const likeCount = artwork.bookmarkCount ?? 0;
+  const liked = artwork.isLiked ?? false;
+  const likeCount = artwork.likeCount ?? artwork.bookmarkCount ?? 0;
   const toggleLike = useToggleArtworkLike(artwork.artworkId);
 
   useEffect(() => {
@@ -121,7 +121,7 @@ export function ArtworkMeta({ artwork }: Props) {
       </button>
 
       {!isAtTop && (
-        <ArtworkSaveButton artworkId={artwork.artworkId} saved={artwork.isBookmarked ?? false} />
+        <ArtworkSaveButton artworkId={artwork.artworkId} saved={artwork.isArchived ?? false} />
       )}
       {loginModal}
     </div>

--- a/src/components/common/ErrorView.tsx
+++ b/src/components/common/ErrorView.tsx
@@ -22,7 +22,7 @@ export function ErrorView({
   return (
     <div
       className={cn(
-        'w-full max-w-md mx-auto flex flex-col items-center justify-center gap-3 p-6 bg-page text-center select-none font-[Pretendard,sans-serif]',
+        'w-full max-w-md mx-auto flex flex-col items-center justify-center gap-3 p-6 bg-page text-center select-none',
         fullScreen ? 'h-dvh' : 'flex-1 my-auto min-h-60',
         className,
       )}

--- a/src/components/common/LoadingView.tsx
+++ b/src/components/common/LoadingView.tsx
@@ -14,7 +14,7 @@ export function LoadingView({
   return (
     <div
       className={cn(
-        'w-full max-w-md mx-auto flex flex-col items-center justify-center gap-3 p-6 bg-page text-center select-none font-[Pretendard,sans-serif]',
+        'w-full max-w-md mx-auto flex flex-col items-center justify-center gap-3 p-6 bg-page text-center select-none',
         fullScreen ? 'h-dvh' : 'flex-1 my-auto min-h-50',
         className,
       )}

--- a/src/components/display-manage/ExhibitionMeta.tsx
+++ b/src/components/display-manage/ExhibitionMeta.tsx
@@ -10,7 +10,7 @@ export function ExhibitionMeta({
   return (
     <div className="flex-1 min-w-0">
       {showBadge && (
-        <span className="typo-body-xxs-regular inline-block text-white bg-tag-blue px-2 py-0.5 rounded mb-3">
+        <span className="typo-body-xxs-regular inline-block text-white px-2 py-0.5 rounded mb-3">
           {ex.status}
         </span>
       )}

--- a/src/components/displaydetailpage/DisplaySaveButton.tsx
+++ b/src/components/displaydetailpage/DisplaySaveButton.tsx
@@ -10,7 +10,7 @@ interface DisplaySaveButtonProps {
   className?: string;
   id?: string;
   displayId: number;
-  /* 전시 상세의 isBookmarked. 저장 여부에 따라 버튼 문구가 바뀝니다. */
+  /* 전시 상세의 isArchived. 저장 여부에 따라 버튼 문구가 바뀝니다. */
   saved?: boolean;
 }
 

--- a/src/components/displaydetailpage/ExhibitionMeta.tsx
+++ b/src/components/displaydetailpage/ExhibitionMeta.tsx
@@ -124,7 +124,7 @@ export function ExhibitionMeta({ display: ex }: Props) {
 
       {!isAtTop && (
         <div className="px-1 pt-10">
-          <DisplaySaveButton displayId={ex.displayId} saved={ex.isBookmarked ?? false} />
+          <DisplaySaveButton displayId={ex.displayId} saved={ex.isArchived ?? false} />
         </div>
       )}
       {loginModal}

--- a/src/components/homepage/ArtworkPreviewSection.tsx
+++ b/src/components/homepage/ArtworkPreviewSection.tsx
@@ -47,7 +47,7 @@ export function ArtworkPreviewSection({ items, onMoreClick }: Props) {
 
             <div className="absolute left-3 right-3 bottom-3">
               <p className="typo-body-sm-bold text-white">{item.artworkName}</p>
-              <p className="typo-body-xxs-regular text-tag-gray">{item.artistName}</p>
+              <p className="typo-body-xxs-regular text-bt-gray">{item.artistName}</p>
             </div>
           </Link>
         ))}

--- a/src/components/homepage/ExhibitionSection.tsx
+++ b/src/components/homepage/ExhibitionSection.tsx
@@ -1,9 +1,7 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { Bookmark } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import type { HomeExhibitionDto } from '@/api/dto';
-import { queryKeys } from '@/api/queryKeys';
 import { SectionHeader } from '@/components/homepage/SectionHeader';
 import {
   useArchivedExhibitions,
@@ -55,6 +53,7 @@ function ExhibitionCard({
           type="button"
           aria-label={isSaved ? '북마크 취소' : '북마크'}
           aria-pressed={isSaved}
+          onKeyDown={(e) => e.stopPropagation()}
           onClick={(e) => onBookmarkClick(item.displayId, isSaved, e)}
           className="absolute inset-e-0 bottom-0 px-2.5 pb-2 flex items-end justify-end cursor-pointer"
         >
@@ -93,8 +92,7 @@ export function ExhibitionSection({ title, items, linkTo }: Props) {
   const unarchive = useUnarchiveExhibition();
   const { loginModal, openLoginModal } = useLoginRequiredModal();
   const archivePolicy = useArchivePolicy();
-  const { data: archivedData, isLoading: isArchiveLoading } = useArchivedExhibitions();
-  const queryClient = useQueryClient();
+  const { data: archivedData } = useArchivedExhibitions();
 
   const savedExhibitionIds = new Set(archivedData?.savedExhibitions?.map((s) => s.displayId) ?? []);
 

--- a/src/components/homepage/ExhibitionSection.tsx
+++ b/src/components/homepage/ExhibitionSection.tsx
@@ -1,7 +1,19 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { Bookmark } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import type { HomeExhibitionDto } from '@/api/dto';
+import { queryKeys } from '@/api/queryKeys';
 import { SectionHeader } from '@/components/homepage/SectionHeader';
+import {
+  useArchivedExhibitions,
+  useArchiveExhibition,
+  useUnarchiveExhibition,
+} from '@/hooks/queries/useArchive';
+import { useLoginRequiredModal } from '@/hooks/usePermissionRequiredModal';
+import { useArchivePolicy } from '@/hooks/usePolicy';
+import { cn } from '@/utils/cn';
+import { hasPermission } from '@/utils/hasPermission';
 
 const formatMonthDay = (date: string) => {
   if (!date) return '';
@@ -9,9 +21,18 @@ const formatMonthDay = (date: string) => {
   return `${month}.${day}`;
 };
 
-function ExhibitionCard({ item }: { item: HomeExhibitionDto }) {
+function ExhibitionCard({
+  item,
+  savedExhibitionIds,
+  onBookmarkClick,
+}: {
+  item: HomeExhibitionDto;
+  savedExhibitionIds: Set<number>;
+  onBookmarkClick: (displayId: number, saved: boolean, e: React.MouseEvent) => void;
+}) {
   const navigate = useNavigate();
   const orgDept = [item.organization, item.department].filter(Boolean).join(' ');
+  const isSaved = item.isArchived === true || savedExhibitionIds.has(item.displayId);
 
   return (
     <article
@@ -26,10 +47,27 @@ function ExhibitionCard({ item }: { item: HomeExhibitionDto }) {
         }
       }}
     >
-      <div className="w-full aspect-3/4 rounded-xl shrink-0 overflow-hidden bg-box200">
+      <div className="w-full aspect-3/4 rounded-xl shrink-0 overflow-hidden bg-box200 relative">
         {item.posterImageUrl ? (
           <img src={item.posterImageUrl} alt={item.title} className="w-full h-full object-cover" />
         ) : null}
+        <button
+          type="button"
+          aria-label={isSaved ? '북마크 취소' : '북마크'}
+          aria-pressed={isSaved}
+          onClick={(e) => onBookmarkClick(item.displayId, isSaved, e)}
+          className="absolute inset-e-0 bottom-0 px-2.5 pb-2 flex items-end justify-end cursor-pointer"
+        >
+          <Bookmark
+            className={cn(
+              'size-4.5 drop-shadow-sm transition-colors',
+              isSaved ? 'text-bookmark' : 'text-white',
+            )}
+            strokeWidth={1.8}
+            fill={isSaved ? 'currentColor' : 'transparent'}
+            stroke="currentColor"
+          />
+        </button>
       </div>
       <div className="flex flex-col">
         <p className="typo-body-xs-bold text-main truncate">{item.title}</p>
@@ -51,12 +89,40 @@ type Props = {
 };
 
 export function ExhibitionSection({ title, items, linkTo }: Props) {
+  const archive = useArchiveExhibition();
+  const unarchive = useUnarchiveExhibition();
+  const { loginModal, openLoginModal } = useLoginRequiredModal();
+  const archivePolicy = useArchivePolicy();
+  const { data: archivedData, isLoading: isArchiveLoading } = useArchivedExhibitions();
+  const queryClient = useQueryClient();
+
+  const savedExhibitionIds = new Set(archivedData?.savedExhibitions?.map((s) => s.displayId) ?? []);
+
+  const handleBookmarkClick = (displayId: number, saved: boolean, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (displayId <= 0) return;
+
+    if (!hasPermission(archivePolicy, saved ? 'delete' : 'create')) {
+      openLoginModal();
+      return;
+    }
+
+    const mutation = saved ? unarchive : archive;
+    mutation.mutate(displayId);
+  };
+
   return (
     <section className="mb-7">
+      {loginModal}
       <SectionHeader title={title} linkTo={linkTo} />
       <div className="grid grid-cols-3 gap-2 px-4">
         {items.map((item) => (
-          <ExhibitionCard key={item.displayId} item={item} />
+          <ExhibitionCard
+            key={item.displayId}
+            item={item}
+            savedExhibitionIds={savedExhibitionIds}
+            onBookmarkClick={handleBookmarkClick}
+          />
         ))}
       </div>
     </section>

--- a/src/components/homepage/LoungeSection.tsx
+++ b/src/components/homepage/LoungeSection.tsx
@@ -12,7 +12,7 @@ export function LoungeSection({ posts }: Props) {
       <SectionHeader title="라운지" linkTo="/lounge" />
       <div>
         {posts.map((post) => (
-          <LoungePostCard key={post.loungePostId} post={post} className="mx-4 mb-3" />
+          <LoungePostCard key={post.loungePostId} post={post} className="mx-5 mb-3" />
         ))}
       </div>
     </section>

--- a/src/components/layout/FNB.tsx
+++ b/src/components/layout/FNB.tsx
@@ -22,7 +22,7 @@ export function FNB({ hasFixedBottomBar = false, className }: FNBProps) {
   return (
     <footer
       className={cn(
-        'w-full max-w-md mx-auto bg-line-soft px-4 sm:px-7.5 pt-6 overflow-hidden',
+        'w-full max-w-md mx-auto bg-fnb px-6.5 py-6 overflow-hidden',
         hasFixedBottomBar ? 'pb-28' : 'pb-8',
         className,
       )}
@@ -35,7 +35,7 @@ export function FNB({ hasFixedBottomBar = false, className }: FNBProps) {
         </div>
 
         {/* 크레딧 목록 */}
-        <div className="flex flex-wrap items-start gap-x-4 gap-y-4 sm:gap-x-7">
+        <div className="flex flex-wrap items-start gap-7">
           {credits.map((item) => (
             <div className="flex flex-col gap-0.5 shrink-0" key={item.role}>
               <p className="typo-body-xs-regular text-hint">{item.role}</p>

--- a/src/components/lounge-board/LoungeBoardPostCard.tsx
+++ b/src/components/lounge-board/LoungeBoardPostCard.tsx
@@ -21,8 +21,8 @@ export function LoungeBoardPostCard({ post, tagLabel }: Props) {
       tabIndex={0}
       onKeyDown={(e) => e.key === 'Enter' && navigate(detailPath)}
     >
-      <span className="self-start h-5 px-2 py-0.5 bg-tag-gray rounded-sm inline-flex items-center">
-        <span className="typo-body-xxs-bold text-tag-blue whitespace-nowrap">
+      <span className="self-start h-5 px-2 py-0.5 bg-tag-bg rounded-sm inline-flex items-center">
+        <span className="typo-body-xxs-bold text-tag-fg whitespace-nowrap">
           {tagLabel ?? LOUNGE_CATEGORY_TAGS[post.category]}
         </span>
       </span>

--- a/src/components/mypage/MyPageHeader.tsx
+++ b/src/components/mypage/MyPageHeader.tsx
@@ -44,7 +44,7 @@ export function MyPageHeader({
           <h1 className="typo-heading-3xl text-main">My Page</h1>
           {isArtistVerified && isArtistView && (
             <span className="inline-flex items-center px-2.5 py-1 bg-sky-100 rounded-sm">
-              <span className="text-tag-blue typo-body-xs-regular">작가인증</span>
+              <span className="text-tag-fg typo-body-xs-regular">작가인증</span>
             </span>
           )}
         </div>

--- a/src/components/search/ExhibitionMapCard.tsx
+++ b/src/components/search/ExhibitionMapCard.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 
-import { Bookmark, MapPin } from 'lucide-react';
+import { Bookmark, Calendar, MapPin } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import type { NearbyDisplay } from '../../hooks/useNearbyDisplays';
@@ -56,27 +56,23 @@ export function ExhibitionMapCard({
     <Link
       to={`/display/${exhibition.displayId}`}
       onClick={handleCardClick}
-      className={`flex w-full cursor-pointer items-start gap-3 rounded-2xl p-3.5 text-left no-underline shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04),inset_1px_1px_4px_0px_rgba(1,8,21,0.20),inset_-2px_-2px_2px_0px_rgba(255,255,255,0.90)] ${
-        selected ? 'bg-box outline outline-1 -outline-offset-1 outline-line' : 'bg-box100'
-      }`}
+      className="flex justify-between items-center w-full py-4.5 bg-white border-b border-line cursor-pointer"
     >
-      <img
-        src={exhibition.posterImageUrl}
-        alt=""
-        className="h-32 w-24 shrink-0 rounded-xl bg-box200 object-cover"
-      />
+      <div className="flex gap-4.5 overflow-hidden">
+        <div className="size-[84px] shrink-0 rounded-lg overflow-hidden bg-box">
+          <img
+            src={exhibition.posterImageUrl}
+            alt={exhibition.title}
+            className="size-full object-cover"
+          />
+        </div>
 
-      <div className="flex flex-1 flex-col gap-4">
-        <span className="w-fit rounded-sm bg-box200 px-2 py-0.5">
-          <span className="typo-body-xxs-regular text-main">{exhibition.status}</span>
-        </span>
+        <div className="flex flex-col gap-2 min-w-0">
+          <h3 className="typo-body-base-bold text-main truncate">{exhibition.title}</h3>
 
-        <div className="flex flex-col gap-2.5">
-          <h3 className="typo-body-md-bold text-main">{exhibition.title}</h3>
-
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col">
-              <span className="typo-body-xs-regular text-sub700">{exhibition.hostName}</span>
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-1">
+              <Calendar className="size-2.5 text-faint" strokeWidth={1.7} aria-hidden />
               <span className="typo-body-xs-regular text-hint">{exhibition.period}</span>
             </div>
 
@@ -90,7 +86,6 @@ export function ExhibitionMapCard({
 
       <button
         type="button"
-        aria-label={exhibition.isBookmarked ? '북마크 해제' : '북마크'}
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
@@ -98,11 +93,7 @@ export function ExhibitionMapCard({
         }}
         className="shrink-0 focus:outline-none focus:ring-2 focus:ring-main focus:ring-offset-2"
       >
-        <Bookmark
-          className={exhibition.isBookmarked ? 'size-4 fill-main text-main' : 'size-4 text-faint'}
-          strokeWidth={1.2}
-          aria-hidden
-        />
+        <Bookmark className="size-4 text-faint" strokeWidth={1.2} aria-hidden />
       </button>
     </Link>
   );

--- a/src/components/team-manage/StatusBadge.tsx
+++ b/src/components/team-manage/StatusBadge.tsx
@@ -17,7 +17,7 @@ export function StatusBadge({ status }: StatusBadgeProps) {
   return (
     <span
       className={`typo-body-xs-regular shrink-0 rounded-sm px-2.5 py-1 text-center ${
-        accent ? 'bg-tag-gray text-link' : 'bg-box200 text-main'
+        accent ? 'bg-tag-bg text-link' : 'bg-box200 text-main'
       }`}
     >
       {STATUS_LABEL[status]}

--- a/src/components/ui/LoungePostCard.tsx
+++ b/src/components/ui/LoungePostCard.tsx
@@ -40,6 +40,7 @@ export function LoungePostCard({ post, className = '' }: LoungePostCardProps) {
       tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
           handleClick();
         }
       }}

--- a/src/components/ui/LoungePostCard.tsx
+++ b/src/components/ui/LoungePostCard.tsx
@@ -1,4 +1,7 @@
+import { useNavigate } from 'react-router-dom';
+
 import type { LoungePostSummaryDto } from '@/api/dto';
+import { toLoungeCategoryKey } from '@/constants/loungeCategories';
 
 const CATEGORY_LABEL: Record<string, string> = {
   WORK_TIP: '준비·작업 팁',
@@ -22,26 +25,37 @@ type LoungePostCardProps = {
 };
 
 export function LoungePostCard({ post, className = '' }: LoungePostCardProps) {
-  const { category, title, content, writer, createdAt, commentCount } = post;
+  const navigate = useNavigate();
+  const { category, loungePostId, title, writer, createdAt, commentCount } = post;
+  const categoryKey = toLoungeCategoryKey(category) ?? 'review';
+
+  const handleClick = () => {
+    navigate(`/lounge/${categoryKey}/${loungePostId}`);
+  };
 
   return (
     <div
-      className={`px-4 py-3.5 bg-card rounded-lg shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)] flex flex-col gap-2.5 ${className}`}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          handleClick();
+        }
+      }}
+      className={`cursor-pointer px-4 py-3.5 bg-card rounded-lg shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)] border border-line-soft flex flex-col gap-2.5 overflow-hidden ${className}`}
     >
       <div className="flex justify-between items-start w-full">
-        <div className="flex flex-col gap-2 flex-1 min-w-0">
-          <div className="px-2 py-0.5 bg-bt-gray rounded-sm inline-flex items-center self-start">
-            <span className="text-link text-[10px] font-bold">
+        <div className="flex flex-col gap-3 flex-1 min-w-0">
+          <div className="px-2 py-0.5 bg-tag-bg rounded-sm inline-flex items-center self-start">
+            <span className="text-tag-fg typo-body-xxs-regular">
               {CATEGORY_LABEL[category] ?? category}
             </span>
           </div>
 
           <div className="flex flex-col gap-1 w-full min-w-0">
             <p className="typo-body-sm-bold text-main truncate">{title}</p>
-            {content ? (
-              <p className="typo-body-xs-regular text-sub600 truncate">{content}</p>
-            ) : null}
-            <div className="flex items-center gap-2 typo-body-xs-regular text-faint mt-0.5">
+            <div className="flex items-center gap-2 typo-body-xs-regular text-faint">
               <span>{writer?.nickname}</span>
               <span>·</span>
               <span>{formatRelativeTime(createdAt)}</span>

--- a/src/components/ui/SaveButtonUI.tsx
+++ b/src/components/ui/SaveButtonUI.tsx
@@ -24,7 +24,7 @@ export function SaveButtonUI({
       type="button"
       id={id}
       onClick={onClick}
-      className={`w-full py-3.5 rounded-xl text-[15px] font-bold font-[Pretendard,sans-serif] tracking-tight transition-all duration-200 active:scale-[0.98] flex items-center justify-center gap-2 ${
+      className={`w-full py-3.5 rounded-xl text-[15px] font-bold tracking-tight transition-all duration-200 active:scale-[0.98] flex items-center justify-center gap-2 ${
         isDark ? 'bg-[#111] text-white' : 'bg-white border border-[#e0e0e0] text-[#111]'
       } ${className}`}
     >

--- a/src/hooks/queries/useArchive.ts
+++ b/src/hooks/queries/useArchive.ts
@@ -3,7 +3,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
   ArchivedExhibitionDto,
   ArchiveMemoRequestDto,
-  DisplayDetailDto,
   GetArchivedArtworksResponseDataDto,
   GetArchivedExhibitionsResponseDataDto,
 } from '@/api/dto';
@@ -101,8 +100,10 @@ export const useArchiveExhibition = () => {
       return { previousList };
     },
     onError: (_, __, context) => {
-      if (context?.previousList) {
+      if (context?.previousList !== undefined) {
         queryClient.setQueryData(queryKeys.archives.displays.list(), context.previousList);
+      } else {
+        queryClient.removeQueries({ queryKey: queryKeys.archives.displays.list() });
       }
     },
     onSettled: (_, __, exhibitionId) => {
@@ -137,8 +138,10 @@ export const useUnarchiveExhibition = () => {
       return { previousList };
     },
     onError: (_, __, context) => {
-      if (context?.previousList) {
+      if (context?.previousList !== undefined) {
         queryClient.setQueryData(queryKeys.archives.displays.list(), context.previousList);
+      } else {
+        queryClient.removeQueries({ queryKey: queryKeys.archives.displays.list() });
       }
     },
     onSettled: (_, __, exhibitionId) => {

--- a/src/hooks/queries/useArchive.ts
+++ b/src/hooks/queries/useArchive.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type {
+  ArchivedExhibitionDto,
   ArchiveMemoRequestDto,
+  DisplayDetailDto,
   GetArchivedArtworksResponseDataDto,
   GetArchivedExhibitionsResponseDataDto,
 } from '@/api/dto';
@@ -79,12 +81,35 @@ export const useArchiveExhibition = () => {
 
   return useMutation({
     mutationFn: archiveExhibition,
-    onSuccess: (_, exhibitionId) =>
-      Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.all() }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(exhibitionId) }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() }),
-      ]),
+    onMutate: async (exhibitionId) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.archives.displays.all() });
+
+      const previousList = queryClient.getQueryData<GetArchivedExhibitionsResponseDataDto>(
+        queryKeys.archives.displays.list(),
+      );
+
+      const newItem = { displayId: exhibitionId } as ArchivedExhibitionDto;
+
+      queryClient.setQueryData<GetArchivedExhibitionsResponseDataDto>(
+        queryKeys.archives.displays.list(),
+        (old) => ({
+          ...old,
+          savedExhibitions: [...(old?.savedExhibitions ?? []), newItem],
+        }),
+      );
+
+      return { previousList };
+    },
+    onError: (_, __, context) => {
+      if (context?.previousList) {
+        queryClient.setQueryData(queryKeys.archives.displays.list(), context.previousList);
+      }
+    },
+    onSettled: (_, __, exhibitionId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(exhibitionId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() });
+    },
   });
 };
 
@@ -93,12 +118,34 @@ export const useUnarchiveExhibition = () => {
 
   return useMutation({
     mutationFn: unarchiveExhibition,
-    onSuccess: (_, exhibitionId) =>
-      Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.all() }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(exhibitionId) }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() }),
-      ]),
+    onMutate: async (exhibitionId) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.archives.displays.all() });
+
+      const previousList = queryClient.getQueryData<GetArchivedExhibitionsResponseDataDto>(
+        queryKeys.archives.displays.list(),
+      );
+
+      queryClient.setQueryData<GetArchivedExhibitionsResponseDataDto>(
+        queryKeys.archives.displays.list(),
+        (old) => ({
+          ...old,
+          savedExhibitions:
+            old?.savedExhibitions?.filter((s) => s.displayId !== exhibitionId) ?? [],
+        }),
+      );
+
+      return { previousList };
+    },
+    onError: (_, __, context) => {
+      if (context?.previousList) {
+        queryClient.setQueryData(queryKeys.archives.displays.list(), context.previousList);
+      }
+    },
+    onSettled: (_, __, exhibitionId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.archives.displays.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(exhibitionId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() });
+    },
   });
 };
 

--- a/src/hooks/useNearbyDisplays.ts
+++ b/src/hooks/useNearbyDisplays.ts
@@ -21,7 +21,7 @@ export interface NearbyDisplay {
   placeName: string;
   latitude: number;
   longitude: number;
-  isBookmarked: boolean; // 현재 API에 없음, 추후 추가 필요
+  isArchived: boolean; // 현재 API에 없음, 추후 추가 필요
 }
 
 export interface NearbyParams {
@@ -66,7 +66,7 @@ async function fetchNearbyDisplays(params: NearbyParams): Promise<NearbyDisplay[
     placeName: marker.locationName,
     latitude: marker.latitude,
     longitude: marker.longitude,
-    isBookmarked: false, // TODO: 북마크 API 연동 필요
+    isArchived: false, // TODO: 북마크 API 연동 필요
   }));
 }
 

--- a/src/pages/ArtworkDetailPage.tsx
+++ b/src/pages/ArtworkDetailPage.tsx
@@ -219,7 +219,8 @@ export function ArtworkDetailPage() {
     exhibitionPeriod: detail.exhibitionInfo?.exhibitionPeriod ?? '',
     exhibitionThumbnail: displayPoster,
     bookmarkCount: detail.likeCount ?? 0,
-    isBookmarked: detail.isLiked ?? false,
+    isLiked: detail.isLiked ?? false,
+    isArchived: false,
   };
 
   /* 썸네일로 지정된 이미지를 앞에 두고, 없으면 등록 순서대로 보여줍니다. */

--- a/src/pages/DisplayDetailPage.tsx
+++ b/src/pages/DisplayDetailPage.tsx
@@ -54,10 +54,7 @@ export function DisplayDetailPage() {
       {activeTab !== 'review' && (
         <BottomFixedBar
           button={
-            <DisplaySaveButton
-              displayId={display.displayId}
-              saved={display.isBookmarked ?? false}
-            />
+            <DisplaySaveButton displayId={display.displayId} saved={display.isArchived ?? false} />
           }
         />
       )}

--- a/src/pages/EditArtistProfilePage.tsx
+++ b/src/pages/EditArtistProfilePage.tsx
@@ -219,7 +219,7 @@ function EditArtistProfileForm({ artistProfile }: { artistProfile?: ArtistProfil
               value={externalLink}
               onChange={(e) => setExternalLink(e.target.value)}
               placeholder="포트폴리오, 인스타그램, 개인 웹사이트 링크"
-              className="h-11 rounded-2xl bg-card px-3.5 typo-body-sm-regular text-tag-blue outline-none placeholder:text-faint"
+              className="h-11 rounded-2xl bg-card px-3.5 typo-body-sm-regular text-tag-fg outline-none placeholder:text-faint"
             />
           </div>
 

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -94,7 +94,7 @@ export const Homepage = () => {
   }
 
   return (
-    <div className="w-full max-w-md mx-auto bg-page min-h-dvh overflow-x-hidden pt-2.5 pb-20 font-[Pretendard,sans-serif]">
+    <div className="w-full max-w-md mx-auto bg-page min-h-dvh overflow-x-hidden pt-2.5">
       {loginModal}
       {artistVerificationModal}
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -226,9 +226,26 @@ export function LoginPage() {
         onGuest={async () => {
           try {
             await logout({});
-          } catch {
-            // Ignore error if not logged in
-          } finally {
+            useAuthStore.getState().clearAuth();
+            navigate('/home');
+          } catch (err: unknown) {
+            const status =
+              (err as { status?: number; response?: { status?: number } })?.status ??
+              (err as { response?: { status?: number } })?.response?.status;
+
+            const isServerErrorOrNetwork =
+              (status !== undefined && status >= 500) ||
+              (err as { code?: string })?.code === 'ERR_NETWORK' ||
+              (err as Error)?.message === 'Network Error' ||
+              (err as Error)?.message?.includes('Network');
+
+            if (isServerErrorOrNetwork) {
+              setAuthError(
+                (err as Error)?.message || '로그아웃 처리 중 네트워크/서버 오류가 발생했습니다.',
+              );
+              return;
+            }
+
             useAuthStore.getState().clearAuth();
             navigate('/home');
           }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -54,7 +54,7 @@ function LoginContent({
   error?: string;
 }) {
   return (
-    <main className="relative flex h-dvh w-full flex-col overflow-hidden bg-page font-[Pretendard,sans-serif]">
+    <main className="relative flex h-dvh w-full flex-col overflow-hidden bg-page">
       {/* Background Image - Wall-to-Wall */}
       <img
         src={onboardingSplash}
@@ -217,7 +217,7 @@ export function LoginPage() {
   }, []);
 
   return (
-    <div className="flex min-h-dvh w-full items-center justify-center bg-page font-[Pretendard,sans-serif]">
+    <div className="flex min-h-dvh w-full items-center justify-center bg-page">
       <LoginContent
         isLogoVisible={isLogoVisible}
         isUIReady={isUIReady}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,11 +2,13 @@ import { useEffect, useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
+import { logout } from '@/api/endpoints';
 import googleIcon from '@/assets/onboarding/googleIcon.svg';
 import kakaoIcon from '@/assets/onboarding/kakaoIcon.svg';
 import loginLogo from '@/assets/onboarding/login-logo.svg';
 import onboardingSplash from '@/assets/onboarding/onboarding-splash.png';
 import { useGoogleAuthorizationUrl, useKakaoAuthorizationUrl } from '@/hooks/queries/useAuth';
+import { useAuthStore } from '@/stores/authStore';
 import { cn } from '@/utils/cn';
 
 const LOGIN_ASSETS = [loginLogo, kakaoIcon, googleIcon, onboardingSplash];
@@ -221,7 +223,16 @@ export function LoginPage() {
         isUIReady={isUIReady}
         isStartingOAuth={isStartingOAuth}
         error={authError}
-        onGuest={() => navigate('/home')}
+        onGuest={async () => {
+          try {
+            await logout({});
+          } catch {
+            // Ignore error if not logged in
+          } finally {
+            useAuthStore.getState().clearAuth();
+            navigate('/home');
+          }
+        }}
         onKakao={() => {
           void startOAuthLogin('kakao');
         }}

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -273,7 +273,7 @@ const POLICY_DOCUMENTS: Record<
 
 function MobileShell({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-dvh w-full items-center justify-center bg-[#f0f0f0] font-[Pretendard,sans-serif]">
+    <div className="flex min-h-dvh w-full items-center justify-center bg-[#f0f0f0]">
       <div className="relative flex h-dvh w-full max-w-md flex-col overflow-hidden bg-white">
         {children}
       </div>

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -55,8 +55,8 @@
   --modal-btn-hover-fg: var(--palette-gray-white);
 
   /* Tag */
-  --tag-blue: var(--palette-blue);
-  --tag-gray: var(--palette-token-200);
+  --tag-bg: var(--palette-token-200);
+  --tag-fg: var(--palette-gray-black);
 
   /* Button */
   --bt-gray: var(--palette-gray-200);

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -17,6 +17,7 @@
   --bg-heart: var(--palette-red);
   --bg-bookmark: var(--palette-gray-300);
   --bg-logo: var(--palette-navy);
+  --bg-fnb: var(--palette-gray-200);
 
   /* Foreground — 텍스트와 아이콘이 같은 스케일을 공유한다 */
   --fg-main: var(--palette-gray-black);

--- a/src/styles/tokens/theme.css
+++ b/src/styles/tokens/theme.css
@@ -56,8 +56,8 @@
   --color-modal-btn-hover-fg: var(--modal-btn-hover-fg);
 
   /* Tag */
-  --color-tag-blue: var(--tag-blue);
-  --color-tag-gray: var(--tag-gray);
+  --color-tag-bg: var(--tag-bg);
+  --color-tag-fg: var(--tag-fg);
 
   /* Button */
   --color-bt-gray: var(--bt-gray);

--- a/src/styles/tokens/theme.css
+++ b/src/styles/tokens/theme.css
@@ -18,6 +18,7 @@
   --color-heart: var(--bg-heart);
   --color-bookmark: var(--bg-bookmark);
   --color-logo: var(--bg-logo);
+  --color-fnb: var(--bg-fnb);
 
   /* Foreground (text + icon) */
   --color-main: var(--fg-main);

--- a/src/types/exhibition.ts
+++ b/src/types/exhibition.ts
@@ -80,7 +80,7 @@ export interface ExhibitionDetail {
   hours: string;
   location: string;
   bookmarkCount: number;
-  isBookmarked: boolean;
+  isArchived: boolean;
   heroImages: string[];
   description: string;
   contentImages: string[];
@@ -137,7 +137,9 @@ export interface ArtworkDetail {
   exhibitionPeriod: string;
   exhibitionThumbnail: string;
   bookmarkCount: number;
-  isBookmarked: boolean;
+  isArchived: boolean;
+  isLiked?: boolean;
+  likeCount?: number;
 }
 
 export interface GuestbookReviewReply {

--- a/src/utils/mypage.ts
+++ b/src/utils/mypage.ts
@@ -1,3 +1,3 @@
 export function statusBadgeClass(status: string): string {
-  return status.includes('종료') ? 'bg-tag-gray' : 'bg-tag-gray';
+  return status.includes('종료') ? 'bg-tag-bg' : 'bg-tag-bg';
 }


### PR DESCRIPTION
## 📝 작업 내용

- 메인페이지 라운지 섹션 카드 디자인 수정
- 태그 디자인토큰 수정
- 이제 라운지섹션 카드를 클릭하면 해당 게시글로 이동됩니다.
- 메인페이지 전시카드에 북마크 기능 추가
- 북마크에 낙관적업데이트 적용
- 저장 관련 isBookmarked를 isArchived로 통일

## 🔍 관련 이슈

- close #178 

## 🖼️ 스크린샷

<img width="386" height="540" alt="image" src="https://github.com/user-attachments/assets/43f8faf3-dd81-4341-a2bc-50827c6e82ee" />
<img width="384" height="391" alt="image" src="https://github.com/user-attachments/assets/d8c20f36-d383-46fb-845d-4b995d750b22" />

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 참고사항
- 푸시할 때 올라간 optimistic-ui.md는 무시하셔도 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 홈 전시 카드에서 전시를 저장하거나 저장 해제할 수 있습니다.
  - 비로그인 상태에서 저장 시 로그인 안내가 표시됩니다.
  - 라운지 게시물 카드를 클릭하거나 키보드로 선택해 상세 페이지로 이동할 수 있습니다.
  - 저장 상태 변경이 즉시 반영되며, 오류 발생 시 이전 상태로 복구됩니다.

- **개선 사항**
  - 작품의 좋아요 상태와 개수가 올바르게 표시됩니다.
  - 전시 검색 카드가 목록형 레이아웃으로 개선되었습니다.
  - 하단 메뉴, 태그, 여백 및 글꼴 스타일이 조정되었습니다.

- **문서**
  - 낙관적 UI 구현 가이드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->