### PR TITLE
fix: 전시 학교명 표시 위치 수정

### DIFF
--- a/src/api/dto/display.dto.ts
+++ b/src/api/dto/display.dto.ts
@@ -11,6 +11,7 @@ export interface HomeExhibitionDto {
   posterImageUrl: string;
   organization: string;
   department: string;
+  schoolDepartmentName?: string;
   startedAt: string;
   endedAt: string;
   dayLeft?: number;

--- a/src/components/displaydetailpage/ExhibitionMeta.tsx
+++ b/src/components/displaydetailpage/ExhibitionMeta.tsx
@@ -67,7 +67,7 @@ export function ExhibitionMeta({ display: ex }: Props) {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const fullSubtitle = [ex.organization, ex.subtitle].filter(Boolean).join(' ');
+  const fullSubtitle = ex.subtitle;
   const displayedLikeCount = ex.likeCount ?? 0;
   const canToggleArchive = hasPermission(archivePolicy, liked ? 'delete' : 'create');
   /* 로그인한 사용자만 해당. 실제 좋아요 여부를 확인하기 전에는 토글을 막아 중복 요청을 방지합니다. */

--- a/src/components/homepage/ExhibitionSection.tsx
+++ b/src/components/homepage/ExhibitionSection.tsx
@@ -29,7 +29,8 @@ function ExhibitionCard({
   onBookmarkClick: (displayId: number, saved: boolean, e: React.MouseEvent) => void;
 }) {
   const navigate = useNavigate();
-  const orgDept = [item.organization, item.department].filter(Boolean).join(' ');
+  const schoolDepartmentName =
+    item.schoolDepartmentName ?? [item.organization, item.department].filter(Boolean).join(' ');
   const isSaved = item.isArchived === true || savedExhibitionIds.has(item.displayId);
 
   return (
@@ -70,8 +71,10 @@ function ExhibitionCard({
       </div>
       <div className="flex flex-col">
         <p className="typo-body-xs-bold text-main truncate">{item.title}</p>
-        {orgDept ? (
-          <p className="typo-body-xs-regular text-sub700 truncate -mt-0.5">{orgDept}</p>
+        {schoolDepartmentName ? (
+          <p className="typo-body-xs-regular text-sub700 truncate -mt-0.5">
+            {schoolDepartmentName}
+          </p>
         ) : null}
         <p className="typo-body-xs-regular text-hint mt-0.5">
           {formatMonthDay(item.startedAt)} - {formatMonthDay(item.endedAt)}

--- a/src/mocks/data/repository.ts
+++ b/src/mocks/data/repository.ts
@@ -65,6 +65,7 @@ const displayToListItem = (display: (typeof MOCK_DISPLAY_DETAILS)[number]) => ({
   content: display.content,
   organization: display.organization,
   department: display.department,
+  schoolDepartmentName: [display.organization, display.department].filter(Boolean).join(' '),
   displayType: display.displayType,
   displayFields: display.displayFields,
   region: display.region,
@@ -84,6 +85,7 @@ const displayToListItem = (display: (typeof MOCK_DISPLAY_DETAILS)[number]) => ({
   likeCount: 12 + display.displayId,
   liked: false,
   archived: false,
+  isArchived: false,
 });
 
 const displayToDetail = (display: (typeof MOCK_DISPLAY_DETAILS)[number]) => ({

--- a/src/mocks/handlers/archive.ts
+++ b/src/mocks/handlers/archive.ts
@@ -14,20 +14,22 @@ const getFirstImageUrl = (item: any) =>
   '';
 
 const archivedExhibitions = () => ({
-  savedExhibitions: mockDb.displays.map((display: any) => ({
-    savedExhibitionId: display.displayId,
-    displayId: display.displayId,
-    title: display.title,
-    thumbnailUrl: getFirstImageUrl(display),
-    organization: display.organization,
-    placeName: display.placeName,
-    startDate: display.startDate ?? display.startedAt,
-    endDate: display.endDate ?? display.endedAt,
-    displayType: display.displayType,
-    status: display.status,
-    memo: display.memo ?? null,
-    savedAt: '2026-08-02T00:00:00.000Z',
-  })),
+  savedExhibitions: mockDb.displays
+    .filter((display: any) => display.isArchived ?? display.archived ?? false)
+    .map((display: any) => ({
+      savedExhibitionId: display.displayId,
+      displayId: display.displayId,
+      title: display.title,
+      thumbnailUrl: getFirstImageUrl(display),
+      organization: display.organization,
+      placeName: display.placeName,
+      startDate: display.startDate ?? display.startedAt,
+      endDate: display.endDate ?? display.endedAt,
+      displayType: display.displayType,
+      status: display.status,
+      memo: display.memo ?? null,
+      savedAt: '2026-08-02T00:00:00.000Z',
+    })),
 });
 
 const archivedArtworks = () => ({
@@ -86,6 +88,14 @@ const updateDisplayMemo = (archiveDisplayId: number, memo: string | null) => {
   const display = mockDb.displays.find((item: any) => item.displayId === archiveDisplayId);
   if (display) {
     Object.assign(display, { memo });
+  }
+};
+
+const updateDisplayArchiveStatus = (displayId: number, isArchived: boolean) => {
+  const display = mockDb.displays.find((item: any) => item.displayId === displayId);
+
+  if (display) {
+    Object.assign(display, { archived: isArchived, isArchived });
   }
 };
 
@@ -199,20 +209,22 @@ export const archiveHandlers = [
     http.get(path, () => success('/api/v1/archives/exhibitions', archivedExhibitions())),
   ),
   ...paths('/api/v1/archives/exhibitions/{exhibitionId}').map((path) =>
-    http.post(path, ({ params }) =>
-      success(
-        '/api/v1/archives/exhibitions/{exhibitionId}',
-        okStatus(toNumber(params.exhibitionId), true),
-      ),
-    ),
+    http.post(path, ({ params }) => {
+      const exhibitionId = toNumber(params.exhibitionId);
+
+      updateDisplayArchiveStatus(exhibitionId, true);
+
+      return success('/api/v1/archives/exhibitions/{exhibitionId}', okStatus(exhibitionId, true));
+    }),
   ),
   ...paths('/api/v1/archives/exhibitions/{exhibitionId}').map((path) =>
-    http.delete(path, ({ params }) =>
-      success(
-        '/api/v1/archives/exhibitions/{exhibitionId}',
-        okStatus(toNumber(params.exhibitionId), false),
-      ),
-    ),
+    http.delete(path, ({ params }) => {
+      const exhibitionId = toNumber(params.exhibitionId);
+
+      updateDisplayArchiveStatus(exhibitionId, false);
+
+      return success('/api/v1/archives/exhibitions/{exhibitionId}', okStatus(exhibitionId, false));
+    }),
   ),
   ...paths('/api/v1/archives/exhibitions/{savedExhibitionId}').map((path) =>
     http.get(path, ({ params }) =>

--- a/src/mocks/handlers/display.ts
+++ b/src/mocks/handlers/display.ts
@@ -287,6 +287,8 @@ export const displayHandlers = [
             endDate: display.period?.endDate ?? display.endedAt,
             locationName: display.location?.placeName ?? display.placeName,
             posterImageUrl: display.posterImageUrl,
+            schoolDepartmentName: display.schoolDepartmentName,
+            isArchived: display.isArchived ?? display.archived ?? false,
             latitude: coordinates.latitude,
             longitude: coordinates.longitude,
           };


### PR DESCRIPTION
## 📝 작업 내용

- 홈 전시 카드 DTO에 `schoolDepartmentName` 필드를 추가했습니다.
- 홈 전시 카드에서 학교/학과명 표시 시 `schoolDepartmentName`을 우선 사용하도록 수정했습니다.
- 전시 상세 메타 영역에서 학교명을 제거하고 부제목만 표시하도록 수정했습니다.
- MSW 전시 목록/지도 mock 응답에도 `schoolDepartmentName` 및 저장 상태 필드를 보강했습니다.

## 🔍 관련 이슈

- close #228

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

검증 명령어:
- `pnpm lint`
- `pnpm build`

## 💬 기타 참고 사항

- `pnpm typecheck` 스크립트는 없어 실행하지 않았고, `pnpm build`의 `tsc -b` 단계로 타입 검증을 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 전시 카드에서 학교·학과명이 보다 정확하게 표시됩니다.
  * 학교·학과명 정보가 제공되지 않는 경우에도 기존 기관·학과 정보로 자연스럽게 표시됩니다.
  * 전시 상세 화면의 부제목이 불필요한 조직명 없이 정확하게 표시됩니다.
  * 지도 전시 정보에 학교·학과명과 보관 상태가 안정적으로 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->