### PR TITLE
fix: 개인 작품 상세페이지 저장 버튼 API 연동

### DIFF
--- a/src/components/artworkdetailpage/PersonalArtworkSaveButton.tsx
+++ b/src/components/artworkdetailpage/PersonalArtworkSaveButton.tsx
@@ -1,0 +1,52 @@
+import { SaveButtonUI } from '@/components/ui/SaveButtonUI';
+import { useArchivePersonalArtwork, useUnarchivePersonalArtwork } from '@/hooks/queries/useArchive';
+import { useLoginRequiredModal } from '@/hooks/usePermissionRequiredModal';
+import { useArchivePolicy } from '@/hooks/usePolicy';
+import { hasPermission } from '@/utils/hasPermission';
+
+type Props = {
+  className?: string;
+  id?: string;
+  personalArtworkId: number;
+  /* 개인 작품 상세의 isArchived. 저장 여부에 따라 버튼 문구가 바뀝니다. */
+  saved?: boolean;
+};
+
+export function PersonalArtworkSaveButton({
+  className = '',
+  id,
+  personalArtworkId,
+  saved = false,
+}: Props) {
+  const archive = useArchivePersonalArtwork();
+  const unarchive = useUnarchivePersonalArtwork();
+  const { loginModal, openLoginModal } = useLoginRequiredModal();
+  const archivePolicy = useArchivePolicy();
+  const isPending = archive.isPending || unarchive.isPending;
+  const canToggleArchive = hasPermission(archivePolicy, saved ? 'delete' : 'create');
+
+  const toggleSave = () => {
+    if (isPending || personalArtworkId <= 0) return;
+    if (!canToggleArchive) {
+      openLoginModal();
+      return;
+    }
+
+    if (saved) unarchive.mutate(personalArtworkId);
+    else archive.mutate(personalArtworkId);
+  };
+
+  return (
+    <>
+      <SaveButtonUI
+        text={saved ? '저장됨' : '작품 저장'}
+        variant="dark"
+        isSaved={saved}
+        onClick={toggleSave}
+        className={className}
+        id={id}
+      />
+      {loginModal}
+    </>
+  );
+}

--- a/src/pages/PersonalArtworkDetailPage.tsx
+++ b/src/pages/PersonalArtworkDetailPage.tsx
@@ -9,7 +9,9 @@ import type {
   PersonalArtworkQuestionReplyResponseDataDto,
   PersonalArtworkQuestionResponseDataDto,
 } from '@/api/dto';
+import { PersonalArtworkSaveButton } from '@/components/artworkdetailpage/PersonalArtworkSaveButton';
 import { BottomCommentBar, ErrorView, LoadingView } from '@/components/common';
+import { BottomFixedBar } from '@/components/displaydetailpage';
 import { HeroSlider } from '@/components/displaydetailpage/HeroSlider';
 import { FALLBACK_POSTER_IMAGE, FALLBACK_PROFILE_IMAGE } from '@/constants';
 import {
@@ -752,6 +754,20 @@ export function PersonalArtworkDetailPage() {
             </div>
           )}
         </div>
+      )}
+
+      {activeTab === 'intro' && (
+        <BottomFixedBar
+          button={
+            <PersonalArtworkSaveButton
+              className="w-full"
+              personalArtworkId={personalArtworkId}
+              saved={artwork.isArchived ?? false}
+            />
+          }
+          shareTitle={artwork.artworkName}
+          shareImageUrl={displayHeroImages[0]}
+        />
       )}
 
       {activeTab === 'guestbook' && (


### PR DESCRIPTION
## 📝 작업 내용

- 개인 작품 상세 페이지에 저장(작품 저장) 버튼이 없어 추가했습니다.
- 기존 작품 상세페이지의 `ArtworkSaveButton`과 동일한 구조로 `PersonalArtworkSaveButton`을 신설하고, 이미 구현돼 있었지만 어디서도 쓰이지 않던 `useArchivePersonalArtwork` / `useUnarchivePersonalArtwork` 훅(POST·DELETE `/v1/archives/personal-artworks/:personalArtworkId`)을 연결했습니다.
- 저장 여부는 `artwork.isArchived ?? false`로 API 응답 값을 그대로 사용하며, 하드코딩된 폴백 데이터는 없습니다.
- 비로그인 상태에서 저장 버튼 클릭 시 기존 정책(`useArchivePolicy` + 로그인 필요 모달)과 동일하게 동작합니다.

## 🔍 관련 이슈

- #244

## 🖼️ 스크린샷

- (스크린샷 첨부 예정)

## 🧪 테스트 결과

- [x] 정상 작동 확인 (MSW mock 환경에서 저장 버튼 렌더링 및 비로그인 시 로그인 모달 노출 확인, `tsc --noEmit` 통과)
- [x] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 저장 버튼은 기존 `ArtworkSaveButton`을 재사용하지 않고 별도 컴포넌트로 분리했습니다. `ArtworkSaveButton`은 일반 작품(`/v1/archives/artworks`) API에 고정돼 있어 그대로 재사용하면 개인 작품에도 일반 작품 저장 API가 호출되는 문제가 있어, 동일한 구조를 따르는 `PersonalArtworkSaveButton`을 새로 만들었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 개인 작품 상세 페이지에서 작품을 저장하거나 저장 해제할 수 있습니다.
  * 로그인하지 않은 경우 저장 시 로그인 안내가 표시됩니다.
  * 작품 소개 탭에 저장 버튼이 포함된 하단 고정 바를 추가했습니다.
  * 방명록 탭에서는 기존 댓글 입력 바가 계속 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->