### PR TITLE
refactor: 라운지 QA 이후 전면 리팩토링 완료

### DIFF
--- a/src/components/common/BottomCommentBar.tsx
+++ b/src/components/common/BottomCommentBar.tsx
@@ -170,23 +170,23 @@ export function BottomCommentBar({
   return (
     <div
       className={cn(
-        'fixed bottom-0 left-1/2 z-50 w-full max-w-md -translate-x-1/2 bg-card px-5 pt-3 pb-[calc(env(safe-area-inset-bottom)+46px)] shadow-[0px_-4px_18px_0px_rgba(4,0,250,0.06)]',
+        'fixed bottom-0 left-1/2 z-50 w-full max-w-md -translate-x-1/2 border-t border-line bg-card px-5 pt-4 pb-[calc(env(safe-area-inset-bottom)+46px)] shadow-[0px_-4px_18px_0px_rgba(4,0,250,0.06)]',
         className,
       )}
     >
       <LoginConfirmModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
       {replyingTo && (
-        <div className="-mx-5 mb-3 flex items-center justify-between gap-2 border-b border-line-soft px-5 pb-3">
-          <span className="typo-body-xs-regular truncate text-hint">
-            {replyingTo}님에게 답글 남기는 중
+        <div className="-mx-5 mb-3 flex items-center gap-2 px-5 pb-2">
+          <span className="typo-body-xs-regular text-hint">
+            <span className="typo-body-xs-bold">{replyingTo}</span>에게 답글 작성 중
           </span>
           <button
             type="button"
             onClick={onCancelReply}
             aria-label="답글 취소"
-            className="shrink-0 cursor-pointer text-hint"
+            className="typo-body-xs-regular text-faint cursor-pointer"
           >
-            <X size={16} strokeWidth={1.5} />
+            취소
           </button>
         </div>
       )}

--- a/src/components/common/ImageModal.tsx
+++ b/src/components/common/ImageModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import { X } from 'lucide-react';
@@ -10,25 +10,60 @@ type Props = {
 };
 
 export function ImageModal({ imageUrl, isOpen, onClose }: Props) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
+      previousFocusRef.current = document.activeElement as HTMLElement;
+
+      // Request animation frame ensures the modal is rendered before focusing
+      requestAnimationFrame(() => {
+        closeButtonRef.current?.focus();
+      });
+
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          onClose();
+        }
+      };
+
+      document.addEventListener('keydown', handleKeyDown);
+
+      return () => {
+        document.body.style.overflow = '';
+        document.removeEventListener('keydown', handleKeyDown);
+        // Restore focus
+        if (previousFocusRef.current) {
+          previousFocusRef.current.focus();
+        }
+      };
     } else {
       document.body.style.overflow = '';
     }
     return () => {
       document.body.style.overflow = '';
     };
