### PR TITLE
fix: mobile-web-app-capable meta 태그 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#ECECF2" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   </head>
   <body class="bg-[#F0F0F3]">


### PR DESCRIPTION
## 📝 작업 내용

- `index.html`에 `mobile-web-app-capable` meta 태그 추가 (기존 `apple-mobile-web-app-capable`는 유지)
- 콘솔에 뜨던 deprecated 경고 제거

## 🔍 관련 이슈

- close #257

## 🖼️ 스크린샷

- 단순 meta 태그 추가로 시각적 변화 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 콘솔 경고: `<meta name="apple-mobile-web-app-capable" content="yes"> is deprecated. Please include <meta name="mobile-web-app-capable" content="yes">`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모바일 웹 앱으로 실행할 수 있도록 지원을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->