### PR TITLE
fix: 작가 인증 입력 필드 ref 전달 수정

### DIFF
--- a/src/components/artist-verification/ArtistProfileSection.tsx
+++ b/src/components/artist-verification/ArtistProfileSection.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react';
+
 import { ArtistVerificationField } from './ArtistVerificationField';
 import { VerificationTextField } from './VerificationTextField';
 
@@ -7,37 +9,32 @@ interface ArtistProfileSectionProps {
   // RHF attributes
   name?: string;
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
-  ref?: React.Ref<HTMLInputElement>;
   error?: boolean;
   registerOnChange?: React.ChangeEventHandler<HTMLInputElement>;
 }
 
-export function ArtistProfileSection({
-  value,
-  onChange,
-  name,
-  onBlur,
-  ref,
-  error,
-  registerOnChange,
-}: ArtistProfileSectionProps) {
-  return (
-    <ArtistVerificationField
-      label="대표 작가 프로필명"
-      htmlFor="artist-profile-name"
-      className="mt-8"
-    >
-      <VerificationTextField
-        id="artist-profile-name"
-        value={value}
-        onChange={onChange}
-        placeholder="작가 프로필명"
-        name={name}
-        onBlur={onBlur}
-        ref={ref}
-        error={error}
-        registerOnChange={registerOnChange}
-      />
-    </ArtistVerificationField>
-  );
-}
+export const ArtistProfileSection = forwardRef<HTMLInputElement, ArtistProfileSectionProps>(
+  ({ value, onChange, name, onBlur, error, registerOnChange }, ref) => {
+    return (
+      <ArtistVerificationField
+        label="대표 작가 프로필명"
+        htmlFor="artist-profile-name"
+        className="mt-8"
+      >
+        <VerificationTextField
+          id="artist-profile-name"
+          value={value}
+          onChange={onChange}
+          placeholder="작가 프로필명"
+          name={name}
+          onBlur={onBlur}
+          ref={ref}
+          error={error}
+          registerOnChange={registerOnChange}
+        />
+      </ArtistVerificationField>
+    );
+  },
+);
+
+ArtistProfileSection.displayName = 'ArtistProfileSection';

--- a/src/components/artist-verification/VerificationTextField.tsx
+++ b/src/components/artist-verification/VerificationTextField.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { forwardRef, type ReactNode } from 'react';
 
 import { cn } from '@/utils/cn';
 
@@ -14,48 +14,53 @@ interface VerificationTextFieldProps {
   // react-hook-form 호환성
   name?: string;
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
-  ref?: React.Ref<HTMLInputElement>;
   // RHF 전용 onChange 매핑
   registerOnChange?: React.ChangeEventHandler<HTMLInputElement>;
 }
 
-export function VerificationTextField({
-  id,
-  placeholder,
-  value,
-  onChange,
-  right,
-  error,
-  inputMode,
-  maxLength,
-  name,
-  onBlur,
-  ref,
-  registerOnChange,
-}: VerificationTextFieldProps) {
-  return (
-    <div
-      className={cn(
-        'flex h-10 items-center border-b px-3 pb-px',
-        error ? 'border-error' : value ? 'border-hint' : 'border-line',
-      )}
-    >
-      <input
-        id={id}
-        name={name}
-        value={value}
-        ref={ref}
-        maxLength={maxLength}
-        inputMode={inputMode}
-        onBlur={onBlur}
-        onChange={(event) => {
-          registerOnChange?.(event);
-          onChange?.(event.target.value);
-        }}
-        placeholder={placeholder}
-        className="min-w-0 flex-1 bg-transparent typo-body-sm-regular text-main outline-none placeholder:text-line"
-      />
-      {right}
-    </div>
-  );
-}
+export const VerificationTextField = forwardRef<HTMLInputElement, VerificationTextFieldProps>(
+  (
+    {
+      id,
+      placeholder,
+      value,
+      onChange,
+      right,
+      error,
+      inputMode,
+      maxLength,
+      name,
+      onBlur,
+      registerOnChange,
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        className={cn(
+          'flex h-10 items-center border-b px-3 pb-px',
+          error ? 'border-error' : value ? 'border-hint' : 'border-line',
+        )}
+      >
+        <input
+          id={id}
+          name={name}
+          value={value}
+          ref={ref}
+          maxLength={maxLength}
+          inputMode={inputMode}
+          onBlur={onBlur}
+          onChange={(event) => {
+            registerOnChange?.(event);
+            onChange?.(event.target.value);
+          }}
+          placeholder={placeholder}
+          className="min-w-0 flex-1 bg-transparent typo-body-sm-regular text-main outline-none placeholder:text-line"
+        />
+        {right}
+      </div>
+    );
+  },
+);
+
+VerificationTextField.displayName = 'VerificationTextField';


### PR DESCRIPTION
## 📝 작업 내용

- 작가 인증 페이지에서 작가명 입력 필드의 `ref` 전달 오류를 수정했습니다.
- `ArtistProfileSection`, `VerificationTextField`에 `forwardRef`를 적용해 RHF 등록이 정상 동작하도록 수정했습니다.

## 🔍 관련 이슈

- close #216

## 🖼️ 스크린샷

- 생략

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함

## 💬 기타 참고 사항

- `pnpm lint`, `pnpm exec tsc -b` 통과했습니다.