### PR TITLE
feat: 루트 경로 인증 상태별 분기

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,7 @@
-import { createBrowserRouter, LoaderFunctionArgs, Navigate } from 'react-router-dom';
+import { createBrowserRouter, LoaderFunctionArgs } from 'react-router-dom';
 
 import { PrivateRoute } from './components/auth/PrivateRoute';
+import { RootRedirect } from './components/auth/RootRedirect';
 import { Layout } from './components/layout';
 import { AnswerPage } from './pages/AnswerPage';
 import { ArtistVerificationPage } from './pages/artist-verification';
@@ -64,7 +65,7 @@ export const router = createBrowserRouter([
     element: <Layout />,
     children: [
       // 🔓 공개 라우트 (비로그인 게스트 접근 가능)
-      { index: true, element: <Navigate to="/login" replace /> },
+      { index: true, element: <RootRedirect /> },
       { path: 'home', element: <Homepage /> },
       { path: 'search', element: <SearchPage /> },
       {

--- a/src/components/auth/RootRedirect.tsx
+++ b/src/components/auth/RootRedirect.tsx
@@ -1,0 +1,9 @@
+import { Navigate } from 'react-router-dom';
+
+import { useAuthStore } from '@/stores/authStore';
+
+export function RootRedirect() {
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  return <Navigate to={accessToken ? '/home' : '/login'} replace />;
+}


### PR DESCRIPTION
## 작업 내용

- 루트 경로(`/`) 접근 시 인증 상태에 따라 이동 경로를 분기했습니다.
- 로그인 상태면 `/home`, 비로그인 상태면 `/login`으로 이동합니다.

## 테스트

- [x] pnpm lint
- [x] pnpm build

Closes #249
