### PR TITLE
fix : api 연동 1차 확인

### DIFF
--- a/src/components/exhibition-register/AffiliationInput.tsx
+++ b/src/components/exhibition-register/AffiliationInput.tsx
@@ -6,9 +6,8 @@ interface AffiliationInputProps {
   onSchoolChange: (school: string) => void;
   department: string;
   onDepartmentChange: (department: string) => void;
-  organizer: string;
-  onOrganizerChange: (organizer: string) => void;
   readonly?: boolean;
+  isDepartmentRequired?: boolean;
 }
 
 export function AffiliationInput({
@@ -17,9 +16,8 @@ export function AffiliationInput({
   onSchoolChange,
   department,
   onDepartmentChange,
-  organizer,
-  onOrganizerChange,
   readonly = false,
+  isDepartmentRequired = true,
 }: AffiliationInputProps) {
   if (group === 'institution') {
     return (
@@ -31,7 +29,9 @@ export function AffiliationInput({
         <div className="bg-card px-4 py-3.5 flex flex-col gap-2">
           <label htmlFor="department-input" className="flex items-center gap-1">
             <span className="text-sub700 typo-body-xs-bold leading-4">세부소속</span>
-            <span className="text-red-400 typo-body-xs-regular leading-5">*</span>
+            {isDepartmentRequired && (
+              <span className="text-red-400 typo-body-xs-regular leading-5">*</span>
+            )}
           </label>
           <input
             id="department-input"
@@ -46,20 +46,18 @@ export function AffiliationInput({
   }
 
   return (
-    <div
-      className={`rounded-2xl outline outline-1 outline-offset-[-1px] outline-line ${readonly ? 'overflow-hidden' : ''}`}
-    >
-      <div className="bg-card px-4 py-3.5 flex flex-col gap-2">
+    <div className={`bg-neutral-50 rounded-2xl ${readonly ? 'overflow-hidden' : ''}`}>
+      <div className="px-4 py-3.5 flex flex-col gap-2">
         <label htmlFor="organizer-input" className="flex items-center gap-1">
-          <span className="text-sub700 typo-body-xs-bold leading-4">주최 / 소속명</span>
+          <span className="text-dark typo-body-xs-bold leading-4">주최 / 소속명</span>
           <span className="text-red-400 typo-body-xs-regular leading-5">*</span>
         </label>
         <input
           id="organizer-input"
-          value={organizer}
-          onChange={(e) => onOrganizerChange(e.target.value)}
+          value={school}
+          onChange={(e) => onSchoolChange(e.target.value)}
           placeholder="팀, 모임, 연합명을 입력해주세요"
-          className="h-10 px-3 bg-input-soft-bg rounded-2xl outline outline-1 outline-offset-[-1px] outline-line-soft typo-body-sm-regular text-main placeholder:text-hint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          className="h-10 px-3 bg-input-soft-bg rounded-2xl outline -outline-offset-1 outline-input-soft-border typo-body-sm-regular text-main placeholder:text-hint focus:outline-input-soft-border"
         />
       </div>
     </div>

--- a/src/components/exhibition-register/SchoolSearchInput.tsx
+++ b/src/components/exhibition-register/SchoolSearchInput.tsx
@@ -48,9 +48,10 @@ export function SchoolSearchInput({ value, onChange, readonly = false }: SchoolS
             value={inputValue}
             onChange={(e) => {
               if (!readonly) {
-                setSchoolQuery(e.target.value);
+                const val = e.target.value;
+                setSchoolQuery(val);
                 setSchoolOpen(true);
-                onChange('');
+                onChange(val);
               }
             }}
             onFocus={handleSchoolFocus}

--- a/src/components/homepage/ArtworkPreviewMoreView.tsx
+++ b/src/components/homepage/ArtworkPreviewMoreView.tsx
@@ -3,68 +3,57 @@ import { useEffect, useState } from 'react';
 import { ChevronLeft, X } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
-import type { ArtworkPreviewItemDto } from '@/api/dto';
+import { useInfiniteArtworkPreview } from '@/hooks/queries/useHome';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { cn } from '@/utils/cn';
 
 import { FILTER_CONFIG } from '../search';
 
 // '전체' 옵션을 제외한 순수 카테고리 필터 목록
 const CATEGORY_OPTIONS = FILTER_CONFIG.전시분야.options.filter((opt) => opt.value !== null);
-const CATEGORY_LABELS = CATEGORY_OPTIONS.map((opt) => opt.label);
 
 type Props = {
-  items: ArtworkPreviewItemDto[];
   onClose?: () => void;
 };
 
-// 각 작품의 카테고리를 매핑하는 헬퍼 함수
-function getItemCategory(item: ArtworkPreviewItemDto, index: number): string {
-  for (const cat of CATEGORY_LABELS) {
-    if (
-      item.artworkName.includes(cat) ||
-      item.exhibitionInfo?.exhibitionTitle?.includes(cat) ||
-      ('field' in item && typeof item.field === 'string' && item.field.includes(cat))
-    ) {
-      return cat;
-    }
-  }
-  // 목 데이터에 분야명이 직접 포함되지 않은 경우 인덱스로 균등 분배
-  return CATEGORY_LABELS[index % CATEGORY_LABELS.length];
-}
+export function ArtworkPreviewMoreView({ onClose }: Props) {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
-export function ArtworkPreviewMoreView({ items, onClose }: Props) {
-  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  // 카테고리 칩 선택 값에 해당하는 API 파라미터 값 추출
+  const apiType = selectedCategory
+    ? CATEGORY_OPTIONS.find((opt) => opt.label === selectedCategory)?.value || undefined
+    : undefined;
+
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isPending, isError } =
+    useInfiniteArtworkPreview({ type: apiType });
+
+  const artworks = data?.pages.flatMap((page) => page.artworks) ?? [];
+
+  const triggerRef = useInfiniteScroll({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   // 마운트 시 최상단으로 자동 스크롤
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
-  // 카테고리 다중 선택 토글 핸들러
+  // 카테고리 단일 선택 토글 핸들러
   const handleToggleCategory = (label: string) => {
-    setSelectedCategories((prev) =>
-      prev.includes(label) ? prev.filter((cat) => cat !== label) : [...prev, label],
-    );
+    setSelectedCategory((prev) => (prev === label ? null : label));
   };
 
   // 개별 카테고리 삭제
-  const handleRemoveCategory = (label: string) => {
-    setSelectedCategories((prev) => prev.filter((cat) => cat !== label));
+  const handleRemoveCategory = () => {
+    setSelectedCategory(null);
   };
 
   // 전체 선택 해제 (초기화)
   const handleResetCategories = () => {
-    setSelectedCategories([]);
+    setSelectedCategory(null);
   };
-
-  // 선택한 카테고리에 맞는 작품만 실시간 동적 필터링
-  const filteredItems =
-    selectedCategories.length > 0
-      ? items.filter((item, idx) => {
-          const itemCategory = getItemCategory(item, idx);
-          return selectedCategories.includes(itemCategory);
-        })
-      : items;
 
   return (
     <div className="w-full max-w-md mx-auto bg-page min-h-dvh overflow-x-hidden pt-4 pb-4">
@@ -91,7 +80,7 @@ export function ArtworkPreviewMoreView({ items, onClose }: Props) {
         {/* 칩 스크롤 영역 */}
         <div className="flex gap-1.5 overflow-x-auto scrollbar-none select-none">
           {CATEGORY_OPTIONS.map((opt) => {
-            const isSelected = selectedCategories.includes(opt.label);
+            const isSelected = selectedCategory === opt.label;
             return (
               <button
                 key={opt.label}
@@ -117,23 +106,20 @@ export function ArtworkPreviewMoreView({ items, onClose }: Props) {
           })}
         </div>
 
-        {/* 선택된 다중 필터 태그 & 초기화 버튼 */}
-        {selectedCategories.length > 0 && (
+        {/* 선택된 필터 태그 & 초기화 버튼 */}
+        {selectedCategory && (
           <div className="w-full flex justify-between items-center select-none">
             <div className="flex items-center gap-2.5 flex-wrap">
-              {selectedCategories.map((cat) => (
-                <button
-                  key={cat}
-                  type="button"
-                  onClick={() => handleRemoveCategory(cat)}
-                  className="flex items-center gap-1 cursor-pointer group"
-                >
-                  <span className="typo-body-xs-regular text-sub700 group-hover:text-main">
-                    {cat}
-                  </span>
-                  <X className="size-3 text-sub700 group-hover:text-main" />
-                </button>
-              ))}
+              <button
+                type="button"
+                onClick={handleRemoveCategory}
+                className="flex items-center gap-1 cursor-pointer group"
+              >
+                <span className="typo-body-xs-regular text-sub700 group-hover:text-main">
+                  {selectedCategory}
+                </span>
+                <X className="size-3 text-sub700 group-hover:text-main" />
+              </button>
             </div>
 
             <button
@@ -149,38 +135,56 @@ export function ArtworkPreviewMoreView({ items, onClose }: Props) {
 
       {/* 작품 목록 */}
       <div className="grid grid-cols-2 gap-2.5 px-5">
-        {filteredItems.length > 0 ? (
-          filteredItems.map((item) => (
-            <Link
-              key={item.artworkId}
-              to={`/artwork/${item.artworkId}`}
-              className="relative h-64 overflow-hidden rounded-2xl bg-box200 cursor-pointer hover:opacity-95 active:scale-[0.98] transition-all group block focus:outline-none focus-visible:ring-2 focus-visible:ring-main"
-            >
-              {item.artworkImageUrl ? (
-                <img
-                  src={item.artworkImageUrl}
-                  alt={item.artworkName}
-                  className="h-full w-full object-cover select-none group-hover:scale-105 transition-transform duration-300"
-                />
-              ) : (
-                <div className="w-full h-full bg-box200" />
-              )}
-              {/* 하단 어두운 그라데이션 */}
-              <div className="absolute inset-0 bg-linear-to-t from-black/75 via-black/20 to-transparent pointer-events-none" />
+        {artworks.length > 0
+          ? artworks.map((item) => (
+              <Link
+                key={item.artworkId}
+                to={`/artwork/${item.artworkId}`}
+                className="relative h-64 overflow-hidden rounded-2xl bg-box200 cursor-pointer hover:opacity-95 active:scale-[0.98] transition-all group block focus:outline-none focus-visible:ring-2 focus-visible:ring-main"
+              >
+                {item.artworkImageUrl ? (
+                  <img
+                    src={item.artworkImageUrl}
+                    alt={item.artworkName}
+                    className="h-full w-full object-cover select-none group-hover:scale-105 transition-transform duration-300"
+                  />
+                ) : (
+                  <div className="w-full h-full bg-box200" />
+                )}
+                {/* 하단 어두운 그라데이션 */}
+                <div className="absolute inset-0 bg-linear-to-t from-black/75 via-black/20 to-transparent pointer-events-none" />
 
-              {/* 카드 텍스트 */}
-              <div className="absolute left-3.5 right-3.5 bottom-3.5 flex flex-col gap-0.5 pointer-events-none">
-                <p className="typo-body-md-bold text-white line-clamp-1">{item.artworkName}</p>
-                <p className="typo-body-xs-regular text-zinc-300 truncate">
-                  {item.artistName || item.exhibitionInfo?.exhibitionTitle}
-                </p>
+                {/* 카드 텍스트 */}
+                <div className="absolute left-3.5 right-3.5 bottom-3.5 flex flex-col gap-0.5 pointer-events-none">
+                  <p className="typo-body-md-bold text-white line-clamp-1">{item.artworkName}</p>
+                  <p className="typo-body-xs-regular text-zinc-300 truncate">
+                    {item.artistName || item.exhibitionInfo?.exhibitionTitle}
+                  </p>
+                </div>
+              </Link>
+            ))
+          : !isPending &&
+            !isError && (
+              <div className="col-span-2 py-16 text-center text-hint typo-body-sm-regular">
+                해당 카테고리의 작품이 없습니다.
               </div>
-            </Link>
-          ))
-        ) : (
+            )}
+        {isPending && (
           <div className="col-span-2 py-16 text-center text-hint typo-body-sm-regular">
-            해당 카테고리의 작품이 없습니다.
+            불러오는 중...
           </div>
+        )}
+        {isError && (
+          <div className="col-span-2 py-16 text-center text-error typo-body-sm-regular">
+            에러가 발생했습니다.
+          </div>
+        )}
+      </div>
+
+      {/* 스크롤 감지 및 추가 로딩 인디케이터 */}
+      <div ref={triggerRef} className="w-full flex justify-center py-4">
+        {isFetchingNextPage && (
+          <div className="text-center text-sub600 typo-body-sm-regular">더 불러오는 중...</div>
         )}
       </div>
     </div>

--- a/src/components/lounge/CommunitySection.tsx
+++ b/src/components/lounge/CommunitySection.tsx
@@ -4,6 +4,8 @@ import { useNavigate } from 'react-router-dom';
 import loungeReviewThumbnail from '@/assets/lounge/LoungeReviewThumbnail.svg';
 import loungeVenueThumbnail from '@/assets/lounge/LoungeVenueThumbnail.svg';
 import type { LoungeCategoryKey } from '@/constants/loungeCategories';
+import { useLoginRequiredModal } from '@/hooks/usePermissionRequiredModal';
+import { useAuthStore } from '@/stores/authStore';
 
 import { LoungeCard } from './LoungeCard';
 
@@ -36,16 +38,27 @@ function MultilineText({ text }: { text: string }) {
 
 export function CommunitySection() {
   const navigate = useNavigate();
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const { loginModal, openLoginModal } = useLoginRequiredModal();
+
+  const handleCardClick = (path: string) => {
+    if (!accessToken) {
+      openLoginModal();
+    } else {
+      navigate(path);
+    }
+  };
 
   return (
     <div className="flex flex-col gap-2.5">
+      {loginModal}
       <div className="flex items-center justify-between gap-3.5">
         <LoungeCard
           className="min-w-0 h-[343px]"
           title="전시후기"
           description={<MultilineText text={'전시를 체험한\n이야기와 감상을 나눠요'} />}
           image={loungeReviewThumbnail}
-          onClick={() => navigate('/lounge/review')}
+          onClick={() => handleCardClick('/lounge/review')}
           bordered
         />
 
@@ -56,7 +69,7 @@ export function CommunitySection() {
               className="h-[165px]"
               title={title}
               description={<MultilineText text={description} />}
-              onClick={() => navigate(`/lounge/${category}`)}
+              onClick={() => handleCardClick(`/lounge/${category}`)}
             />
           ))}
         </div>
@@ -64,7 +77,7 @@ export function CommunitySection() {
 
       <LoungeCard
         className="flex justify-between h-[100px]"
-        onClick={() => navigate('/lounge/venue')}
+        onClick={() => handleCardClick('/lounge/venue')}
       >
         <div className="flex items-end min-w-0 flex-1">
           <div className="flex-1 min-w-0 h-12 flex flex-col justify-end gap-px">

--- a/src/hooks/queries/useHome.ts
+++ b/src/hooks/queries/useHome.ts
@@ -1,6 +1,6 @@
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQueries, useQuery } from '@tanstack/react-query';
 
-import type { GetClosingSoonDisplaysRequestDto } from '@/api/dto';
+import type { GetArtworkPreviewRequestDto, GetClosingSoonDisplaysRequestDto } from '@/api/dto';
 import {
   getArtworkPreview,
   getClosingSoonDisplays,
@@ -49,6 +49,19 @@ export const useClosingSoonDisplays = (params: GetClosingSoonDisplaysRequestDto 
 export const useDuPicks = () => useQuery(duPicksQuery());
 
 export const useHomeArtworkPreview = () => useQuery(homeArtworkPreviewQuery());
+
+export const useInfiniteArtworkPreview = (params: GetArtworkPreviewRequestDto = {}) =>
+  useInfiniteQuery({
+    queryKey: queryKeys.displayArtworks.preview(params),
+    queryFn: ({ pageParam = 0 }) =>
+      getArtworkPreview({
+        ...params,
+        page: pageParam,
+        size: params.size ?? 10,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => (lastPage.isLast ? null : lastPage.page + 1),
+  });
 
 export const useHomeLoungePosts = () => useQuery(homeLoungePostsQuery());
 

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+
+interface UseInfiniteScrollProps {
+  hasNextPage: boolean | undefined;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+  threshold?: number;
+  rootMargin?: string;
+}
+
+export function useInfiniteScroll({
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  threshold = 0.1,
+  rootMargin = '0px',
+}: UseInfiniteScrollProps) {
+  const triggerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold, rootMargin },
+    );
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage, threshold, rootMargin]);
+
+  return triggerRef;
+}

--- a/src/pages/ArtistNameSetup.tsx
+++ b/src/pages/ArtistNameSetup.tsx
@@ -46,7 +46,7 @@ const getRegion = (address: string): CreateDisplayRequestDto['region'] => {
 const optionalText = (value?: string | null) => {
   const trimmed = value?.trim();
 
-  return trimmed ? trimmed : undefined;
+  return trimmed ? trimmed : '';
 };
 
 function SummaryRow({ label, value }: SummaryRowProps) {
@@ -116,7 +116,6 @@ export function ArtistNameSetup() {
       qnaAccount: (registerState.contact ?? '').trim(),
       schoolOrOrganization: optionalText(registerState.school),
       departmentOrClub: optionalText(registerState.department),
-      hostOrganizationName: optionalText(registerState.organizer),
       subtitle: optionalText(registerState.subtitle),
       description: optionalText(registerState.intro),
       precautions: optionalText(registerState.notice),

--- a/src/pages/DisplayDetailPage.tsx
+++ b/src/pages/DisplayDetailPage.tsx
@@ -15,6 +15,8 @@ import {
 } from '@/components/displaydetailpage';
 import { BackButton } from '@/components/ui/BackButton';
 import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
+import { useLoginRequiredModal } from '@/hooks/usePermissionRequiredModal';
+import { useAuthStore } from '@/stores/authStore';
 import type { DetailTabKey } from '@/types/exhibition';
 import { parseDisplayId } from '@/utils/parseDisplayId';
 
@@ -24,6 +26,8 @@ export function DisplayDetailPage() {
   const displayId = parseDisplayId(id);
 
   const [activeTab, setActiveTab] = useState<DetailTabKey>('intro');
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const { loginModal, openLoginModal } = useLoginRequiredModal();
 
   const { data: display, isPending, isError } = useDisplayDetail(displayId ?? 0);
 
@@ -45,6 +49,7 @@ export function DisplayDetailPage() {
 
   return (
     <div className="w-full max-w-md mx-auto min-h-dvh bg-page relative">
+      {loginModal}
       <div className="fixed top-4 left-1/2 z-30 w-full max-w-md -translate-x-1/2 px-4 pointer-events-none">
         <BackButton
           id="display-back-btn"
@@ -54,7 +59,16 @@ export function DisplayDetailPage() {
       </div>
       <HeroSlider images={heroImages} />
       <ExhibitionMeta display={display} />
-      <DetailTabNav activeTab={activeTab} onTabChange={setActiveTab} />
+      <DetailTabNav
+        activeTab={activeTab}
+        onTabChange={(tab) => {
+          if (tab === 'review' && !accessToken) {
+            openLoginModal();
+          } else {
+            setActiveTab(tab);
+          }
+        }}
+      />
       {/* 하단 전시 저장 바에 콘텐츠 마지막 부분이 가려지지 않도록 여백을 확보합니다. */}
       {activeTab === 'intro' && (
         <div className="pb-28">

--- a/src/pages/ExhibitionRegister.tsx
+++ b/src/pages/ExhibitionRegister.tsx
@@ -33,12 +33,10 @@ export function ExhibitionRegister() {
   const [type, setType] = useState<string | null>((restored.type as string) ?? null);
   const [field, setField] = useState<string[]>((restored.field as string[]) ?? []);
 
-  const [school, setSchool] = useState(
-    (restored.school as string) ?? artistProfile?.schoolName ?? '',
-  );
+  const [school, setSchool] = useState((restored.school as string) ?? '');
   const [department, setDepartment] = useState((restored.department as string) ?? '');
   const [organizer, setOrganizer] = useState((restored.organizer as string) ?? '');
-  const schoolValue = school || artistProfile?.schoolName || '';
+  const schoolValue = school;
 
   const selectedGroup = useMemo<ExhibitionTypeGroup | null>(() => {
     const found = EXHIBITION_TYPES.find((t) => t.label === type);

--- a/src/pages/ExhibitionRegister.tsx
+++ b/src/pages/ExhibitionRegister.tsx
@@ -35,7 +35,6 @@ export function ExhibitionRegister() {
 
   const [school, setSchool] = useState((restored.school as string) ?? '');
   const [department, setDepartment] = useState((restored.department as string) ?? '');
-  const [organizer, setOrganizer] = useState((restored.organizer as string) ?? '');
   const schoolValue = school;
 
   const selectedGroup = useMemo<ExhibitionTypeGroup | null>(() => {
@@ -46,11 +45,24 @@ export function ExhibitionRegister() {
   const navigate = useNavigate();
 
   const isAffiliationValid = () => {
-    if (!selectedGroup) return true;
-    if (selectedGroup === 'institution') {
-      return department.trim() !== '';
+    if (!type) return false;
+
+    // 1. 졸업 전시(GRADUATION) & 과제 전시(TASK)
+    if (type === '졸업 전시' || type === '과제 전시') {
+      return schoolValue.trim() !== '' && department.trim() !== '';
     }
-    return organizer.trim() !== '';
+
+    // 2. 학과·학회 전시(CLUB - institution) & 연합 전시(JOINT)
+    if (type === '학과·학회 전시' || type === '연합 전시') {
+      return schoolValue.trim() !== '';
+    }
+
+    // 3. 소모임·동아리 전시(CLUB - organization) & 기타 단체 전시(ETC)
+    if (type === '소모임·동아리 전시' || type === '기타 단체 전시') {
+      return schoolValue.trim() !== '';
+    }
+
+    return true;
   };
 
   const isFormValid =
@@ -75,7 +87,6 @@ export function ExhibitionRegister() {
         field,
         school: schoolValue,
         department,
-        organizer,
       },
     });
   };
@@ -166,8 +177,6 @@ export function ExhibitionRegister() {
                 onSchoolChange={setSchool}
                 department={department}
                 onDepartmentChange={setDepartment}
-                organizer={organizer}
-                onOrganizerChange={setOrganizer}
               />
             </div>
           )}

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -96,12 +96,7 @@ export const Homepage = () => {
   }, [accessToken, setAccessToken]);
 
   if (isArtworkPreviewOpen) {
-    return (
-      <ArtworkPreviewMoreView
-        items={artworkPreviewItems}
-        onClose={() => setIsArtworkPreviewOpen(false)}
-      />
-    );
+    return <ArtworkPreviewMoreView onClose={() => setIsArtworkPreviewOpen(false)} />;
   }
 
   return (

--- a/src/pages/Settingpage.tsx
+++ b/src/pages/Settingpage.tsx
@@ -27,7 +27,7 @@ export function SettingPage() {
     logoutMutation.mutate(
       {},
       {
-        onSuccess: () => {
+        onSettled: () => {
           navigate('/login', { replace: true });
         },
       },


### PR DESCRIPTION
## 📝 작업 내용

* **작품 미리보기 무한 스크롤 구현 및 공통 훅 분리**
  - 홈 화면 작품 미리보기 및 더보기 페이지에 무한 스크롤(`useInfiniteArtworkPreview`) 연동
  - `IntersectionObserver` 기반 재사용 가능한 공통 무한 스크롤 감지 훅(`useInfiniteScroll`) 분리
* **비회원 권한 제어 모달 적용**
  - 비회원이 전시 상세 페이지 내 후기 탭이나 라운지 내 카드 클릭 시, API 에러(401) 리다이렉션 발생 전에 로그인 유도 모달 띄우도록 가드 추가
* **로그아웃 리다이렉트 흐름 개선**
  - 설정 페이지 로그아웃 시 성공/실패 여부 관계없이 `onSettled` 시점에 로그인 페이지(`/login`)로 즉시 이동
* **전시 등록 유효성 검사 보완 및 API 페이로드 개선**
  - 전시 유형에 맞춰 학교/학과 정보 필수 입력 유효성 검증 분기 구현
  - 드롭다운 선택 외에 대학교명 직접 입력 시에도 상태에 저장되도록 수정
  - 스웨거 규격에 맞춰 `organizer` 및 `hostOrganizationName` 관련 비표준 필드를 제거하고 `schoolOrOrganization`으로 통합 맵핑


## 🔍 관련 이슈

- close #191



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 작품 미리보기에서 카테고리별 단일 필터와 무한 스크롤을 지원합니다.
  - 로그인하지 않은 경우 커뮤니티 이용 및 전시 후기 확인 시 로그인 안내가 표시됩니다.
- **개선**
  - 작품 목록의 로딩, 추가 로딩, 오류 및 결과 없음 상태를 제공합니다.
  - 소속 정보 입력 및 전시 유형별 학교·학과 검증을 개선했습니다.
  - 로그아웃 요청 결과와 관계없이 로그인 화면으로 이동합니다.
- **버그 수정**
  - 작품 검색어 입력 시 현재 입력값이 정상적으로 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->