### PR TITLE
feat: 전시 등록 API 연동 (임시저장/등록)

### DIFF
--- a/src/api/endpoints/display.ts
+++ b/src/api/endpoints/display.ts
@@ -99,6 +99,10 @@ export const updateDisplayReservation = async (
 ): Promise<UpdateDisplayReservationResponseDataDto> =>
   apiRequest(`/v1/display/${displayId}/reservation`, { method: 'PATCH', body });
 
+// PATCH /v1/display/publish
+export const publishDisplay = async (displayId: number): Promise<DisplayDetailDto> =>
+  apiRequest('/v1/display/publish', { method: 'PATCH', body: { displayId } });
+
 // POST /v1/display/like
 export const toggleDisplayLike = async (
   displayId: number,

--- a/src/hooks/queries/useDisplayBrowse.ts
+++ b/src/hooks/queries/useDisplayBrowse.ts
@@ -6,7 +6,13 @@ import type {
   SearchDisplaysRequestDto,
   UpdateDisplayRequestDto,
 } from '@/api/dto';
-import { createDisplay, getDisplayMap, searchDisplays, updateDisplay } from '@/api/endpoints';
+import {
+  createDisplay,
+  getDisplayMap,
+  publishDisplay,
+  searchDisplays,
+  updateDisplay,
+} from '@/api/endpoints';
 import { queryKeys } from '@/api/queryKeys';
 
 export const useSearchDisplays = (params: SearchDisplaysRequestDto) =>
@@ -43,6 +49,19 @@ export const useUpdateDisplay = (displayId: number | undefined) => {
     },
     onSuccess: () => {
       if (!displayId) return;
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(displayId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() });
+    },
+  });
+};
+
+// PATCH /v1/display/publish: 전시 등록하기
+export const usePublishDisplay = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (displayId: number) => publishDisplay(displayId),
+    onSuccess: (_, displayId) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(displayId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.displays.lists() });
     },

--- a/src/pages/ExhibitionManagePage.tsx
+++ b/src/pages/ExhibitionManagePage.tsx
@@ -13,6 +13,7 @@ import { useHideFooter } from '@/components/layout';
 import { ExhibitionHeader } from '@/components/ui';
 import { type VisibilityType } from '@/constants/visibility';
 import { useDisplayArtworks } from '@/hooks/queries/useDisplayArtworks';
+import { useCreateDisplay, usePublishDisplay } from '@/hooks/queries/useDisplayBrowse';
 import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
 import { useDisplayMembers } from '@/hooks/queries/useDisplayMembers';
 import { useDisplayPolicy } from '@/hooks/usePolicy';
@@ -47,7 +48,6 @@ export function ExhibitionManage() {
   const { displayId: paramDisplayId } = useParams();
   const { state } = useLocation();
 
-  // 등록된 전시 데이터를 서버에서 불러옵니다. URL 파라미터나 state에서 displayId를 가져옵니다.
   const displayId = Number(paramDisplayId ?? state?.displayId ?? state?.id ?? 0);
   const { data: display } = useDisplayDetail(displayId);
   const { data: memberList } = useDisplayMembers(displayId);
@@ -59,6 +59,9 @@ export function ExhibitionManage() {
     },
   );
   const canEditDisplay = Boolean(display) && hasPermission(displayPolicy, 'edit');
+
+  const createDisplayMutation = useCreateDisplay();
+  const publishDisplayMutation = usePublishDisplay();
 
   /* 팀원 목록의 accepted로 참여팀원과 초대대기를 나눕니다. */
   const teamMembers = memberList?.members ?? [];
