### PR TITLE
fix: 전시 등록 시간 선택 모바일 입력 수정

### DIFF
--- a/src/components/ui/TimeSheet.tsx
+++ b/src/components/ui/TimeSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { BottomSheet } from '@/components/ui/BottomSheet';
 
@@ -47,6 +47,7 @@ export function TimeSheet({
 
   /** 직접 입력 중인 숫자 버퍼 ("1" -> "18") */
   const bufferRef = useRef('');
+  const inputRef = useRef<HTMLInputElement>(null);
   const prevOpenRef = useRef(open);
 
   const enforceTimeOrder = (t: typeof time, activeField: Field) => {
@@ -74,9 +75,16 @@ export function TimeSheet({
       });
       setField('startHour');
       bufferRef.current = '';
+      inputRef.current?.focus({ preventScroll: true });
     }
     prevOpenRef.current = open;
   }, [open, value]);
+
+  useLayoutEffect(() => {
+    if (open) {
+      inputRef.current?.focus({ preventScroll: true });
+    }
+  }, [open]);
 
   const isHourField = field === 'startHour' || field === 'endHour';
 
@@ -141,6 +149,25 @@ export function TimeSheet({
     }
   };
 
+  const focusInput = () => {
+    inputRef.current?.focus();
+  };
+
+  const selectField = (nextField: Field) => {
+    bufferRef.current = '';
+    setField(nextField);
+    focusInput();
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const digit = e.currentTarget.value.replace(/\D/g, '').slice(-1);
+    e.currentTarget.value = '';
+
+    if (digit) {
+      commitDigit(digit);
+    }
+  };
+
   const label = `${pad(time.startHour)}:${pad(time.startMinute)} - ${pad(time.endHour)}:${pad(time.endMinute)}`;
 
   const confirm = () => {
@@ -156,25 +183,31 @@ export function TimeSheet({
           <div
             role="group"
             tabIndex={0}
+            onClick={focusInput}
             onKeyDown={handleKeyDown}
-            className="flex w-full min-w-0 items-center justify-center gap-[clamp(0.125rem,1.7vw,0.5rem)] outline-none"
+            className="relative flex w-full min-w-0 items-center justify-center gap-[clamp(0.125rem,1.7vw,0.5rem)] outline-none"
           >
+            <input
+              ref={inputRef}
+              type="tel"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              autoComplete="off"
+              aria-label="운영시간 숫자 입력"
+              className="absolute left-1/2 top-1/2 size-px -translate-x-1/2 -translate-y-1/2 opacity-0"
+              onChange={handleInputChange}
+              onKeyDown={handleKeyDown}
+            />
             <Segment
               value={time.startHour}
               active={field === 'startHour'}
-              onSelect={() => {
-                bufferRef.current = '';
-                setField('startHour');
-              }}
+              onSelect={() => selectField('startHour')}
             />
             <Colon />
             <Segment
               value={time.startMinute}
               active={field === 'startMinute'}
-              onSelect={() => {
-                bufferRef.current = '';
-                setField('startMinute');
-              }}
+              onSelect={() => selectField('startMinute')}
             />
 
             <span className="px-0.5 text-[clamp(2rem,11vw,3rem)] leading-none text-main">-</span>
@@ -182,19 +215,13 @@ export function TimeSheet({
             <Segment
               value={time.endHour}
               active={field === 'endHour'}
-              onSelect={() => {
-                bufferRef.current = '';
-                setField('endHour');
-              }}
+              onSelect={() => selectField('endHour')}
             />
             <Colon />
             <Segment
               value={time.endMinute}
               active={field === 'endMinute'}
-              onSelect={() => {
-                bufferRef.current = '';
-                setField('endMinute');
-              }}
+              onSelect={() => selectField('endMinute')}
             />
           </div>
 

--- a/src/pages/exhibition-register/ExhibitionBasicInfo.tsx
+++ b/src/pages/exhibition-register/ExhibitionBasicInfo.tsx
@@ -460,7 +460,7 @@ export function ExhibitionBasicInfo() {
             <Underline>
               <input
                 id="place-name"
-                placeholder="전시명을 입력해주세요"
+                placeholder="장소명을 입력해주세요"
                 className="typo-body-xs-regular w-full bg-transparent text-main outline-none placeholder:text-input-placeholder"
                 {...register('placeName')}
               />


### PR DESCRIPTION
## 📝 작업 내용

- 전시 등록 운영시간 선택 시트에 모바일 숫자 키보드를 띄울 수 있는 실제 입력 요소를 연결했습니다.
- 시간 필드 선택 시 입력 포커스를 유지해 Safari/PWA 환경에서도 시간을 수정할 수 있도록 했습니다.
- 전시 기본 정보의 장소명 입력 placeholder를 "장소명을 입력해주세요"로 수정했습니다.

## 🔍 관련 이슈

- close #259

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

검증 명령어
- pnpm lint
- pnpm build

## 💬 기타 참고 사항

- 기존 키보드 입력, 자동 다음 필드 이동, 시작/종료 시간 순서 보정 로직은 유지했습니다.