### PR TITLE
fix: 작가 인증 흐름 API 호출 정리

### DIFF
--- a/src/components/artist-verification/VerificationTextField.tsx
+++ b/src/components/artist-verification/VerificationTextField.tsx
@@ -49,11 +49,8 @@ export function VerificationTextField({
         inputMode={inputMode}
         onBlur={onBlur}
         onChange={(event) => {
-          if (registerOnChange) {
-            registerOnChange(event);
-          } else {
-            onChange?.(event.target.value);
-          }
+          registerOnChange?.(event);
+          onChange?.(event.target.value);
         }}
         placeholder={placeholder}
         className="min-w-0 flex-1 bg-transparent typo-body-sm-regular text-main outline-none placeholder:text-line"

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { Outlet, useLocation, useMatches } from 'react-router-dom';
 
-import { useMyArtistProfile, useUserMe } from '@/hooks/queries/useUserProfile';
+import { useUserMe } from '@/hooks/queries/useUserProfile';
 import { useRedirectAfterLogin } from '@/hooks/usePendingRedirect';
 import { useUserStore } from '@/stores/useUserStore';
 import { cn } from '@/utils/cn';
@@ -19,19 +19,13 @@ export function Layout() {
   const matches = useMatches();
   const [manualFooterHidden, setManualFooterHidden] = useState(false);
 
-  /* 로그인 상태일 때 계정 정보와 작가 프로필을 userStore에 sync합니다. */
+  /* 로그인 상태일 때 계정 정보를 userStore에 sync합니다. */
   const { data: userMe } = useUserMe();
-  const { data: artistProfile } = useMyArtistProfile({ enabled: !!userMe });
   const setUserMe = useUserStore((s) => s.setUserMe);
-  const setArtistProfile = useUserStore((s) => s.setArtistProfile);
 
   useEffect(() => {
     if (userMe) setUserMe(userMe);
   }, [userMe, setUserMe]);
-
-  useEffect(() => {
-    if (artistProfile) setArtistProfile(artistProfile);
-  }, [artistProfile, setArtistProfile]);
 
   // 로그인 후 복귀 경로가 있는 경우 이동 처리
   useRedirectAfterLogin();

--- a/src/pages/artist-verification/ArtistVerificationPage.tsx
+++ b/src/pages/artist-verification/ArtistVerificationPage.tsx
@@ -235,6 +235,7 @@ export function ArtistVerificationPage() {
                 const { onChange: regOnChange, onBlur, ref, name } = register('artistName');
                 return (
                   <ArtistProfileSection
+                    value={artistName}
                     error={Boolean(errors.artistName)}
                     name={name}
                     onBlur={onBlur}


### PR DESCRIPTION
## 📝 작업 내용

- 작가 인증 프로필명 입력값 동기화 오류를 수정했습니다.
- 작가 프로필 자동 조회로 발생하던 불필요한 API 호출을 제거했습니다.

## 🔍 관련 이슈

- close #214

## 🧪 테스트 결과

- [x] pnpm lint
- [x] pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 작가 인증 입력란에서 기본 변경 처리와 추가 변경 처리가 모두 정상적으로 실행됩니다.
  * 작가 프로필 이름 입력값이 현재 상태와 올바르게 동기화됩니다.

* **개선**
  * 레이아웃에서 불필요한 작가 프로필 조회 및 동기화 처리를 제거해 동작을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->