-  }, [isOpen]);
+  }, [isOpen, onClose]);
 
   if (!isOpen || !imageUrl) return null;
 
   return createPortal(
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="확대된 이미지"
       className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm cursor-pointer"
       onClick={onClose}
     >
-      <button type="button" className="absolute top-4 right-4 p-2 text-white" onClick={onClose}>
+      <button
+        type="button"
+        ref={closeButtonRef}
+        aria-label="이미지 닫기"
+        className="absolute top-4 right-4 p-2 text-white"
+        onClick={onClose}
+      >
         <X className="size-8" />
       </button>
       <img

--- a/src/components/common/ImageModal.tsx
+++ b/src/components/common/ImageModal.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+import { X } from 'lucide-react';
+
+type Props = {
+  imageUrl: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export function ImageModal({ imageUrl, isOpen, onClose }: Props) {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  if (!isOpen || !imageUrl) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm cursor-pointer"
+      onClick={onClose}
+    >
+      <button type="button" className="absolute top-4 right-4 p-2 text-white" onClick={onClose}>
+        <X className="size-8" />
+      </button>
+      <img
+        src={imageUrl}
+        alt="확대된 이미지"
+        className="max-h-[90vh] max-w-[90vw] object-contain cursor-default"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/common/ImageUploader.tsx
+++ b/src/components/common/ImageUploader.tsx
@@ -47,11 +47,11 @@ export function ImageUploader({
   );
 
   return (
-    <div className="mt-2 flex gap-2 flex-wrap">
+    <div className="mt-2 flex gap-2 overflow-x-auto scrollbar-none w-full pb-1">
       {images.map((image, index) => (
         <div
           key={image.id}
-          className="relative size-24 bg-card rounded-xl outline outline-1 outline-offset-[-1px] outline-line overflow-hidden"
+          className="relative size-24 shrink-0 bg-card rounded-xl outline outline-1 outline-offset-[-1px] outline-line overflow-hidden"
         >
           <img
             src={image.previewUrl}
@@ -72,7 +72,7 @@ export function ImageUploader({
         <button
           type="button"
           onClick={handleImageClick}
-          className="size-24 bg-card rounded-xl outline outline-1 outline-offset-[-1px] outline-line flex flex-col items-center justify-center gap-3"
+          className="size-24 shrink-0 bg-card rounded-xl outline outline-1 outline-offset-[-1px] outline-line flex flex-col items-center justify-center gap-3"
           aria-label={emptyLabel ?? '이미지 업로드'}
         >
           <div className="size-10 bg-page rounded-full flex items-center justify-center">

--- a/src/components/common/comment/CommentItem.tsx
+++ b/src/components/common/comment/CommentItem.tsx
@@ -1,9 +1,11 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 
 import { Heart } from 'lucide-react';
 
 import defaultProfileIcon from '@/assets/common/DefaultProfileIcon.svg';
 import { cn } from '@/utils/cn';
+
+import { ImageModal } from '../ImageModal';
 
 import type { CommentData } from './types';
 
@@ -36,6 +38,8 @@ type Props = {
   likeIconSize?: IconSize;
   /** 답글의 좋아요 하트 아이콘 크기. */
   replyLikeIconSize?: IconSize;
+  /** 좋아요 버튼 위치 */
+  likePosition?: 'bottom' | 'top-right';
 };
 
 const DEFAULT_LIKE_ICON_SIZE: IconSize = { width: 14, height: 14 };
@@ -62,6 +66,7 @@ export const CommentItem = memo(function CommentItem({
   showDivider = false,
   likeIconSize = DEFAULT_LIKE_ICON_SIZE,
   replyLikeIconSize = DEFAULT_LIKE_ICON_SIZE,
+  likePosition = 'bottom',
 }: Props) {
   const iconSize = isReply ? replyLikeIconSize : likeIconSize;
   const commentId = comment.id;
@@ -74,6 +79,8 @@ export const CommentItem = memo(function CommentItem({
   const highlightKey = isReply ? `reply-${commentId}` : `comment-${commentId}`;
   const isComposingReply = activeReplyId === highlightKey;
   const replyCount = comment.replyCount ?? 0;
+
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
 
   const handleLikeClick = () => {
     if (isLikePending) return;
@@ -100,12 +107,17 @@ export const CommentItem = memo(function CommentItem({
   return (
     <div className={cn('w-full flex flex-col', tightSpacing ? 'gap-0' : 'gap-2', className)}>
       <div
-        className={`relative flex flex-col -mx-5 px-5 ${dividerClasses} ${bleedClasses} ${isComposingReply ? 'bg-box' : ''}`}
+        className={cn(
+          'relative flex flex-col -mx-5 px-5',
+          dividerClasses,
+          bleedClasses,
+          isComposingReply && 'bg-box',
+        )}
       >
         {isComposingReply && (
           <div className="absolute top-0 left-0 h-full w-[3px] rounded-r-full bg-[#8E8E93]" />
         )}
-        <div className={`flex items-center gap-1.5 ${isReply ? 'pl-9' : ''}`}>
+        <div className={cn('flex items-center gap-1.5', isReply && 'pl-9')}>
           <img
             alt=""
             className="size-7 rounded-full shrink-0 object-cover"
@@ -118,15 +130,36 @@ export const CommentItem = memo(function CommentItem({
             <span className="typo-body-sm-bold text-main">{comment.author}</span>
             <span className="typo-body-xs-regular text-hint">{comment.time}</span>
           </div>
+          {likePosition === 'top-right' && !isDeleted && (
+            <button
+              type="button"
+              onClick={handleLikeClick}
+              disabled={isLikePending}
+              aria-pressed={comment.isLiked}
+              aria-label={`좋아요 ${comment.likeCount}개`}
+              className="flex items-center gap-1 disabled:opacity-50"
+            >
+              <Heart
+                width={iconSize.width}
+                height={iconSize.height}
+                className={comment.isLiked ? 'fill-heart text-heart' : 'text-faint'}
+                strokeWidth={1.5}
+              />
+              <span className="typo-body-xs-regular text-faint">{comment.likeCount}</span>
+            </button>
+          )}
         </div>
 
         {!isDeleted && comment.images && comment.images.length > 0 && (
           <div className={`${contentIndent} mt-1 flex gap-1 overflow-x-auto scrollbar-none`}>
             {comment.images.map((url) => (
-              <div
+              <button
                 key={url}
-                className="w-[106px] h-[129px] shrink-0 rounded-sm bg-gray-300 bg-cover bg-center"
+                type="button"
+                className="w-[106px] h-[129px] shrink-0 rounded-sm bg-gray-300 bg-cover bg-center cursor-pointer"
                 style={{ backgroundImage: `url(${url})` }}
+                onClick={() => setSelectedImage(url)}
+                aria-label="이미지 크게 보기"
               />
             ))}
           </div>
@@ -138,7 +171,7 @@ export const CommentItem = memo(function CommentItem({
           {isDeleted ? '삭제된 글입니다.' : comment.content}
         </p>
 
-        <div className={`${contentIndent} mt-3 flex items-center justify-between gap-2`}>
+        <div className={cn(contentIndent, 'mt-3 flex items-center justify-between gap-2')}>
           <div className="flex items-center gap-2">
             {!isDeleted && (
               <button
@@ -152,8 +185,8 @@ export const CommentItem = memo(function CommentItem({
                 }
                 className={
                   isComposingReply
-                    ? 'text-[12px] font-bold text-[#3A3A3C]'
-                    : 'typo-body-xs-regular text-faint'
+                    ? 'typo-body-xs-bold text-[#3A3A3C]'
+                    : 'typo-body-xs-regular text-hint'
                 }
               >
                 답글달기
@@ -163,7 +196,7 @@ export const CommentItem = memo(function CommentItem({
               <button
                 type="button"
                 onClick={() => onToggleReplies?.()}
-                className="typo-body-xs-regular text-faint"
+                className="typo-body-xs-regular text-hint"
               >
                 댓글{replyCount}
               </button>
@@ -172,14 +205,14 @@ export const CommentItem = memo(function CommentItem({
               <button
                 type="button"
                 onClick={handleDeleteClick}
-                className="typo-body-xs-regular text-faint"
+                className="typo-body-xs-regular text-hint"
               >
                 삭제
               </button>
             )}
           </div>
 
-          {!isDeleted && (
+          {likePosition === 'bottom' && !isDeleted && (
             <button
               type="button"
               onClick={handleLikeClick}
@@ -218,6 +251,7 @@ export const CommentItem = memo(function CommentItem({
               showDivider={showDivider}
               likeIconSize={likeIconSize}
               replyLikeIconSize={replyLikeIconSize}
+              likePosition={likePosition}
             />
           ))}
           {hasMoreReplies && (
@@ -232,6 +266,12 @@ export const CommentItem = memo(function CommentItem({
           )}
         </div>
       )}
+
+      <ImageModal
+        imageUrl={selectedImage}
+        isOpen={selectedImage !== null}
+        onClose={() => setSelectedImage(null)}
+      />
     </div>
   );
 });

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -4,6 +4,7 @@ export { BottomCommentBar } from './BottomCommentBar';
 export type { CommentData } from './comment';
 export { CommentItem } from './comment';
 export { ErrorView } from './ErrorView';
+export { ImageModal } from './ImageModal';
 export { ImageUploader } from './ImageUploader';
 export { LoadingView } from './LoadingView';
 export { LoginConfirmModal } from './LoginConfirmModal';

--- a/src/components/displaydetailpage/ReviewTab.tsx
+++ b/src/components/displaydetailpage/ReviewTab.tsx
@@ -54,28 +54,27 @@ export function ReviewTab({ className, display, displayId }: Props) {
   const reviewPolicy = useDisplayReviewPolicy(display);
   const replyPolicy = useDisplayReviewReplyPolicy(display);
 
-  const [replyTarget, setReplyTarget] = useState<{ commentId: number; author: string } | null>(
-    null,
-  );
-  const [activeReplyId, setActiveReplyId] = useState<string | null>(null);
+  const [replyState, setReplyState] = useState<{
+    commentId: number;
+    author: string;
+    highlightId: string;
+  } | null>(null);
+
   const clearReplyTarget = () => {
-    setReplyTarget(null);
-    setActiveReplyId(null);
+    setReplyState(null);
   };
 
   const handleReplyClick = useCallback((commentId: number, author: string, highlightId: string) => {
-    setActiveReplyId((prev) => {
-      if (prev === highlightId) {
-        setReplyTarget(null);
+    setReplyState((prev) => {
+      if (prev?.highlightId === highlightId) {
         return null;
       }
-      setReplyTarget({ commentId, author });
-      return highlightId;
+      return { commentId, author, highlightId };
     });
   }, []);
 
   const createReview = useCreateDisplayReview(displayId);
-  const createReply = useCreateDisplayReviewReply(displayId, replyTarget?.commentId ?? 0);
+  const createReply = useCreateDisplayReviewReply(displayId, replyState?.commentId ?? 0);
 
   const reviews = (data?.pages.flatMap((page) => page.reviews) ?? []).filter(
     // 답글 없는 삭제된 후기는 목록에서 완전히 제외 (답글이 있으면 "삭제된 글입니다"로 표시)
@@ -142,7 +141,7 @@ export function ReviewTab({ className, display, displayId }: Props) {
               displayId={displayId}
               review={review}
               myUserId={myUserId}
-              activeReplyId={activeReplyId}
+              activeReplyId={replyState?.highlightId ?? null}
               onReplyClick={handleReplyClick}
             />
           ))}
@@ -161,11 +160,11 @@ export function ReviewTab({ className, display, displayId }: Props) {
       <BottomCommentBar
         placeholder="글을 입력하세요."
         imageDomain="display-review"
-        isSubmitting={replyTarget ? createReply.isPending : createReview.isPending}
-        replyingTo={replyTarget?.author}
+        isSubmitting={replyState ? createReply.isPending : createReview.isPending}
+        replyingTo={replyState?.author}
         onCancelReply={clearReplyTarget}
         onSubmit={({ content, images }) => {
-          if (replyTarget) {
+          if (replyState) {
             if (!hasPermission(replyPolicy, 'reply.create')) {
               openLoginModal();
               return;

--- a/src/components/displaydetailpage/ReviewTab.tsx
+++ b/src/components/displaydetailpage/ReviewTab.tsx
@@ -64,8 +64,14 @@ export function ReviewTab({ className, display, displayId }: Props) {
   };
 
   const handleReplyClick = useCallback((commentId: number, author: string, highlightId: string) => {
-    setReplyTarget({ commentId, author });
-    setActiveReplyId(highlightId);
+    setActiveReplyId((prev) => {
+      if (prev === highlightId) {
+        setReplyTarget(null);
+        return null;
+      }
+      setReplyTarget({ commentId, author });
+      return highlightId;
+    });
   }, []);
 
   const createReview = useCreateDisplayReview(displayId);

--- a/src/components/lounge-board/LoungeBoardActionBar.tsx
+++ b/src/components/lounge-board/LoungeBoardActionBar.tsx
@@ -15,9 +15,16 @@ type Props = {
   likeCount: number;
   isLiked: boolean;
   isSaved: boolean;
+  hasComments?: boolean;
 };
 
-export function LoungeBoardActionBar({ postId, likeCount, isLiked, isSaved }: Props) {
+export function LoungeBoardActionBar({
+  postId,
+  likeCount,
+  isLiked,
+  isSaved,
+  hasComments = true,
+}: Props) {
   const { loginModal, openLoginModal } = useLoginRequiredModal();
   const loungePostPolicy = useLoungePostPolicy();
   const likeMutation = useLikeLoungePost();
@@ -61,9 +68,9 @@ export function LoungeBoardActionBar({ postId, likeCount, isLiked, isSaved }: Pr
   return (
     <div className="w-full flex flex-col gap-5">
       <div className="flex flex-col">
-        <div className="-mx-5 border-t border-zinc-300" />
+        <div className="-mx-5 border-t border-line-soft" />
 
-        <div className="-mx-5 flex items-center pt-[18px]">
+        <div className="-mx-5 flex items-center pt-4.5">
           <div className="flex items-center gap-2">
             <button
               type="button"
@@ -75,9 +82,7 @@ export function LoungeBoardActionBar({ postId, likeCount, isLiked, isSaved }: Pr
                 className={`size-5 ${isLiked ? 'fill-heart text-heart' : 'text-faint'}`}
                 strokeWidth={1.5}
               />
-              <span className="typo-body-sm-regular text-hint min-w-[3ch] tabular-nums">
-                {likeCount}
-              </span>
+              <span className="typo-body-sm-regular text-hint">{likeCount}</span>
             </button>
 
             <button
@@ -86,9 +91,8 @@ export function LoungeBoardActionBar({ postId, likeCount, isLiked, isSaved }: Pr
               disabled={isScrapMutating}
               className="px-5 py-2 rounded-[10px] flex items-center gap-1.5 disabled:opacity-50"
             >
-              {/* 저장됨 아이콘 색 임시로 피그마 값을 하드코딩했습니다(서현민) */}
               <Bookmark
-                className={`size-4 ${isSaved ? 'text-[#C4C4C4] fill-[#C4C4C4]' : 'text-hint'}`}
+                className={`size-4 ${isSaved ? 'text-bookmark fill-bookmark' : 'text-faint'}`}
                 strokeWidth={1.5}
               />
               <span className="typo-body-sm-regular text-hint">저장</span>
@@ -97,7 +101,7 @@ export function LoungeBoardActionBar({ postId, likeCount, isLiked, isSaved }: Pr
         </div>
       </div>
 
-      <div className="-mx-5 h-1 bg-zinc-300" />
+      {hasComments && <div className="-mx-5 h-1 bg-line-soft" />}
 
       {loginModal}
     </div>

--- a/src/components/lounge-board/LoungeBoardCommentItem.tsx
+++ b/src/components/lounge-board/LoungeBoardCommentItem.tsx
@@ -163,6 +163,7 @@ export const LoungeBoardCommentItem = memo(function LoungeBoardCommentItem({
         onReplyClick={handleReplyClick}
         activeReplyId={activeReplyId}
         tightSpacing
+        likePosition="top-right"
       />
       {loginModal}
     </>

--- a/src/components/lounge-board/LoungeBoardCommentItem.tsx
+++ b/src/components/lounge-board/LoungeBoardCommentItem.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
+import type { LoungeCommentDto } from '@/api/dto/lounge.dto';
 import type { CommentData } from '@/components/common';
 import { CommentItem } from '@/components/common';
 import {
@@ -10,13 +11,12 @@ import {
 import { useLoungeReplies } from '@/hooks/queries/useLoungeReplies';
 import { useLoginRequiredModal } from '@/hooks/usePermissionRequiredModal';
 import { useLoungeCommentPolicy } from '@/hooks/usePolicy';
-import type { LoungeBoardComment } from '@/types/exhibition';
 import { formatRelativeTime } from '@/utils/date';
 import { hasPermission } from '@/utils/hasPermission';
 
 type Props = {
   postId: number;
-  comment: LoungeBoardComment;
+  comment: LoungeCommentDto;
   isDeleted?: boolean;
   onDelete?: (commentId: string) => void;
   onReplyClick?: (commentId: number, author: string, highlightId: string) => void;
@@ -40,7 +40,7 @@ export const LoungeBoardCommentItem = memo(function LoungeBoardCommentItem({
   /* like/unlike/delete는 로그인 여부만 확인하면 됩니다 — 삭제 버튼 자체는
    * CommentItem이 isMyComment일 때만 노출하므로 소유권 재검증은 불필요합니다. */
   const isLoggedIn = hasPermission(loungeCommentPolicy, 'like');
-  const commentId = Number(comment.id);
+  const commentId = Number(comment.loungeCommentId);
   const isComposingReply = activeReplyId === `comment-${commentId}`;
 
   useEffect(() => {
@@ -79,6 +79,22 @@ export const LoungeBoardCommentItem = memo(function LoungeBoardCommentItem({
           })) ?? []
       ).filter((reply) => !removedReplyIds.has(reply.id)),
     [repliesData, removedReplyIds],
+  );
+
+  const commentData: CommentData = useMemo(
+    () => ({
+      id: String(comment.loungeCommentId),
+      author: comment.writer.nickname,
+      avatarUrl: comment.writer.profileImageUrl,
+      time: formatRelativeTime(comment.createdAt),
+      content: comment.content,
+      likeCount: comment.likeCount,
+      isLiked: comment.isLiked,
+      isMyComment: comment.isMyComment,
+      replyCount: comment.replyCount,
+      images: comment.imageUrls.length > 0 ? comment.imageUrls : undefined,
+    }),
+    [comment],
   );
 
   const handleLike = useCallback(
@@ -148,7 +164,7 @@ export const LoungeBoardCommentItem = memo(function LoungeBoardCommentItem({
   return (
     <>
       <CommentItem
-        comment={comment}
+        comment={commentData}
         isDeleted={isDeleted}
         replies={replies}
         repliesOpen={repliesOpen}

--- a/src/components/lounge-board/LoungeBoardHeader.tsx
+++ b/src/components/lounge-board/LoungeBoardHeader.tsx
@@ -36,7 +36,7 @@ export function LoungeBoardHeader({
   };
 
   return (
-    <div className={`relative flex items-center pt-[11px] ${className}`}>
+    <div className={`relative flex items-center py-3 ${className}`}>
       <div className="h-9 flex items-center gap-3">
         <button type="button" aria-label="뒤로가기" onClick={() => navigate(-1)}>
           <ChevronLeft className="size-7 text-main" />
@@ -48,7 +48,7 @@ export function LoungeBoardHeader({
         <button
           type="button"
           onClick={handleWriteClick}
-          className="absolute top-[14px] right-[33px] flex flex-col items-center gap-1"
+          className="absolute top-3.5 right-8.25 flex flex-col items-center gap-1"
         >
           <SquarePen className="size-3.5 text-faint" />
           <span className="typo-body-xs-regular text-faint">글 작성</span>

--- a/src/components/lounge-board/LoungeBoardPostCard.tsx
+++ b/src/components/lounge-board/LoungeBoardPostCard.tsx
@@ -11,18 +11,26 @@ type Props = {
 export function LoungeBoardPostCard({ post, tagLabel }: Props) {
   const navigate = useNavigate();
   const detailPath = `/lounge/${post.category}/${post.id}`;
-  const hasImages = Boolean(post.images && post.images.length > 0);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    if (e.key === 'Enter') {
+      navigate(detailPath);
+    } else if (e.key === ' ') {
+      e.preventDefault();
+      navigate(detailPath);
+    }
+  };
 
   return (
     <article
-      className={`${hasImages ? 'h-[280px]' : 'h-[148px]'} px-4 py-3.5 bg-stone-50 rounded-lg shadow-[8px_8px_18px_0px_rgba(67,0,209,0.02)] outline outline-2 outline-offset-[-2px] outline-neutral-50 flex flex-col gap-3 overflow-hidden cursor-pointer`}
+      className="max-h-70 px-4 py-3.5 bg-stone-50 rounded-lg shadow-[8px_8px_18px_0px_rgba(67,0,209,0.02)] outline outline-2 outline-offset-[-2px] outline-neutral-50 flex flex-col gap-3 overflow-hidden cursor-pointer"
       onClick={() => navigate(detailPath)}
       role="button"
       tabIndex={0}
-      onKeyDown={(e) => e.key === 'Enter' && navigate(detailPath)}
+      onKeyDown={handleKeyDown}
     >
       <span className="self-start h-5 px-2 py-0.5 bg-tag-bg rounded-sm inline-flex items-center">
-        <span className="typo-body-xxs-bold text-tag-fg whitespace-nowrap">
+        <span className="typo-body-xxs-regular text-tag-fg whitespace-nowrap">
           {tagLabel ?? LOUNGE_CATEGORY_TAGS[post.category]}
         </span>
       </span>
@@ -31,12 +39,12 @@ export function LoungeBoardPostCard({ post, tagLabel }: Props) {
         <div className="flex flex-col gap-1">
           <h3 className="typo-body-sm-bold text-main truncate">{post.title}</h3>
 
-          {post.images && post.images.length > 0 && (
+          {Boolean(post.images?.length) && (
             <div className="flex gap-1">
-              {post.images.slice(0, 3).map((src, index) => (
+              {post.images?.slice(0, 3).map((src, index) => (
                 <div
-                  key={index}
-                  className="w-[108px] h-[130px] shrink-0 rounded-sm overflow-hidden"
+                  key={`${src}-${index}`}
+                  className="w-27 h-32.5 shrink-0 rounded-sm overflow-hidden"
                 >
                   <img alt="" className="w-full h-full object-cover" src={src} />
                 </div>
@@ -47,12 +55,16 @@ export function LoungeBoardPostCard({ post, tagLabel }: Props) {
           <p className="typo-body-sm-regular text-main line-clamp-2">{post.description}</p>
         </div>
 
-        <div className="flex items-center gap-2">
-          <span className="typo-body-xs-regular text-faint">{post.author}</span>
-          <span className="typo-body-xs-regular text-faint">·</span>
-          <span className="typo-body-xs-regular text-faint">{post.time}</span>
-          <span className="typo-body-xs-regular text-faint">·</span>
-          <span className="typo-body-xs-regular text-faint">댓글 {post.commentCount}</span>
+        <div className="flex items-center gap-2 typo-body-xs-regular text-faint">
+          <span>{post.author}</span>
+          <span>·</span>
+          <span>{post.time}</span>
+          {Boolean(post.commentCount) && (
+            <>
+              <span>·</span>
+              <span>댓글 {post.commentCount}</span>
+            </>
+          )}
         </div>
       </div>
     </article>

--- a/src/components/lounge-board/LoungeBoardPostDetail.tsx
+++ b/src/components/lounge-board/LoungeBoardPostDetail.tsx
@@ -1,24 +1,25 @@
 import { useState } from 'react';
 
+import type { LoungePostDetailDto } from '@/api/dto/lounge.dto';
 import { ImageModal } from '@/components/common/ImageModal';
 import { FALLBACK_PROFILE_IMAGE } from '@/constants';
 import { useLoungePostPolicy } from '@/hooks/usePolicy';
-import type { LoungeBoardDetail } from '@/types/exhibition';
+import { formatDate } from '@/utils/date';
 import { hasPermission } from '@/utils/hasPermission';
 
 import { LoungeBoardPostMenu } from './LoungeBoardPostMenu';
 
 type Props = {
-  review: LoungeBoardDetail;
+  post: LoungePostDetailDto;
   onEdit?: () => void;
   onDelete?: () => void;
 };
 
-export function LoungeBoardPostDetail({ review, onEdit, onDelete }: Props) {
+export function LoungeBoardPostDetail({ post, onEdit, onDelete }: Props) {
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
 
-  const post = { isMyPost: Boolean(review.isMyPost) };
-  const loungePostPolicy = useLoungePostPolicy(post);
+  const policyPost = { isMyPost: Boolean(post.isMyPost) };
+  const loungePostPolicy = useLoungePostPolicy(policyPost);
   const canShowPostMenu =
     hasPermission(loungePostPolicy, 'edit') || hasPermission(loungePostPolicy, 'delete');
 
@@ -26,22 +27,31 @@ export function LoungeBoardPostDetail({ review, onEdit, onDelete }: Props) {
     <div className="w-full flex flex-col gap-4">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <img className="size-10 rounded-full shrink-0" src={FALLBACK_PROFILE_IMAGE} />
+          <img
+            alt=""
+            className="size-10 rounded-full shrink-0 object-cover"
+            src={post.writer.profileImageUrl || FALLBACK_PROFILE_IMAGE}
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).src = FALLBACK_PROFILE_IMAGE;
+            }}
+          />
           <div className="flex flex-col items-start gap-1">
-            <p className="typo-body-sm-bold text-main">{review.author}</p>
-            <p className="typo-body-xs-regular text-faint">{review.date}</p>
+            <p className="typo-body-sm-bold text-main">{post.writer.nickname}</p>
+            <p className="typo-body-xs-regular text-faint">{formatDate(post.createdAt)}</p>
           </div>
         </div>
 
-        {canShowPostMenu && <LoungeBoardPostMenu post={post} onEdit={onEdit} onDelete={onDelete} />}
+        {canShowPostMenu && (
+          <LoungeBoardPostMenu post={policyPost} onEdit={onEdit} onDelete={onDelete} />
+        )}
       </div>
 
       <div className="flex flex-col gap-3.5">
-        <h2 className="typo-body-xl-bold text-main">{review.title}</h2>
+        <h2 className="typo-body-xl-bold text-main">{post.title}</h2>
 
-        {review.images && review.images.length > 0 && (
+        {post.postImageUrls && post.postImageUrls.length > 0 && (
           <div className="flex gap-1 overflow-x-auto scrollbar-none">
-            {review.images.map((src, index) => (
+            {post.postImageUrls.map((src, index) => (
               <button
                 key={index}
                 type="button"
@@ -56,17 +66,20 @@ export function LoungeBoardPostDetail({ review, onEdit, onDelete }: Props) {
         )}
 
         <p className="typo-body-sm-regular text-main">
-          {review.content.map((paragraph, index) => (
-            <span key={index}>
-              {index > 0 && (
-                <>
-                  <br />
-                  <br />
-                </>
-              )}
-              {paragraph}
-            </span>
-          ))}
+          {post.content
+            .split('\n')
+            .filter((line) => line.length > 0)
+            .map((paragraph, index) => (
+              <span key={index}>
+                {index > 0 && (
+                  <>
+                    <br />
+                    <br />
+                  </>
+                )}
+                {paragraph}
+              </span>
+            ))}
         </p>
       </div>
 

--- a/src/components/lounge-board/LoungeBoardPostDetail.tsx
+++ b/src/components/lounge-board/LoungeBoardPostDetail.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+
+import { ImageModal } from '@/components/common/ImageModal';
 import { FALLBACK_PROFILE_IMAGE } from '@/constants';
 import { useLoungePostPolicy } from '@/hooks/usePolicy';
 import type { LoungeBoardDetail } from '@/types/exhibition';
@@ -12,6 +15,8 @@ type Props = {
 };
 
 export function LoungeBoardPostDetail({ review, onEdit, onDelete }: Props) {
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
   const post = { isMyPost: Boolean(review.isMyPost) };
   const loungePostPolicy = useLoungePostPolicy(post);
   const canShowPostMenu =
@@ -21,11 +26,7 @@ export function LoungeBoardPostDetail({ review, onEdit, onDelete }: Props) {
     <div className="w-full flex flex-col gap-4">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <img
-            alt=""
-            className="size-10 rounded-full shrink-0 border-[1.33px] border-stone-300"
-            src={FALLBACK_PROFILE_IMAGE}
-          />
+          <img className="size-10 rounded-full shrink-0" src={FALLBACK_PROFILE_IMAGE} />
           <div className="flex flex-col items-start gap-1">
             <p className="typo-body-sm-bold text-main">{review.author}</p>
             <p className="typo-body-xs-regular text-faint">{review.date}</p>
@@ -41,9 +42,15 @@ export function LoungeBoardPostDetail({ review, onEdit, onDelete }: Props) {
         {review.images && review.images.length > 0 && (
           <div className="flex gap-1 overflow-x-auto scrollbar-none">
             {review.images.map((src, index) => (
-              <div key={index} className="w-[112px] h-[136px] shrink-0 rounded-sm overflow-hidden">
+              <button
+                key={index}
+                type="button"
+                onClick={() => setSelectedImage(src)}
+                className="w-[112px] h-[136px] shrink-0 rounded-sm overflow-hidden cursor-pointer"
+                aria-label="이미지 크게 보기"
+              >
                 <img alt="" className="w-full h-full object-cover" src={src} />
-              </div>
+              </button>
             ))}
           </div>
         )}
@@ -62,6 +69,12 @@ export function LoungeBoardPostDetail({ review, onEdit, onDelete }: Props) {
           ))}
         </p>
       </div>
+
+      <ImageModal
+        imageUrl={selectedImage}
+        isOpen={selectedImage !== null}
+        onClose={() => setSelectedImage(null)}
+      />
     </div>
   );
 }

--- a/src/components/lounge-board/LoungeBoardPostMenu.tsx
+++ b/src/components/lounge-board/LoungeBoardPostMenu.tsx
@@ -18,7 +18,6 @@ export function LoungeBoardPostMenu({ post, onEdit, onDelete }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
   const loungePostPolicy = useLoungePostPolicy(post);
-  // 메뉴바 자체에서도 권한 체크를 하지만, 더 방어적으로 만들기 위해 여기서도 권한 제어를 넣었습니다.
   const canEdit = hasPermission(loungePostPolicy, 'edit');
   const canDelete = hasPermission(loungePostPolicy, 'delete');
 

--- a/src/components/lounge/CommunitySection.tsx
+++ b/src/components/lounge/CommunitySection.tsx
@@ -51,7 +51,7 @@ export function CommunitySection() {
             title="모집·협업"
             description={
               <span className="whitespace-pre-wrap">
-                {'전시 준비 과정과\n작업 노하우를 공유해요'}
+                {'전시를 함께 만들\n팀원과 협업 파트너를 찾아요'}
               </span>
             }
             onClick={() => handleCardClick('/lounge/collab')}

--- a/src/components/lounge/CommunitySection.tsx
+++ b/src/components/lounge/CommunitySection.tsx
@@ -1,8 +1,8 @@
 import { ArrowUpRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
-import loungeReviewThumbnail from '@/assets/lounge/LoungeReviewThumbnail.svg';
-import loungeVenueThumbnail from '@/assets/lounge/LoungeVenueThumbnail.svg';
+import loungeReviewThumbnail from '@/assets/lounge/LoungeReviewThumbnail.svg?inline';
+import loungeVenueThumbnail from '@/assets/lounge/LoungeVenueThumbnail.svg?inline';
 import { useLoginRequiredModal } from '@/hooks/usePermissionRequiredModal';
 import { useAuthStore } from '@/stores/authStore';
 

--- a/src/components/lounge/CommunitySection.tsx
+++ b/src/components/lounge/CommunitySection.tsx
@@ -3,38 +3,10 @@ import { useNavigate } from 'react-router-dom';
 
 import loungeReviewThumbnail from '@/assets/lounge/LoungeReviewThumbnail.svg';
 import loungeVenueThumbnail from '@/assets/lounge/LoungeVenueThumbnail.svg';
-import type { LoungeCategoryKey } from '@/constants/loungeCategories';
 import { useLoginRequiredModal } from '@/hooks/usePermissionRequiredModal';
 import { useAuthStore } from '@/stores/authStore';
 
 import { LoungeCard } from './LoungeCard';
-
-const TIP_CARDS: { category: LoungeCategoryKey; title: string; description: string }[] = [
-  {
-    category: 'tips',
-    title: '전시 준비·작업 팁',
-    description: '전시 준비 과정과\n작업 노하우를 공유해요',
-  },
-  {
-    category: 'collab',
-    title: '모집·협업',
-    description: '전시 준비 과정과\n작업 노하우를 공유해요',
-  },
-];
-
-function MultilineText({ text }: { text: string }) {
-  const lines = text.split('\n');
-  return (
-    <>
-      {lines.map((line, index) => (
-        <span key={line}>
-          {index > 0 && <br />}
-          {line}
-        </span>
-      ))}
-    </>
-  );
-}
 
 export function CommunitySection() {
   const navigate = useNavigate();
@@ -52,37 +24,49 @@ export function CommunitySection() {
   return (
     <div className="flex flex-col gap-2.5">
       {loginModal}
-      <div className="flex items-center justify-between gap-3.5">
+      <div className="grid grid-cols-2 gap-3.5">
         <LoungeCard
-          className="min-w-0 h-[343px]"
+          className="h-85.75"
           title="전시후기"
-          description={<MultilineText text={'전시를 체험한\n이야기와 감상을 나눠요'} />}
+          description={
+            <span className="whitespace-pre-wrap">{'전시를 체험한\n이야기와 감상을 나눠요'}</span>
+          }
           image={loungeReviewThumbnail}
           onClick={() => handleCardClick('/lounge/review')}
-          bordered
         />
 
-        <div className="w-[162px] min-w-0 flex flex-col gap-2.5">
-          {TIP_CARDS.map(({ category, title, description }) => (
-            <LoungeCard
-              key={category}
-              className="h-[165px]"
-              title={title}
-              description={<MultilineText text={description} />}
-              onClick={() => handleCardClick(`/lounge/${category}`)}
-            />
-          ))}
+        <div className="flex flex-col gap-2.5">
+          <LoungeCard
+            className="h-41.25"
+            title="전시 준비·작업 팁"
+            description={
+              <span className="whitespace-pre-wrap">
+                {'전시 준비 과정과\n작업 노하우를 공유해요'}
+              </span>
+            }
+            onClick={() => handleCardClick('/lounge/tips')}
+          />
+          <LoungeCard
+            className="h-41.25"
+            title="모집·협업"
+            description={
+              <span className="whitespace-pre-wrap">
+                {'전시 준비 과정과\n작업 노하우를 공유해요'}
+              </span>
+            }
+            onClick={() => handleCardClick('/lounge/collab')}
+          />
         </div>
       </div>
 
       <LoungeCard
-        className="flex justify-between h-[100px]"
+        className="flex justify-between h-25"
         onClick={() => handleCardClick('/lounge/venue')}
       >
         <div className="flex items-end min-w-0 flex-1">
           <div className="flex-1 min-w-0 h-12 flex flex-col justify-end gap-px">
             <h3 className="typo-body-xl-semibold text-main truncate">전시 장소 대여</h3>
-            <p className="typo-body-xs-regular text-sub600 truncate">
+            <p className="typo-body-xs-regular text-sub700 truncate">
               전시 장소에 대한 정보를 공유해요
             </p>
           </div>

--- a/src/components/lounge/LoungeCard.tsx
+++ b/src/components/lounge/LoungeCard.tsx
@@ -22,7 +22,6 @@ export function LoungeCard({
 }: Props) {
   return (
     <div
-      // bordered: --line 토큰(#c4c4c4)이 피그마 zinc-300(#d4d4d8)과 달라 임시로 피그마 값을 하드코딩했습니다(서현민)
       className={`p-3 bg-box100 rounded-lg overflow-hidden shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04),inset_2px_2px_3px_0px_rgba(0,0,0,0.20),inset_-2px_-2px_3px_0px_rgba(255,255,255,1.00)] ${bordered ? 'outline outline-1 outline-offset-[-1px] outline-zinc-300/70' : ''} ${onClick ? 'cursor-pointer' : ''} ${className}`}
       onClick={onClick}
       role={onClick ? 'button' : undefined}
@@ -45,11 +44,11 @@ export function LoungeCard({
           <div className="h-full flex flex-col justify-between items-end">
             <div className="flex flex-col items-end gap-8">
               <ArrowUpRight className="size-5 text-faint" strokeWidth={2.5} />
-              <img alt="" className="w-[162px] h-[169px] object-cover" src={image} />
+              <img alt="" className="w-40.5 h-42.25 object-cover" src={image} />
             </div>
             <div className="w-full flex flex-col items-start gap-1">
               <h3 className="typo-body-xl-semibold text-main">{title}</h3>
-              {description && <p className="typo-body-xs-regular text-sub600">{description}</p>}
+              {description && <p className="typo-body-xs-regular text-sub700">{description}</p>}
             </div>
           </div>
         ) : (
@@ -57,7 +56,7 @@ export function LoungeCard({
             <ArrowUpRight className="size-5 text-faint" strokeWidth={2.5} />
             <div className="w-full flex flex-col items-start gap-1">
               <h3 className="typo-body-xl-semibold text-main">{title}</h3>
-              {description && <p className="typo-body-xs-regular text-sub600">{description}</p>}
+              {description && <p className="typo-body-xs-regular text-sub700">{description}</p>}
             </div>
           </div>
         )

--- a/src/components/lounge/MyActivitySection.tsx
+++ b/src/components/lounge/MyActivitySection.tsx
@@ -1,9 +1,9 @@
 import { ArrowUpRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
-import myCommentsIcon from '@/assets/lounge/my-comments.svg';
-import savedPostsIcon from '@/assets/lounge/saved-posts.svg';
-import scrapsIcon from '@/assets/lounge/scraps.svg';
+import myCommentsIcon from '@/assets/lounge/my-comments.svg?inline';
+import savedPostsIcon from '@/assets/lounge/saved-posts.svg?inline';
+import scrapsIcon from '@/assets/lounge/scraps.svg?inline';
 
 import { LoungeCard } from './LoungeCard';
 

--- a/src/components/lounge/MyActivitySection.tsx
+++ b/src/components/lounge/MyActivitySection.tsx
@@ -10,12 +10,12 @@ import { LoungeCard } from './LoungeCard';
 const ACTIVITY_CARDS: { image: string; imageClassName: string; title: string; tab: string }[] = [
   {
     image: savedPostsIcon,
-    imageClassName: 'w-[47px] h-[37px]',
+    imageClassName: 'w-11.75 h-9.25',
     title: '작성한 글',
     tab: 'written',
   },
-  { image: myCommentsIcon, imageClassName: 'w-10 h-[38px]', title: '내 댓글', tab: 'comments' },
-  { image: scrapsIcon, imageClassName: 'w-[42px] h-10', title: '스크랩', tab: 'scraps' },
+  { image: myCommentsIcon, imageClassName: 'w-10 h-9.5', title: '내 댓글', tab: 'comments' },
+  { image: scrapsIcon, imageClassName: 'w-10.5 h-10', title: '스크랩', tab: 'scraps' },
 ];
 
 export function MyActivitySection() {
@@ -27,7 +27,7 @@ export function MyActivitySection() {
       <h2 className="typo-body-xl-bold text-main">내 활동</h2>
       <div className="grid grid-cols-3 gap-2.5">
         {ACTIVITY_CARDS.map(({ image, imageClassName, title, tab }) => (
-          <LoungeCard key={title} className="relative h-[85px]" onClick={() => goToTab(tab)}>
+          <LoungeCard key={title} className="relative h-21.25" onClick={() => goToTab(tab)}>
             <ArrowUpRight className="absolute top-3 right-3 size-5 text-faint" strokeWidth={2.5} />
             <div className="w-full flex flex-col items-start gap-0.5 mt-0.5">
               <img alt="" className={`${imageClassName} object-contain`} src={image} />

--- a/src/components/post-write/ImageUploadPlaceholder.tsx
+++ b/src/components/post-write/ImageUploadPlaceholder.tsx
@@ -130,11 +130,11 @@ export function ImageUploadPlaceholder({
   }, []);
 
   return (
-    <div className="flex gap-2 flex-wrap">
+    <div className="flex gap-2 overflow-x-auto scrollbar-none w-full pb-1">
       {items.map((item) => (
         <div
           key={item.id}
-          className="relative size-25 bg-card rounded-xl outline outline-1 outline-offset-[-1px] outline-line overflow-hidden"
+          className="relative size-25 shrink-0 bg-card rounded-xl outline outline-1 outline-offset-[-1px] outline-line overflow-hidden"
         >
           <img src={item.previewUrl} alt="업로드한 이미지" className="w-full h-full object-cover" />
           {item.status === 'uploading' && (
@@ -158,7 +158,7 @@ export function ImageUploadPlaceholder({
         <button
           type="button"
           onClick={handleUploadClick}
-          className="size-25 bg-card rounded-xl outline outline-1 outline-offset-[-1px] outline-line flex flex-col items-center justify-center gap-3"
+          className="size-25 shrink-0 bg-card rounded-xl outline outline-1 outline-offset-[-1px] outline-line flex flex-col items-center justify-center gap-3"
           aria-label="이미지 업로드"
         >
           <div className="size-10 bg-gray-100 rounded-full flex items-center justify-center">

--- a/src/hooks/queries/useLoungeComments.ts
+++ b/src/hooks/queries/useLoungeComments.ts
@@ -34,6 +34,7 @@ export const useCreateLoungeComment = () => {
         queryKey: queryKeys.loungeComments.listPrefix(variables.postId),
       });
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(variables.postId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
     },
   });
 };
@@ -50,7 +51,16 @@ export const useDeleteLoungeComment = () => {
   return useMutation({
     mutationFn: ({ commentId }: CommentMutationVariables) => deleteLoungeComment(commentId),
     onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.loungeComments.listPrefix(variables.postId),
+      });
+      if (variables.parentCommentId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.loungeComments.replyLists(variables.parentCommentId),
+        });
+      }
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(variables.postId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
     },
   });
 };

--- a/src/hooks/queries/useLoungeReplies.ts
+++ b/src/hooks/queries/useLoungeReplies.ts
@@ -37,6 +37,8 @@ export const useCreateLoungeReply = () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.loungeComments.listPrefix(variables.postId),
       });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(variables.postId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
     },
   });
 };

--- a/src/hooks/queries/useUserProfile.ts
+++ b/src/hooks/queries/useUserProfile.ts
@@ -69,6 +69,7 @@ export const useUpdateUserMe = () => {
     mutationFn: (body: UpdateMyProfileRequestDto) => updateUserMe(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.all });
     },
   });
 };
@@ -80,6 +81,7 @@ export const useUpdateMyArtistProfile = () => {
     mutationFn: (body: UpdateArtistProfileRequestDto) => updateMyArtistProfile(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.artistProfile() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.all });
     },
   });
 };

--- a/src/mocks/handlers/lounge.ts
+++ b/src/mocks/handlers/lounge.ts
@@ -182,14 +182,16 @@ export const loungeHandlers = [
       } else {
         return HttpResponse.json({ message: 'Parent comment not found' }, { status: 404 });
       }
-      return created('/api/v1/lounge/comments/{parentCommentId}/replies', {
+      const reply = {
         loungeCommentId: Date.now(),
         parentCommentId: parentId,
         ...(await readJson(request)),
         writer: mockDb.me,
         author: mockDb.me,
         createdAt: now(),
-      });
+      };
+      mockDb.loungeComments.unshift(reply);
+      return created('/api/v1/lounge/comments/{parentCommentId}/replies', reply);
     }),
   ),
 ];

--- a/src/mocks/handlers/lounge.ts
+++ b/src/mocks/handlers/lounge.ts
@@ -98,10 +98,15 @@ export const loungeHandlers = [
   ),
   ...paths('/api/v1/lounge/posts/{loungePostId}/comments').map((path) =>
     http.post(path, async ({ params, request }) => {
+      const postId = toNumber(params.loungePostId, 1);
+      const post = findPost(postId);
+      if (post) {
+        post.commentCount = (post.commentCount ?? 0) + 1;
+      }
       const comment = {
         loungeCommentId: Date.now(),
         commentId: Date.now(),
-        loungePostId: toNumber(params.loungePostId, 1),
+        loungePostId: postId,
         parentCommentId: null,
         ...(await readJson(request)),
         writer: mockDb.me,
@@ -115,12 +120,25 @@ export const loungeHandlers = [
     }),
   ),
   ...paths('/api/v1/lounge/comments/{loungeCommentId}').map((path) =>
-    http.delete(path, ({ params }) =>
-      success('/api/v1/lounge/comments/{loungeCommentId}', {
-        loungeCommentId: toNumber(params.loungeCommentId),
+    http.delete(path, ({ params }) => {
+      const commentId = toNumber(params.loungeCommentId);
+      const comment = mockDb.loungeComments.find(
+        (c: any) => c.loungeCommentId === commentId || c.commentId === commentId,
+      );
+      if (comment) {
+        const post = findPost(comment.loungePostId);
+        if (post && (post.commentCount ?? 0) > 0) {
+          post.commentCount = post.commentCount - 1;
+        }
+        mockDb.loungeComments = mockDb.loungeComments.filter(
+          (c: any) => c.loungeCommentId !== commentId && c.commentId !== commentId,
+        );
+      }
+      return success('/api/v1/lounge/comments/{loungeCommentId}', {
+        loungeCommentId: commentId,
         deletedAt: now(),
-      }),
-    ),
+      });
+    }),
   ),
   ...paths('/api/v1/lounge/comments/{loungeCommentId}/likes').map((path) =>
     http.post(path, ({ params }) =>
@@ -151,15 +169,25 @@ export const loungeHandlers = [
     ),
   ),
   ...paths('/api/v1/lounge/comments/{parentCommentId}/replies').map((path) =>
-    http.post(path, async ({ params, request }) =>
-      created('/api/v1/lounge/comments/{parentCommentId}/replies', {
+    http.post(path, async ({ params, request }) => {
+      const parentId = toNumber(params.parentCommentId);
+      const parentComment = mockDb.loungeComments.find(
+        (c: any) => c.loungeCommentId === parentId || c.commentId === parentId,
+      );
+      if (parentComment) {
+        const post = findPost(parentComment.loungePostId);
+        if (post) {
+          post.commentCount = (post.commentCount ?? 0) + 1;
+        }
+      }
+      return created('/api/v1/lounge/comments/{parentCommentId}/replies', {
         loungeCommentId: Date.now(),
-        parentCommentId: toNumber(params.parentCommentId),
+        parentCommentId: parentId,
         ...(await readJson(request)),
         writer: mockDb.me,
         author: mockDb.me,
         createdAt: now(),
-      }),
-    ),
+      });
+    }),
   ),
 ];

--- a/src/mocks/handlers/lounge.ts
+++ b/src/mocks/handlers/lounge.ts
@@ -1,13 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { http } from 'msw';
+import { http, HttpResponse } from 'msw';
 
 import { listResponse, mockDb, okStatus } from '@/mocks/data/repository';
 import { created, paths, readJson, success, toNumber } from '@/mocks/response';
 
 const now = () => new Date().toISOString();
 const findPost = (postId: number) =>
-  mockDb.loungePosts.find((post: any) => post.loungePostId === postId || post.postId === postId) ??
-  mockDb.loungePosts[0];
+  mockDb.loungePosts.find((post: any) => post.loungePostId === postId || post.postId === postId);
 
 export const loungeHandlers = [
   ...paths('/api/v1/lounge/posts').map((path) =>
@@ -17,7 +16,7 @@ export const loungeHandlers = [
     http.post(path, async ({ request }) => {
       const body = await readJson<Record<string, unknown>>(request);
       const post = {
-        ...findPost(1),
+        ...mockDb.loungePosts[0],
         ...body,
         loungePostId: Date.now(),
         postId: Date.now(),
@@ -32,13 +31,16 @@ export const loungeHandlers = [
     }),
   ),
   ...paths('/api/v1/lounge/posts/{loungePostId}').map((path) =>
-    http.get(path, ({ params }) =>
-      success('/api/v1/lounge/posts/{loungePostId}', findPost(toNumber(params.loungePostId, 1))),
-    ),
+    http.get(path, ({ params }) => {
+      const post = findPost(toNumber(params.loungePostId, 1));
+      if (!post) return HttpResponse.json({ message: 'Not Found' }, { status: 404 });
+      return success('/api/v1/lounge/posts/{loungePostId}', post);
+    }),
   ),
   ...paths('/api/v1/lounge/posts/{loungePostId}').map((path) =>
     http.patch(path, async ({ params, request }) => {
       const post = findPost(toNumber(params.loungePostId, 1));
+      if (!post) return HttpResponse.json({ message: 'Not Found' }, { status: 404 });
       Object.assign(post, await readJson(request), { updatedAt: now() });
 
       return success('/api/v1/lounge/posts/{loungePostId}', post);
@@ -100,9 +102,8 @@ export const loungeHandlers = [
     http.post(path, async ({ params, request }) => {
       const postId = toNumber(params.loungePostId, 1);
       const post = findPost(postId);
-      if (post) {
-        post.commentCount = (post.commentCount ?? 0) + 1;
-      }
+      if (!post) return HttpResponse.json({ message: 'Not Found' }, { status: 404 });
+      post.commentCount = (post.commentCount ?? 0) + 1;
       const comment = {
         loungeCommentId: Date.now(),
         commentId: Date.now(),
@@ -176,9 +177,10 @@ export const loungeHandlers = [
       );
       if (parentComment) {
         const post = findPost(parentComment.loungePostId);
-        if (post) {
-          post.commentCount = (post.commentCount ?? 0) + 1;
-        }
+        if (!post) return HttpResponse.json({ message: 'Not Found' }, { status: 404 });
+        post.commentCount = (post.commentCount ?? 0) + 1;
+      } else {
+        return HttpResponse.json({ message: 'Parent comment not found' }, { status: 404 });
       }
       return created('/api/v1/lounge/comments/{parentCommentId}/replies', {
         loungeCommentId: Date.now(),

--- a/src/pages/LoungeBoardDetailPage.tsx
+++ b/src/pages/LoungeBoardDetailPage.tsx
@@ -21,17 +21,6 @@ import {
   useLoungeComments,
 } from '@/hooks/queries/useLoungeComments';
 import { useCreateLoungeReply } from '@/hooks/queries/useLoungeReplies';
-import type { LoungeBoardComment, LoungeBoardDetail } from '@/types/exhibition';
-import { formatRelativeTime } from '@/utils/date';
-
-const formatDate = (iso: string) => {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}.${m}.${day}`;
-};
 
 export const LoungeBoardDetailPage = () => {
   const navigate = useNavigate();
@@ -114,45 +103,14 @@ export const LoungeBoardDetailPage = () => {
   const isValidPost = isValidCategory && !!post && postCategoryKey === category;
   const isLoading = isPostPending || isCommentsPending;
 
-  const review: LoungeBoardDetail | undefined =
-    isValidPost && commentsData
-      ? {
-          id: String(post.loungePostId),
-          category: postCategoryKey,
-          title: post.title,
-          author: post.writer.nickname,
-          date: formatDate(post.createdAt),
-          content: post.content.split('\n').filter((line) => line.length > 0),
-          likeCount: post.likeCount,
-          isLiked: post.isLiked,
-          isSaved: post.isScrapped,
-          isMyPost: post.isMyPost,
-          images: post.postImageUrls.length > 0 ? post.postImageUrls : undefined,
-          comments: commentsData.pages
-            .flatMap((page) => page.comments)
-            .map(
-              (comment): LoungeBoardComment => ({
-                id: String(comment.loungeCommentId),
-                author: comment.writer.nickname,
-                avatarUrl: comment.writer.profileImageUrl,
-                time: formatRelativeTime(comment.createdAt),
-                content: comment.content,
-                likeCount: comment.likeCount,
-                isLiked: comment.isLiked,
-                isMyComment: comment.isMyComment,
-                replyCount: comment.replyCount,
-                commentStatus: comment.commentStatus,
-                images: comment.imageUrls.length > 0 ? comment.imageUrls : undefined,
-              }),
-            ),
-        }
-      : undefined;
-
-  const visibleComments = review
-    ? review.comments
+  const visibleComments = commentsData
+    ? commentsData.pages
+        .flatMap((page) => page.comments)
         .map((comment) => ({
           comment,
-          isDeleted: comment.commentStatus === 'DELETED' || deletedCommentIds.has(comment.id),
+          isDeleted:
+            comment.commentStatus === 'DELETED' ||
+            deletedCommentIds.has(String(comment.loungeCommentId)),
         }))
         .filter(({ isDeleted, comment }) => !(isDeleted && (comment.replyCount ?? 0) === 0))
     : [];
@@ -181,13 +139,13 @@ export const LoungeBoardDetailPage = () => {
           message="잠시 후 다시 시도해주세요."
           onRetry={() => refetchComments()}
         />
-      ) : review ? (
+      ) : isValidPost && post ? (
         <>
           <main className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-5 pt-5 pb-28 flex flex-col gap-7">
             {/* 게시글 정보 섹션 */}
             <article className="flex flex-col items-center gap-7.5">
               <LoungeBoardPostDetail
-                review={review}
+                post={post}
                 onEdit={() => navigate(`/lounge/${category}/${id}/edit`)}
                 onDelete={() =>
                   deletePostMutation.mutate(postId, { onSuccess: () => navigate(-1) })
@@ -195,9 +153,9 @@ export const LoungeBoardDetailPage = () => {
               />
               <LoungeBoardActionBar
                 postId={postId}
-                likeCount={review.likeCount}
-                isLiked={review.isLiked}
-                isSaved={review.isSaved}
+                likeCount={post.likeCount}
+                isLiked={post.isLiked}
+                isSaved={post.isScrapped}
                 hasComments={visibleComments.length > 0}
               />
             </article>
@@ -207,7 +165,7 @@ export const LoungeBoardDetailPage = () => {
               <section className="w-full flex flex-col">
                 {visibleComments.map(({ comment, isDeleted }) => (
                   <LoungeBoardCommentItem
-                    key={comment.id}
+                    key={comment.loungeCommentId}
                     postId={postId}
                     comment={comment}
                     isDeleted={isDeleted}

--- a/src/pages/LoungeBoardDetailPage.tsx
+++ b/src/pages/LoungeBoardDetailPage.tsx
@@ -47,32 +47,36 @@ export const LoungeBoardDetailPage = () => {
   const createReplyMutation = useCreateLoungeReply();
   const deletePostMutation = useDeleteLoungePost();
 
-  const [replyTarget, setReplyTarget] = useState<{ commentId: number; author: string } | null>(
-    null,
-  );
-  const [activeReplyId, setActiveReplyId] = useState<string | null>(null);
+  const [replyState, setReplyState] = useState<{
+    commentId: number;
+    author: string;
+    highlightId: string;
+  } | null>(null);
   const [deletedCommentIds, setDeletedCommentIds] = useState<Set<string>>(new Set());
 
   const clearReplyTarget = () => {
-    setReplyTarget(null);
-    setActiveReplyId(null);
+    setReplyState(null);
   };
 
   const handleReplyClick = useCallback((commentId: number, author: string, highlightId: string) => {
-    setActiveReplyId((prev) => {
-      if (prev === highlightId) {
-        setReplyTarget(null);
+    setReplyState((prev) => {
+      if (prev?.highlightId === highlightId) {
         return null;
       }
-      setReplyTarget({ commentId, author });
-      return highlightId;
+      return { commentId, author, highlightId };
     });
   }, []);
 
   const handleDeleteComment = useCallback(
     (commentId: string) => {
-      deleteCommentMutation.mutate({ postId, commentId: Number(commentId) });
-      setDeletedCommentIds((prev) => new Set(prev).add(commentId));
+      deleteCommentMutation.mutate(
+        { postId, commentId: Number(commentId) },
+        {
+          onSuccess: () => {
+            setDeletedCommentIds((prev) => new Set(prev).add(commentId));
+          },
+        },
+      );
     },
     [deleteCommentMutation, postId],
   );
@@ -171,7 +175,7 @@ export const LoungeBoardDetailPage = () => {
                     isDeleted={isDeleted}
                     onDelete={handleDeleteComment}
                     onReplyClick={handleReplyClick}
-                    activeReplyId={activeReplyId}
+                    activeReplyId={replyState?.highlightId ?? null}
                   />
                 ))}
                 <div ref={commentsTriggerRef} className="h-4" />
@@ -188,15 +192,15 @@ export const LoungeBoardDetailPage = () => {
             placeholder="댓글을 입력하세요."
             imageDomain="lounge"
             isSubmitting={
-              replyTarget ? createReplyMutation.isPending : createCommentMutation.isPending
+              replyState ? createReplyMutation.isPending : createCommentMutation.isPending
             }
-            replyingTo={replyTarget?.author}
+            replyingTo={replyState?.author}
             onCancelReply={clearReplyTarget}
             onSubmit={({ content, images }) => {
               const imageUrls = images.map((image) => image.imageUrl);
-              if (replyTarget) {
+              if (replyState) {
                 createReplyMutation.mutate(
-                  { postId, commentId: replyTarget.commentId, body: { content, imageUrls } },
+                  { postId, commentId: replyState.commentId, body: { content, imageUrls } },
                   { onSuccess: clearReplyTarget },
                 );
                 return;

--- a/src/pages/LoungeBoardDetailPage.tsx
+++ b/src/pages/LoungeBoardDetailPage.tsx
@@ -70,8 +70,14 @@ export const LoungeBoardDetailPage = () => {
   };
 
   const handleReplyClick = useCallback((commentId: number, author: string, highlightId: string) => {
-    setReplyTarget({ commentId, author });
-    setActiveReplyId(highlightId);
+    setActiveReplyId((prev) => {
+      if (prev === highlightId) {
+        setReplyTarget(null);
+        return null;
+      }
+      setReplyTarget({ commentId, author });
+      return highlightId;
+    });
   }, []);
 
   const handleDeleteComment = useCallback(
@@ -142,6 +148,15 @@ export const LoungeBoardDetailPage = () => {
         }
       : undefined;
 
+  const visibleComments = review
+    ? review.comments
+        .map((comment) => ({
+          comment,
+          isDeleted: comment.commentStatus === 'DELETED' || deletedCommentIds.has(comment.id),
+        }))
+        .filter(({ isDeleted, comment }) => !(isDeleted && (comment.replyCount ?? 0) === 0))
+    : [];
+
   return (
     <div className="w-full max-w-md mx-auto h-dvh bg-page flex flex-col">
       <LoungeBoardHeader
@@ -168,8 +183,9 @@ export const LoungeBoardDetailPage = () => {
         />
       ) : review ? (
         <>
-          <main className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-5 pt-5 pb-28">
-            <div className="flex flex-col items-center gap-7.5">
+          <main className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-5 pt-5 pb-28 flex flex-col gap-7">
+            {/* 게시글 정보 섹션 */}
+            <article className="flex flex-col items-center gap-7.5">
               <LoungeBoardPostDetail
                 review={review}
                 onEdit={() => navigate(`/lounge/${category}/${id}/edit`)}
@@ -177,46 +193,37 @@ export const LoungeBoardDetailPage = () => {
                   deletePostMutation.mutate(postId, { onSuccess: () => navigate(-1) })
                 }
               />
+              <LoungeBoardActionBar
+                postId={postId}
+                likeCount={review.likeCount}
+                isLiked={review.isLiked}
+                isSaved={review.isSaved}
+                hasComments={visibleComments.length > 0}
+              />
+            </article>
 
-              <div className="w-full flex flex-col items-center gap-7">
-                <LoungeBoardActionBar
-                  postId={postId}
-                  likeCount={review.likeCount}
-                  isLiked={review.isLiked}
-                  isSaved={review.isSaved}
-                />
-
-                <div className="w-full flex flex-col">
-                  {review.comments
-                    .map((comment) => ({
-                      comment,
-                      isDeleted:
-                        comment.commentStatus === 'DELETED' || deletedCommentIds.has(comment.id),
-                    }))
-                    // 답글 없는 삭제된 부모 댓글은 목록에서 완전히 제외
-                    .filter(
-                      ({ isDeleted, comment }) => !(isDeleted && (comment.replyCount ?? 0) === 0),
-                    )
-                    .map(({ comment, isDeleted }) => (
-                      <LoungeBoardCommentItem
-                        key={comment.id}
-                        postId={postId}
-                        comment={comment}
-                        isDeleted={isDeleted}
-                        onDelete={handleDeleteComment}
-                        onReplyClick={handleReplyClick}
-                        activeReplyId={activeReplyId}
-                      />
-                    ))}
-                  <div ref={commentsTriggerRef} className="h-4" />
-                  {isFetchingMoreComments && (
-                    <div className="py-4 text-center text-sub600 typo-body-xs-regular animate-pulse">
-                      불러오는 중...
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
+            {/* 댓글 정보 섹션 */}
+            {visibleComments.length > 0 && (
+              <section className="w-full flex flex-col">
+                {visibleComments.map(({ comment, isDeleted }) => (
+                  <LoungeBoardCommentItem
+                    key={comment.id}
+                    postId={postId}
+                    comment={comment}
+                    isDeleted={isDeleted}
+                    onDelete={handleDeleteComment}
+                    onReplyClick={handleReplyClick}
+                    activeReplyId={activeReplyId}
+                  />
+                ))}
+                <div ref={commentsTriggerRef} className="h-4" />
+                {isFetchingMoreComments && (
+                  <div className="py-4 text-center text-sub600 typo-body-xs-regular animate-pulse">
+                    불러오는 중...
+                  </div>
+                )}
+              </section>
+            )}
           </main>
 
           <BottomCommentBar

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -33,244 +33,6 @@ const POLICY_TERM_KEYS: Record<PolicyCode, Exclude<TermKey, 'over14'>> = {
   location: 'location',
 };
 
-const POLICY_DOCUMENTS: Record<
-  PolicyCode,
-  {
-    title: string;
-    intro: string;
-    sections: Array<{
-      title: string;
-      paragraphs?: string[];
-      bullets?: string[];
-      definitions?: Array<{ label: string; description: string }>;
-      note?: string;
-    }>;
-    footer?: Array<{ label: string; description: string }>;
-  }
-> = {
-  terms: {
-    title: '서비스 이용약관',
-    intro: '디유 서비스를 이용하기 전에 서비스 이용 조건과 회원의 권리 및 의무를 확인해 주세요.',
-    sections: [
-      {
-        title: '제1조 목적',
-        paragraphs: [
-          '이 약관은 디유가 제공하는 대학생 전시 및 작품 관련 서비스의 이용 조건과 운영자와 회원 간의 권리·의무를 정하는 것을 목적으로 합니다.',
-        ],
-      },
-      {
-        title: '제2조 용어의 정의',
-        definitions: [
-          {
-            label: '서비스',
-            description: '디유가 제공하는 대학생 전시 탐색, 작품 감상, 전시 등록 및 소통 기능 일체',
-          },
-          { label: '회원', description: '소셜로그인을 통해 가입하고 이 약관에 동의한 이용자' },
-          {
-            label: '작가 인증 회원',
-            description: '학교 이메일 인증을 완료하고 작가 프로필을 보유한 회원',
-          },
-          { label: '전시 대표자', description: '전시를 최초 등록하고 관리 권한을 보유한 회원' },
-          {
-            label: '전시 팀원',
-            description: '대표자의 초대를 수락하고 전시 콘텐츠 관리에 참여하는 회원',
-          },
-          {
-            label: '전시·작품 콘텐츠',
-            description: '회원이 등록한 전시 정보, 작품 이미지, 설명, 방명록, Q&A 등 일체',
-          },
-        ],
-      },
-      {
-        title: '제3조 회원가입 및 계정 관리',
-        bullets: [
-          '카카오, 구글 소셜로그인을 통해 가입할 수 있습니다.',
-          '계정 정보는 정확하게 유지하고 관리해야 합니다.',
-          '계정을 타인에게 양도하거나 공유할 수 없습니다.',
-          '만 14세 이상인 이용자만 가입할 수 있습니다.',
-        ],
-      },
-      {
-        title: '제4조 서비스의 제공',
-        bullets: [
-          '전시 탐색 및 상세 정보 열람',
-          '전시와 작품 등록',
-          '전시 팀원 초대 및 공동 관리',
-          '방명록, Q&A, 라운지 등 소통 기능',
-          '전시와 작품 저장 및 개인 메모 기능',
-        ],
-      },
-      {
-        title: '제5조 전시 대표자와 팀원의 권한',
-        bullets: [
-          '전시 대표자는 전시 정보 관리, 팀원 초대, 공개 및 삭제 권한을 가집니다.',
-          '팀원은 부여된 범위 안에서 전시 콘텐츠를 등록하고 관리할 수 있습니다.',
-          '전시 등록과 공개에 대한 최종 책임은 전시 대표자에게 있습니다.',
-        ],
-      },
-      {
-        title: '제6조 회원의 의무',
-        bullets: [
-          '타인의 개인정보 또는 작품을 무단으로 등록해서는 안 됩니다.',
-          '저작권을 침해하거나 불법적인 콘텐츠를 게시해서는 안 됩니다.',
-          '서비스 운영을 방해하는 행동을 할 수 없습니다.',
-        ],
-      },
-      {
-        title: '제7조 게시물과 저작권',
-        bullets: [
-          '회원이 직접 제작한 게시물의 권리는 원칙적으로 회원에게 있습니다.',
-          '회원은 서비스 운영, 전시 및 공유에 필요한 범위에서 디유가 콘텐츠를 노출할 수 있도록 허락합니다.',
-          '권리 침해 신고가 접수되면 콘텐츠가 임시 제한될 수 있습니다.',
-        ],
-      },
-      {
-        title: '제8조 서비스 변경 및 중단',
-        bullets: [
-          '점검, 장애, 운영상 필요에 따라 일부 서비스가 변경되거나 일시 중단될 수 있습니다.',
-          '중요한 변경 사항은 서비스 내에서 사전에 안내합니다.',
-        ],
-      },
-      {
-        title: '제9조 이용 제한',
-        paragraphs: [
-          '타인 사칭, 권리 침해, 불법 콘텐츠 게시, 반복적인 운영 방해 등이 확인될 경우 사전 통지 없이 서비스 이용이 제한될 수 있습니다.',
-        ],
-      },
-      {
-        title: '제10조 회원 탈퇴',
-        bullets: [
-          '회원은 설정 메뉴에서 언제든지 탈퇴할 수 있습니다.',
-          '탈퇴 완료 후 개인정보는 지체 없이 파기합니다.',
-          '회원이 작성한 게시글, 댓글, 방명록, Q&A는 자동 삭제되지 않을 수 있습니다.',
-          "탈퇴 이후 작성자는 '탈퇴한 사용자'로 표시됩니다.",
-          '삭제가 필요한 콘텐츠는 탈퇴 전에 직접 삭제해 주세요.',
-        ],
-      },
-    ],
-    footer: [
-      { label: '서비스명', description: '디유(displayU)' },
-      { label: '운영자', description: '고상준' },
-      { label: '문의 이메일', description: 'displayu.official@gmail.com' },
-    ],
-  },
-  privacy: {
-    title: '개인정보 처리방침',
-    intro: '디유는 서비스 제공에 필요한 최소한의 개인정보를 수집하고 안전하게 관리합니다.',
-    sections: [
-      {
-        title: '1. 수집하는 개인정보',
-        bullets: [
-          '소셜로그인 식별자, 이메일, 닉네임',
-          '작가 인증을 위한 학교 이메일, 학교명, 인증 여부',
-          '서비스 이용 과정에서 생성되는 감상, 질문, 방명록 등 작성 콘텐츠',
-        ],
-      },
-      {
-        title: '2. 개인정보 이용 목적',
-        bullets: [
-          '회원 가입 및 계정 관리',
-          '작가 인증 및 전시 등록 권한 확인',
-          '전시 저장, 감상 작성, Q&A 등 서비스 기능 제공',
-          '고객 문의 응대 및 서비스 안정성 확보',
-        ],
-      },
-      {
-        title: '3. 보유 및 이용기간',
-        paragraphs: [
-          '개인정보는 회원 탈퇴 또는 처리 목적 달성 시 지체 없이 파기합니다. 다만 관련 법령에 따라 보관이 필요한 정보는 정해진 기간 동안 분리 보관합니다.',
-        ],
-      },
-      {
-        title: '4. 제3자 제공',
-        paragraphs: ['디유는 이용자의 개인정보를 동의 없이 외부에 제공하지 않습니다.'],
-      },
-      {
-        title: '5. 이용자의 권리',
-        paragraphs: ['이용자는 다음 권리를 행사할 수 있습니다.'],
-        bullets: ['개인정보 열람', '수정', '삭제', '처리 정지'],
-      },
-      {
-        title: '6. 작성 콘텐츠 처리',
-        note: '회원이 작성한 게시물, 댓글, 방명록 및 Q&A는 탈퇴 시 자동 삭제되지 않습니다. 탈퇴 전에 필요한 콘텐츠를 직접 삭제해 주세요.',
-      },
-      {
-        title: '7. 개인정보 보호 담당자',
-        paragraphs: [
-          '개인정보 보호책임자 고상준',
-          '담당 부서 디유 운영팀',
-          '이메일 displayu.official@gmail.com',
-        ],
-      },
-    ],
-  },
-  location: {
-    title: '위치기반서비스 이용약관',
-    intro: '현재 위치를 활용하여 가까운 전시를 표시합니다',
-    sections: [
-      {
-        title: '1. 위치기반서비스의 목적',
-        bullets: [
-          '이용자의 현재 위치를 기준으로 가까운 전시를 추천합니다.',
-          '현재 위치와 전시장 사이의 거리를 표시합니다.',
-        ],
-      },
-      {
-        title: '2. 이용하는 위치정보',
-        bullets: [
-          '이용자가 위치 권한을 허용한 시점의 현재 위치',
-          '위도 및 경도 기반의 위치값',
-          '지속적인 위치 추적이나 이동 경로 수집은 하지 않습니다.',
-        ],
-      },
-      {
-        title: '3. 위치정보 이용 방식',
-        bullets: [
-          "'내 주변 전시' 또는 거리 표시 기능을 이용할 때만 위치 권한을 요청합니다.",
-          '거리 계산과 가까운 전시 정렬에만 사용합니다.',
-          '위치정보를 이용자의 프로필에 공개하지 않습니다.',
-        ],
-      },
-      {
-        title: '4. 위치정보 보유기간',
-        bullets: [
-          'MVP에서는 현재 위치정보를 서버에 별도로 저장하지 않습니다.',
-          '추천 및 거리 계산이 완료된 후 위치값을 파기합니다.',
-          '실제 개발 방식이 변경되면 약관 내용도 함께 수정됩니다.',
-        ],
-      },
-      {
-        title: '5. 제3자 제공',
-        paragraphs: ['이용자의 개인위치정보를 제3자에게 제공하지 않습니다.'],
-      },
-      {
-        title: '6. 이용자의 권리',
-        bullets: [
-          '이용자는 위치정보 이용 동의를 거부할 수 있습니다.',
-          '브라우저 또는 기기 설정에서 위치 권한을 언제든지 철회할 수 있습니다.',
-          '동의하지 않아도 전시 검색과 일반 서비스는 이용 가능합니다.',
-          '근처 전시 추천 및 거리 표시 기능만 제한됩니다.',
-        ],
-      },
-      {
-        title: '7. 서비스 이용 중단',
-        bullets: [
-          '위치정보를 확인할 수 없거나 위치 권한이 차단된 경우 일반 전시 목록을 제공합니다.',
-          '기기 또는 네트워크 환경에 따라 실제 위치와 오차가 발생할 수 있습니다.',
-        ],
-      },
-      {
-        title: '8. 서비스 제공자 정보',
-        paragraphs: [
-          '서비스명 디유(displayU)',
-          '운영자 고상준',
-          '문의 이메일 displayu.official@gmail.com',
-        ],
-      },
-    ],
-  },
-};
-
 function MobileShell({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-dvh w-full items-center justify-center bg-[#f0f0f0]">
@@ -452,21 +214,6 @@ function TermsScreen({
   );
 }
 
-function PolicyBulletList({ items }: { items: string[] }) {
-  return (
-    <ul className="flex flex-col gap-[6px] pt-3">
-      {items.map((item) => (
-        <li key={item} className="flex items-start gap-[10px]">
-          <span className="mt-[9px] size-[6px] shrink-0 rounded-full bg-[#d1d5db]" />
-          <span className="min-w-0 flex-1 text-[15px] leading-[24.75px] text-[#374151]">
-            {item}
-          </span>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
 function parsePolicyContent(content: string): ParsedPolicyBlock[] {
   return content
     .split(/\n+/)
@@ -528,15 +275,12 @@ function PolicyPlainContent({ content }: { content: string }) {
 
 function TermsDetailScreen({
   agreement,
-  code,
   onBack,
 }: {
   agreement?: AgreementDto;
-  code: PolicyCode;
   onBack: () => void;
 }) {
-  const document = POLICY_DOCUMENTS[code];
-  const title = agreement?.title ?? document.title;
+  const title = agreement?.title ?? '약관 상세';
 
   return (
     <>
@@ -555,68 +299,16 @@ function TermsDetailScreen({
       </header>
 
       <main className="flex-1 overflow-y-auto px-6 pb-8 pt-5">
-        <p className="text-[11.5px] leading-[17.25px] text-[#8a94a6]">
-          시행일 {agreement?.effectiveDate ?? '2026. 08. 01'} · 버전 {agreement?.version ?? '1.0'}
-        </p>
-
-        {agreement ? (
-          <PolicyPlainContent content={agreement.content} />
+        {!agreement ? (
+          <div className="py-10 text-center text-[14px] text-[#8a94a6]">
+            약관 정보를 불러오는 중이거나 문제가 발생했습니다.
+          </div>
         ) : (
           <>
-            <p className="pt-6 text-[15px] leading-[24.75px] text-[#8a94a6]">{document.intro}</p>
-
-            {document.sections.map((section) => (
-              <section key={section.title} className="w-full pt-8">
-                <h2 className="text-[17px] font-semibold leading-[25.5px] text-[#111827]">
-                  {section.title}
-                </h2>
-
-                {section.paragraphs ? (
-                  <div className="flex flex-col gap-[6px] pt-3">
-                    {section.paragraphs.map((paragraph) => (
-                      <p key={paragraph} className="text-[15px] leading-[24.75px] text-[#374151]">
-                        {paragraph}
-                      </p>
-                    ))}
-                  </div>
-                ) : null}
-
-                {section.definitions ? (
-                  <div className="flex flex-col gap-3 pt-3">
-                    {section.definitions.map((definition) => (
-                      <p
-                        key={definition.label}
-                        className="text-[15px] leading-[24.75px] text-[#111827]"
-                      >
-                        <span className="font-medium">{definition.label}</span>
-                        <span className="text-[#374151]">: {definition.description}</span>
-                      </p>
-                    ))}
-                  </div>
-                ) : null}
-
-                {section.bullets ? <PolicyBulletList items={section.bullets} /> : null}
-
-                {section.note ? (
-                  <div className="mt-3 rounded-lg bg-[#f9fafb] p-4">
-                    <p className="text-[15px] leading-6 text-[#374151]">{section.note}</p>
-                  </div>
-                ) : null}
-              </section>
-            ))}
-
-            {document.footer ? (
-              <footer className="mt-8 border-t border-[#e5e7eb] pt-[25px]">
-                <div className="flex flex-col gap-[6px]">
-                  {document.footer.map((row) => (
-                    <p key={row.label} className="text-[13px] leading-[19.5px]">
-                      <span className="font-medium text-[#374151]">{row.label}</span>
-                      <span className="text-[#8a94a6]"> {row.description}</span>
-                    </p>
-                  ))}
-                </div>
-              </footer>
-            ) : null}
+            <p className="text-[11.5px] leading-[17.25px] text-[#8a94a6]">
+              시행일 {agreement.effectiveDate} · 버전 {agreement.version}
+            </p>
+            <PolicyPlainContent content={agreement.content} />
           </>
         )}
       </main>
@@ -902,7 +594,6 @@ export function OnboardingPage() {
       {step === 'termsDetail' ? (
         <TermsDetailScreen
           agreement={findAgreement(POLICY_TERM_KEYS[selectedPolicy])}
-          code={selectedPolicy}
           onBack={() => setStep('terms')}
         />
       ) : null}

--- a/src/types/exhibition.ts
+++ b/src/types/exhibition.ts
@@ -38,36 +38,6 @@ export interface LoungeBoardPost {
   images?: string[];
 }
 
-export interface LoungeBoardComment {
-  id: string;
-  author: string;
-  avatarUrl?: string | null;
-  time: string;
-  content: string;
-  likeCount: number;
-  isLiked: boolean;
-  isMyComment?: boolean;
-  replyCount?: number;
-  commentStatus?: string;
-  images?: string[];
-  replies?: LoungeBoardComment[];
-}
-
-export interface LoungeBoardDetail {
-  id: string;
-  category: LoungeCategoryKey;
-  title: string;
-  author: string;
-  date: string;
-  content: string[];
-  likeCount: number;
-  isLiked: boolean;
-  isSaved: boolean;
-  isMyPost?: boolean;
-  images?: string[];
-  comments: LoungeBoardComment[];
-}
-
 // ─── Detail Types ──────────────────────────────────────────────────────────
 
 export type DetailTabKey = 'intro' | 'artwork' | 'review';


### PR DESCRIPTION
## 📝 작업 내용

- 라운지 메인화면 규격 문제를 수정했습니다.
- 라운지 메인화면 svg가 더 빨리 불려오도록 개선하였습니다. (Vite의 ?inline 모듈 임포트 구문 적용)
- 라운지 게시글 및 댓글들의 UI를 전면 수정하였습니다. 이제 피그마와 똑같습니다.
- 라운지 게시글 및 댓글들이 제대로 업데이트 되지 않는 문제를 해결하였습니다.
- 글 작성에서 사진이 3장 이상일 때 이제 옆으로 슬라이드 되도록 수정하였습니다.
- 기존의 라운지 정보가 types의 exhibition.ts  api폴더의 dto정보와 연결되도록 하였습니다.

- QA에서 나온 문제를 전부 해결했습니다!
- 겸사겸사 약관페이지 api 연동했습니다.

## 🔍 관련 이슈

- close #198

## 🖼️ 스크린샷

<img width="388" height="842" alt="image" src="https://github.com/user-attachments/assets/18114557-b4af-4f4e-9f72-fef060d7427b" />
<img width="386" height="841" alt="image" src="https://github.com/user-attachments/assets/6a75d2c1-f88a-4de6-9782-9d2160c4f611" />


## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 댓글과 게시글 이미지를 클릭해 전체 화면으로 확대해서 볼 수 있습니다.
  * 이미지 업로드 목록을 가로로 스크롤할 수 있습니다.
  * 댓글 좋아요 버튼 위치가 화면 구성에 맞게 표시됩니다.

* **개선**
  * 댓글 및 답글 작성·삭제 후 게시글의 댓글 수와 목록이 즉시 갱신됩니다.
  * 동일한 댓글을 다시 선택하면 답글 작성 대상이 해제됩니다.
  * 게시글 상세 화면의 본문, 작성자 정보, 이미지 및 댓글 표시가 개선되었습니다.

* **스타일**
  * 라운지 카드, 댓글 영역, 헤더와 버튼의 간격 및 색상이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->