### PR TITLE
fix: 작가 인증 상태 서버와 동기화

### DIFF
--- a/src/api/dto/artist.dto.ts
+++ b/src/api/dto/artist.dto.ts
@@ -1,9 +1,17 @@
 import type { ApiResponseDto } from './common.dto';
-import type { ArtistProfileDto } from './user.dto';
 
 export interface CreateArtistProfileRequestDto {
   artistName: string;
   activityFields: string[];
 }
 
-export type CreateArtistProfileResponseDto = ApiResponseDto<ArtistProfileDto>;
+export interface CreateArtistProfileResponseDataDto {
+  artistProfileId: number;
+  artistName: string;
+  schoolEmail: string;
+  univName: string;
+  activityFields: string[];
+  isVerified: boolean;
+}
+
+export type CreateArtistProfileResponseDto = ApiResponseDto<CreateArtistProfileResponseDataDto>;

--- a/src/api/endpoints/artist.ts
+++ b/src/api/endpoints/artist.ts
@@ -1,6 +1,7 @@
 import type {
   ArtistProfileDto,
   CreateArtistProfileRequestDto,
+  CreateArtistProfileResponseDataDto,
   UpdateArtistProfileRequestDto,
   UpdateArtistProfileResponseDataDto,
 } from '@/api/dto';
@@ -10,7 +11,7 @@ import { apiRequest } from '../client';
 // POST /v1/artists/me/artist-profile
 export const createMyArtistProfile = async (
   body: CreateArtistProfileRequestDto,
-): Promise<ArtistProfileDto> =>
+): Promise<CreateArtistProfileResponseDataDto> =>
   apiRequest('/v1/artists/me/artist-profile', { method: 'POST', body });
 
 // GET /v1/artists/me/artist-profile

--- a/src/hooks/queries/useUserProfile.ts
+++ b/src/hooks/queries/useUserProfile.ts
@@ -91,9 +91,18 @@ export const useCreateMyArtistProfile = () => {
 
   return useMutation({
     mutationFn: (body: CreateArtistProfileRequestDto) => createMyArtistProfile(body),
-    onSuccess: () => {
+    onSuccess: (artistProfile) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.artistProfile() });
       queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+
+      const storedUser = useAuthStore.getState().user;
+
+      if (!storedUser) return;
+
+      useAuthStore.getState().setUser({
+        ...storedUser,
+        isArtistVerified: artistProfile.isVerified,
+      });
     },
   });
 };

--- a/src/hooks/queries/useUserProfile.ts
+++ b/src/hooks/queries/useUserProfile.ts
@@ -93,6 +93,7 @@ export const useCreateMyArtistProfile = () => {
     mutationFn: (body: CreateArtistProfileRequestDto) => createMyArtistProfile(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.artistProfile() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
     },
   });
 };

--- a/src/mocks/handlers/artist.ts
+++ b/src/mocks/handlers/artist.ts
@@ -5,25 +5,33 @@ import { created, paths, readJson, success } from '@/mocks/response';
 
 type MockArtistProfile = {
   artistId: number;
+  artistProfileId: number;
   userId: number;
   artistName: string;
   nickname: string;
   profileImageUrl: string | null;
+  schoolEmail: string;
+  univName: string;
   introduction?: string;
   activityFields: string[];
   fields: string[];
+  isVerified: boolean;
   status: string;
 };
 
 let myArtistProfile: MockArtistProfile = {
   artistId: 1,
+  artistProfileId: 1,
   userId: mockDb.me.userId,
   artistName: mockDb.me.nickname,
   nickname: mockDb.me.nickname,
   profileImageUrl: mockDb.me.profileImageUrl,
+  schoolEmail: mockDb.me.schoolEmail,
+  univName: mockDb.me.school,
   introduction: '전시와 작품을 기록하는 작가 프로필입니다.',
   activityFields: ['회화'],
   fields: ['회화'],
+  isVerified: mockDb.me.isVerified,
   status: 'ACTIVE',
 };
 
@@ -36,13 +44,17 @@ export const artistHandlers = [
       const body = await readJson<Partial<MockArtistProfile>>(request);
       myArtistProfile = {
         artistId: 1,
+        artistProfileId: 1,
         userId: mockDb.me.userId,
         artistName: body.artistName ?? mockDb.me.nickname,
         nickname: mockDb.me.nickname,
         profileImageUrl: mockDb.me.profileImageUrl,
+        schoolEmail: mockDb.me.schoolEmail,
+        univName: mockDb.me.school,
         introduction: body.introduction ?? '',
         activityFields: body.activityFields ?? [],
         fields: body.fields ?? body.activityFields ?? [],
+        isVerified: true,
         status: 'ACTIVE',
       };
       mockDb.me.isVerified = true;

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -85,7 +85,6 @@ export const userHandlers = [
     http.post(path, async ({ request }) => {
       const body = await readJson<{ schoolEmail?: string }>(request);
       mockDb.me.schoolEmail = body.schoolEmail ?? mockDb.me.schoolEmail;
-      mockDb.me.isVerified = true;
       mockDb.me.isEmailVerified = true;
 
       return success('/api/v1/users/me/verification/email/confirm', {


### PR DESCRIPTION
## 📝 작업 내용

- 작가 프로필 생성 성공 후 `users.me()` 쿼리를 invalidate하도록 수정했습니다.
- 이메일 인증 완료만으로 mock 유저의 `isVerified`가 true로 변경되지 않도록 수정했습니다.
- DTO 최신화
-  작가 프로필 생성 후 응답받은 isVerified 상태를 즉시 authStore에 반영

## 🔍 관련 이슈

- close #218

## 🖼️ 스크린샷

<img width="533" height="654" alt="스크린샷 2026-08-11 오후 7 21 29" src="https://github.com/user-attachments/assets/d41c71c0-8624-49ab-8281-325311b2f1a7" />

## 🧪 테스트 결과

- [x] 정상 작동 확인 (`pnpm build`)
- [x] 중간에 작가 인증을 나가도 사용자 일관성이 깨지지 않는지

## 💬 기타 참고 사항

- `isVerified`는 이메일 인증 응답값이 아니라 `/users/me`에서 내려주는 서버 상태를 기준으로 사용합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 아티스트 프로필 생성 후 프로필과 현재 사용자 정보가 최신 상태로 반영됩니다.
  * 이메일 인증 확인 결과가 일관되게 표시되도록 개선했습니다.
  * 아티스트 프로필 생성 응답에 프로필 ID, 학교 이메일, 대학명, 활동 분야 및 인증 상태가 정확히 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->