@@ -189,23 +192,57 @@ export function ExhibitionManage() {
         <div className="flex gap-2.5">
           <button
             type="button"
-            className="typo-body-sm-bold h-11 w-24 shrink-0 rounded-xl bg-bt-gray text-main"
+            disabled={createDisplayMutation.isPending}
+            className="typo-body-sm-bold h-11 w-24 shrink-0 rounded-xl bg-bt-gray text-main disabled:opacity-50"
+            onClick={() => {
+              if (!display) {
+                alert('전시 정보를 불러오는 중입니다. 잠시 후 다시 시도해주세요.');
+                return;
+              }
+              createDisplayMutation.mutate({
+                title: display.title,
+                posterImageUrl: display.images?.[0]?.imageUrl || '',
+                type: display.displayType || '',
+                fields: display.displayFields || [],
+                region: display.region || '',
+                startDate: display.period?.startDate || '',
+                endDate: display.period?.endDate || '',
+                openTime: display.period?.startTime || '10:00',
+                closeTime: display.period?.endTime || '18:00',
+                locationName: display.location?.placeName || '',
+                latitude: display.location?.latitude || 0,
+                longitude: display.location?.longitude || 0,
+                roadAddress: display.location?.roadAddress || '',
+                displayNickname: display.teamMembers?.[0]?.displayNickname || '',
+                qnaAccount: display.qnaAccount || '',
+                schoolOrOrganization: display.organization || '',
+                departmentOrClub: display.department ?? undefined,
+                subtitle: display.subtitle ?? undefined,
+                description: display.content ?? undefined,
+                precautions: display.note ?? undefined,
+              });
+            }}
           >
             임시저장
           </button>
           <button
             type="button"
-            className="typo-body-sm-bold h-11 flex-1 rounded-xl bg-dark text-white"
+            disabled={publishDisplayMutation.isPending}
+            className="typo-body-sm-bold h-11 flex-1 rounded-xl bg-dark text-white disabled:opacity-50"
             onClick={() =>
-              navigate(`/exhibition/${displayId}/complete`, {
-                state: {
-                  title: exhibition.title,
-                  school: source?.organization ?? state?.school,
-                  department: source?.department ?? state?.department,
-                  organizer: state?.organizer,
-                  placeName: exhibition.place,
-                  artworkVisibility,
-                  contentVisibility,
+              publishDisplayMutation.mutate(displayId, {
+                onSuccess: () => {
+                  navigate(`/exhibition/${displayId}/complete`, {
+                    state: {
+                      title: exhibition.title,
+                      school: source?.organization ?? state?.school,
+                      department: source?.department ?? state?.department,
+                      organizer: state?.organizer,
+                      placeName: exhibition.place,
+                      artworkVisibility,
+                      contentVisibility,
+                    },
+                  });
                 },
               })
             }


### PR DESCRIPTION
## 깃허브

close #232 

## Summary
- POST /v1/display API를 통한 전시 임시저장 기능 추가
- PATCH /v1/display/publish API를 통한 전시 등록 기능 추가
- 공개 시점 설정 API 자동 연동
- API 요청 body를 이미 로드된 display 서버 데이터로 변경 (400 Bad Request 해결)

## Changes
- `src/api/endpoints/display.ts`: publishDisplay 엔드포인트 추가
- `src/api/dto/display.dto.ts`: PublishDisplayRequestDto, PublishDisplayResponseDataDto 추가
- `src/hooks/queries/useDisplayBrowse.ts`: useCreateDisplay, usePublishDisplay 쿼리훅 추가
- `src/pages/ExhibitionManagePage.tsx`: 임시저장/등록 버튼에 API 연동
- `src/pages/RegisterCompletePage.tsx`: 공개 시점 설정 API 자동 연동

## Test plan
- [x] 전시 관리 페이지에서 "임시저장" 버튼 클릭 시 POST /v1/display 호출 확인
- [x] 전시 관리 페이지에서 "등록하기" 버튼 클릭 시 PATCH /v1/display/publish 호출 확인
- [x] 완료 페이지에서 공개 시점 설정 API 자동 호출 확인
- [x] 전시 등록 후 상태 변경 확인

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 전시를 임시저장하거나 공개 등록할 수 있습니다.
  * 공개 등록이 완료되면 완료 페이지로 자동 이동합니다.
  * 저장 및 공개 등록 처리 중에는 버튼이 비활성화됩니다.
  * 공개 등록 후 전시 상세 및 목록 정보가 최신 상태로 갱신됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->