### PR TITLE
fix: 선택 입력값 등록 차단 해제

### DIFF
--- a/src/api/dto/display.dto.ts
+++ b/src/api/dto/display.dto.ts
@@ -379,9 +379,9 @@ export interface CreateDisplayRequestDto {
   latitude: number;
   longitude: number;
   roadAddress: string;
-  /* 서버 필수값입니다. 이 전시에서 쓸 표시명과 문의(Q&A) 계정입니다. */
+  /* 서버 필수값입니다. 이 전시에서 쓸 표시명입니다. */
   displayNickname: string;
-  qnaAccount: string;
+  qnaAccount?: string;
   schoolOrOrganization: string;
   departmentOrClub?: string;
   subtitle?: string;

--- a/src/api/dto/displayContent.dto.ts
+++ b/src/api/dto/displayContent.dto.ts
@@ -2,7 +2,7 @@ export type ContentCategoryDto = {
   id?: number;
   categoryId?: number;
   name: string;
-  description: string;
+  description?: string | null;
   contentCount?: number;
   sortOrder?: number;
   thumbnailUrl?: string;
@@ -20,7 +20,7 @@ export type ContentImageDto = {
 
 export type CreateContentCategoryRequestDto = {
   name: string;
-  description: string;
+  description?: string;
 };
 
 export type CreateContentCategoryResponseDto = {
@@ -29,7 +29,7 @@ export type CreateContentCategoryResponseDto = {
 
 export type UpdateContentCategoryRequestDto = {
   name: string;
-  description: string;
+  description?: string;
 };
 
 /*

--- a/src/components/artworks-manage/ContentEditSheet.tsx
+++ b/src/components/artworks-manage/ContentEditSheet.tsx
@@ -21,7 +21,7 @@ export function ContentEditSheet({
 }: ContentEditSheetProps) {
   const [title, setTitle] = useState(content.title);
   const [description, setDescription] = useState(content.description);
-  const canSave = title.trim().length > 0 && description.trim().length > 0;
+  const canSave = title.trim().length > 0;
 
   return (
     <BottomSheet

--- a/src/pages/exhibition-register/ArtistNameSetup.tsx
+++ b/src/pages/exhibition-register/ArtistNameSetup.tsx
@@ -76,7 +76,6 @@ const hasCompleteRegisterDraft = (draft: ExhibitionRegisterState) =>
     draft.endTime &&
     draft.placeName &&
     draft.address &&
-    draft.contact?.trim() &&
     draft.latitude !== null &&
     draft.latitude !== undefined &&
     draft.longitude !== null &&
@@ -150,7 +149,6 @@ export function ArtistNameSetup() {
       !registerState.endTime ||
       !registerState.placeName ||
       !registerState.address ||
-      !registerState.contact?.trim() ||
       registerState.latitude === null ||
       registerState.latitude === undefined ||
       registerState.longitude === null ||
@@ -175,7 +173,9 @@ export function ArtistNameSetup() {
       longitude: registerState.longitude,
       roadAddress: registerState.address.trim(),
       displayNickname: data.artistName.trim(),
-      qnaAccount: (registerState.contact ?? '').trim(),
+      ...(optionalText(registerState.contact)
+        ? { qnaAccount: optionalText(registerState.contact) }
+        : {}),
       schoolOrOrganization: optionalText(registerState.school || registerState.organizer) ?? '',
       departmentOrClub: optionalText(registerState.department),
       subtitle: optionalText(registerState.subtitle),


### PR DESCRIPTION
## 📝 작업 내용

- 전시 등록 시 문의 방법이 비어 있어도 최종 등록 단계에서 유실 alert로 막히지 않도록 수정했습니다.
- 문의 방법 값이 있을 때만 `qnaAccount`를 요청 바디에 포함하도록 변경했습니다.
- 전시 콘텐츠 설명이 비어 있어도 콘텐츠 카테고리 생성/수정이 가능하도록 저장 조건을 완화했습니다.
- 백엔드 선택값 처리에 맞춰 관련 DTO 타입을 optional/null 가능으로 조정했습니다.

## 🔍 관련 이슈

- close #254

## 🖼️ 스크린샷

- 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- `pnpm lint`, `pnpm build` 통과
