### PR TITLE
fix: 아카이브 메모 요청 필드 최신화

### DIFF
--- a/src/api/dto/archive.dto.ts
+++ b/src/api/dto/archive.dto.ts
@@ -102,7 +102,7 @@ export interface GetArchivedArtistsResponseDataDto {
 export type GetArchivedArtistsResponseDto = ApiResponseDto<GetArchivedArtistsResponseDataDto>;
 
 export interface ArchiveMemoRequestDto {
-  memo: string;
+  content: string;
 }
 
 export type GetArchivedExhibitionResponseDto = ApiResponseDto<ArchivedExhibitionDto>;

--- a/src/api/dto/archive.dto.ts
+++ b/src/api/dto/archive.dto.ts
@@ -1,4 +1,4 @@
-import type { ApiResponseDto } from './common.dto';
+import type { ApiResponseDto, CursorPageInfoDto } from './common.dto';
 
 export interface ArchivedExhibitionStatusDto {
   exhibitionId: number;

--- a/src/hooks/queries/useArchive.ts
+++ b/src/hooks/queries/useArchive.ts
@@ -280,7 +280,7 @@ export const useUpdateArchivedExhibitionMemo = () => {
                 savedExhibitions:
                   previous.savedExhibitions?.map((exhibition) =>
                     exhibition.savedExhibitionId === archiveDisplayId
-                      ? { ...exhibition, memo: body.memo }
+                      ? { ...exhibition, memo: body.content }
                       : exhibition,
                   ) ?? [],
               }
@@ -332,7 +332,7 @@ export const useUpdateArchivedArtworkMemo = () => {
                 ...previous,
                 works: previous.works.map((artwork) =>
                   artwork.archiveWorkId === archiveWorkId
-                    ? { ...artwork, memo: body.memo }
+                    ? { ...artwork, memo: body.content }
                     : artwork,
                 ),
               }

--- a/src/mocks/handlers/archive.ts
+++ b/src/mocks/handlers/archive.ts
@@ -149,12 +149,13 @@ export const archiveHandlers = [
   ...paths('/api/v1/archives/artworks/{archiveWorkId}/memo').map((path) =>
     http.put(path, async ({ params, request }) => {
       const archiveWorkId = toNumber(params.archiveWorkId);
-      const body = await readJson<{ memo?: string }>(request);
-      const memo = body.memo ?? '';
+      const body = await readJson<{ content?: string }>(request);
+      const memo = body.content ?? '';
       updateArtworkMemo(archiveWorkId, memo);
 
       return success('/api/v1/archives/artworks/{archiveWorkId}/memo', {
         archiveWorkId,
+        memo,
         ...body,
       });
     }),
@@ -221,12 +222,13 @@ export const archiveHandlers = [
   ...paths('/api/v1/archives/exhibitions/{archiveDisplayId}/memo').map((path) =>
     http.put(path, async ({ params, request }) => {
       const archiveDisplayId = toNumber(params.archiveDisplayId);
-      const body = await readJson<{ memo?: string }>(request);
-      const memo = body.memo ?? '';
+      const body = await readJson<{ content?: string }>(request);
+      const memo = body.content ?? '';
       updateDisplayMemo(archiveDisplayId, memo);
 
       return success('/api/v1/archives/exhibitions/{archiveDisplayId}/memo', {
         archiveDisplayId,
+        memo,
         ...body,
       });
     }),

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -262,7 +262,7 @@ export function MyPage() {
     if (memo) {
       updateExhibitionMemo.mutate({
         archiveDisplayId: item.archiveDisplayId ?? Number(item.id),
-        body: { memo },
+        body: { content: memo },
       });
       return;
     }
@@ -273,7 +273,7 @@ export function MyPage() {
     if (memo) {
       updateArtworkMemo.mutate({
         archiveWorkId: item.archiveWorkId ?? Number(item.id),
-        body: { memo },
+        body: { content: memo },
       });
       return;
     }


### PR DESCRIPTION
## 📝 작업 내용

- 아카이브 메모 저장 요청 DTO 필드를 `memo`에서 `content`로 최신화
- 전시/작품 메모 저장 호출부 body를 `{ content }`로 변경
- 메모 저장 성공 시 캐시 반영 로직을 `body.content` 기준으로 수정
- MSW 아카이브 메모 PUT 핸들러도 `content` 요청 필드를 받도록 수정

## 🔍 관련 이슈

- close #226

## 🖼️ 스크린샷

- UI 변경 없음

## 🧪 테스트 결과

- [x] `pnpm build` 성공
- [ ] 테스트 코드 포함 (있다면)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 전시 및 작품 메모 저장·업데이트 요청의 입력 필드를 `memo`에서 `content`로 통일했습니다.
  * 메모 저장 후 화면에 표시되는 값과 응답 데이터가 올바르게 갱신됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->