### PR TITLE
refactor: 설정 페이지 전반 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   </head>
-  <body class="bg-[#F0F0F3]">
+  <body class="bg-page">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/api/dto/display.dto.ts
+++ b/src/api/dto/display.dto.ts
@@ -462,7 +462,9 @@ export interface MyDisplayDto {
   placeName: string;
   postImageUrl: string;
   isLeader?: boolean;
-  publishedStatus?: 'PUBLISHED' | 'DRAFT';
+  publishStatus?: 'PUBLISHED' | 'DRAFT';
+  displayNickname?: string;
+  artistName?: string;
 }
 
 export interface GetMyDisplaysResponseDataDto {

--- a/src/api/dto/display.dto.ts
+++ b/src/api/dto/display.dto.ts
@@ -208,9 +208,19 @@ export interface DisplayTeamMemberDto {
 
 export interface DisplayInvitationDto {
   invitationId: number;
-  inviterUserId: number;
-  inviteeUserId: number;
-  createdAt: string;
+  displayId: number;
+  title: string;
+  posterImageUrl?: string;
+  schoolDepartmentName?: string;
+  startedAt: string;
+  endedAt: string;
+  dayLeft?: number;
+  isArchived?: boolean;
+  /* 하위 호환용 - 추후 서버가 내려줄 수 있는 필드 */
+  inviterUserId?: number;
+  inviteeUserId?: number;
+  createdAt?: string;
+  status?: string;
 }
 
 export type GetDisplayDetailResponseDto = ApiResponseDto<DisplayDetailDto>;
@@ -519,7 +529,7 @@ export interface DisableDisplayInvitationLinkResponseDataDto {
 }
 
 export interface MyDisplayInvitationListResponseDataDto {
-  invitations: DisplayInvitationDto[];
+  exhibitions: DisplayInvitationDto[];
 }
 
 export interface AcceptDisplayInvitationRequestDto {

--- a/src/api/dto/display.dto.ts
+++ b/src/api/dto/display.dto.ts
@@ -202,6 +202,8 @@ export interface DisplayTeamMemberDto {
   displayNickname: string;
   role: string;
   accepted: boolean;
+  loggedIn?: boolean;
+  artistVerified?: boolean;
 }
 
 export interface DisplayInvitationDto {
@@ -470,6 +472,11 @@ export interface MyDisplayDto {
 export interface GetMyDisplaysResponseDataDto {
   createdDisplays: MyDisplayDto[];
   participatedDisplays: MyDisplayDto[];
+}
+
+export interface UpdateMyDisplayNicknameRequestDto {
+  displayId: number;
+  displayNickname: string;
 }
 
 export type ArtistDisplayDto = MyDisplayDto;

--- a/src/api/dto/display.dto.ts
+++ b/src/api/dto/display.dto.ts
@@ -461,6 +461,8 @@ export interface MyDisplayDto {
   department: string;
   placeName: string;
   postImageUrl: string;
+  isLeader?: boolean;
+  publishedStatus?: 'PUBLISHED' | 'DRAFT';
 }
 
 export interface GetMyDisplaysResponseDataDto {

--- a/src/api/endpoints/display.ts
+++ b/src/api/endpoints/display.ts
@@ -169,9 +169,9 @@ export const inviteDisplayMember = async (
 ): Promise<DisplayMemberInvitationResponseDataDto> =>
   apiRequest(`/v1/display-invitations/displays/${displayId}`, { method: 'POST', body });
 
-// GET /v1/display-invitations/me
+// GET /v1/display-invitations
 export const getMyDisplayInvitations = async (): Promise<MyDisplayInvitationListResponseDataDto> =>
-  apiRequest('/v1/display-invitations/me');
+  apiRequest('/v1/display-invitations');
 
 // POST /v1/display-invitations/:invitationId/accept
 export const acceptDisplayInvitation = async (

--- a/src/api/endpoints/display.ts
+++ b/src/api/endpoints/display.ts
@@ -38,6 +38,7 @@ import type {
   UpdateDisplayReservationRequestDto,
   UpdateDisplayReservationResponseDataDto,
   UpdateDisplayResponseDataDto,
+  UpdateMyDisplayNicknameRequestDto,
 } from '@/api/dto';
 
 import { apiRequest } from '../client';
@@ -136,8 +137,9 @@ export const getArtistDisplays = async (
 ): Promise<GetArtistDisplaysResponseDataDto> => apiRequest(`/v1/display/artists/${userId}`);
 
 // PATCH /v1/display/me/nickname
-export const updateMyDisplayNickname = async (body: { nickname: string }): Promise<unknown> =>
-  apiRequest('/v1/display/me/nickname', { method: 'PATCH', body });
+export const updateMyDisplayNickname = async (
+  body: UpdateMyDisplayNicknameRequestDto,
+): Promise<unknown> => apiRequest('/v1/display/me/nickname', { method: 'PATCH', body });
 
 // GET /v1/display/invitation/:token
 export const getDisplayInvitationByToken = async (token: string): Promise<DisplayDetailDto> =>

--- a/src/api/endpoints/display.ts
+++ b/src/api/endpoints/display.ts
@@ -80,6 +80,10 @@ export const getDisplayMap = async (
 export const getDisplayDetail = async (displayId: number): Promise<DisplayDetailDto> =>
   apiRequest(`/v1/display/${displayId}`);
 
+// DELETE /v1/display/:displayId
+export const deleteDisplay = async (displayId: number): Promise<void> =>
+  apiRequest(`/v1/display/${displayId}`, { method: 'DELETE' });
+
 // POST /v1/display
 export const createDisplay = async (
   body: CreateDisplayRequestDto,

--- a/src/components/artist-verification/ArtistVerificationHeader.tsx
+++ b/src/components/artist-verification/ArtistVerificationHeader.tsx
@@ -6,16 +6,16 @@ interface ArtistVerificationHeaderProps {
 
 export function ArtistVerificationHeader({ onBack }: ArtistVerificationHeaderProps) {
   return (
-    <header className="flex h-[34px] shrink-0 items-center">
+    <header className="flex items-center gap-3 pt-4 pb-6">
       <button
         type="button"
         onClick={onBack}
         aria-label="뒤로가기"
-        className="flex h-[34px] w-7 items-center justify-start"
+        className="-ml-1 flex items-center justify-start"
       >
-        <ChevronLeft className="size-[28px] text-logo" strokeWidth={2} />
+        <ChevronLeft className="size-7 text-main" strokeWidth={2} />
       </button>
-      <h1 className="ml-3 typo-body-xl-bold text-main">작가 인증</h1>
+      <h1 className="typo-body-xl-bold text-main">작가 인증</h1>
     </header>
   );
 }

--- a/src/components/common/DeleteConfirmModal.tsx
+++ b/src/components/common/DeleteConfirmModal.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useId, useRef } from 'react';
+
+type Props = {
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function DeleteConfirmModal({ onConfirm, onCancel }: Props) {
+  const descriptionId = useId();
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    cancelButtonRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label="전시 삭제"
+      aria-describedby={descriptionId}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-neutral-900/40 px-10"
+    >
+      <div className="relative w-80 h-48 -translate-y-30 bg-neutral-50/20 rounded-[20px] shadow-[inset_-3px_-3px_3px_-2px_rgba(241,241,241,0.60),inset_4px_4px_3px_-2px_rgba(255,255,255,1.00)] backdrop-blur-[10px] overflow-hidden">
+        <div className="w-72 absolute left-6 top-6 flex flex-col justify-start items-start gap-2">
+          <h3 className="w-72 text-center typo-body-xl-bold text-modal-title">
+            전시를 삭제할까요?
+          </h3>
+          <p id={descriptionId} className="w-72 text-center typo-body-md-regular text-modal-desc">
+            삭제한 전시는 복구할 수 없어요.
+            <br />
+            정말 삭제하시겠어요?
+          </p>
+        </div>
+
+        <div className="absolute left-5 top-[126px] flex justify-start items-center gap-2.5">
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="w-32 h-11 bg-modal-btn-hover-bg rounded-full flex justify-center items-center gap-2.5"
+          >
+            <span className="typo-body-lg-regular text-modal-btn-hover-fg">삭제하기</span>
+          </button>
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            onClick={onCancel}
+            className="w-32 h-11 bg-modal-btn-bg rounded-full flex justify-center items-center gap-2.5"
+          >
+            <span className="typo-body-lg-regular text-modal-btn-fg">취소</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -4,6 +4,7 @@ export { BottomCommentBar } from './BottomCommentBar';
 export { BottomFixedBar } from './BottomFixedBar';
 export type { CommentData } from './comment';
 export { CommentItem } from './comment';
+export { DeleteConfirmModal } from './DeleteConfirmModal';
 export { ErrorView } from './ErrorView';
 export { ImageModal } from './ImageModal';
 export { ImageUploader } from './ImageUploader';

--- a/src/components/display-manage/Common.tsx
+++ b/src/components/display-manage/Common.tsx
@@ -6,7 +6,7 @@ export function Screen({ children }: { children: React.ReactNode }) {
 
 export function Header({ title, onBack }: { title: string; onBack?: () => void }) {
   return (
-    <div className="flex items-center gap-3 px-5 pt-14.5 pb-3">
+    <div className="flex items-center gap-3 px-5 pt-4 pb-6">
       {onBack && (
         <button
           onClick={onBack}

--- a/src/components/display-manage/ExhibitionCard.tsx
+++ b/src/components/display-manage/ExhibitionCard.tsx
@@ -56,7 +56,7 @@ export function ExhibitionCard({
         'bg-neutral-50 shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)]',
       )}
     >
-      <div className="flex items-center gap-3 h-20">
+      <div className="flex items-start gap-3">
         {/* 썸네일 80×80 */}
         <button type="button" onClick={onClick} className="shrink-0">
           <Poster src={ex.thumbnail} w={80} h={80} radius={12} />
@@ -66,7 +66,7 @@ export function ExhibitionCard({
         <button
           type="button"
           onClick={onClick}
-          className="flex min-w-0 flex-1 items-start gap-3 text-left h-full"
+          className="flex min-w-0 flex-1 items-start gap-3 text-left"
         >
           <ExhibitionMeta ex={ex} />
         </button>

--- a/src/components/display-manage/ExhibitionCard.tsx
+++ b/src/components/display-manage/ExhibitionCard.tsx
@@ -1,7 +1,7 @@
 import { MoreHorizontal } from 'lucide-react';
 
-import { useUserMe } from '@/hooks/queries/useUserProfile';
 import { useDisplayArtistNamePolicy, useDisplayPolicy } from '@/hooks/usePolicy';
+import { useAuthStore } from '@/stores/authStore';
 import type { ExhibitionItem } from '@/types/mypage';
 import { cn } from '@/utils/cn';
 import { hasPermission } from '@/utils/hasPermission';
@@ -14,6 +14,7 @@ export function ExhibitionCard({
   menuOpen = false,
   onClick,
   onDelete,
+  onLeave,
   onEditArtistName,
   onToggleMenu,
 }: {
@@ -21,10 +22,11 @@ export function ExhibitionCard({
   menuOpen?: boolean;
   onClick: () => void;
   onDelete: () => void;
+  onLeave: () => void;
   onEditArtistName: () => void;
   onToggleMenu: () => void;
 }) {
-  const { data: userMe } = useUserMe();
+  const userMe = useAuthStore((state) => state.user);
 
   /*
    * 내 전시 목록 응답이 생성/참여를 구분해 주므로 전시 상세를 따로 조회하지 않습니다.
@@ -38,58 +40,82 @@ export function ExhibitionCard({
 
   const displayPolicy = useDisplayPolicy(policyDisplay);
   const displayArtistNamePolicy = useDisplayArtistNamePolicy(policyDisplay);
-  /*
-   * 전시 삭제 API가 아직 없어 메뉴에 노출하지 않습니다.
-   * 서버에 엔드포인트가 생기면 이 상수를 제거하고 정책 판정만 남기면 됩니다.
-   */
-  const IS_DISPLAY_DELETE_SUPPORTED = false;
-  const canDelete = IS_DISPLAY_DELETE_SUPPORTED && hasPermission(displayPolicy, 'delete');
+
+  const canDelete = hasPermission(displayPolicy, 'delete');
   const canEditArtistName = hasPermission(displayArtistNamePolicy, 'edit');
-  const canShowMenu = canEditArtistName || canDelete;
+
+  /* isLeader 값이 있으면 그걸 기준으로, 없으면 isOwner로 fallback */
+  const isLeader = ex.isLeader ?? ex.isOwner ?? false;
+
+  const canShowMenu = canEditArtistName || canDelete || !isLeader;
 
   return (
     <div
       className={cn(
-        'relative flex gap-3 w-full px-4 py-3.5 rounded-2xl border-none items-start overflow-visible',
-        'bg-box100 shadow-[8px_8px_18px_rgba(6,3,45,0.04),inset_1px_1px_4px_rgba(1,8,21,0.20),inset_-2px_-2px_2px_rgba(252,252,252,0.90)]',
+        'relative w-full px-4 py-3.5 rounded-2xl border-none overflow-visible',
+        'bg-neutral-50 shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)]',
       )}
     >
-      <button type="button" onClick={onClick} className="flex min-w-0 flex-1 gap-3 text-left">
-        <Poster src={ex.thumbnail} />
-        <ExhibitionMeta ex={ex} />
-      </button>
-      {canShowMenu && (
+      <div className="flex items-center gap-3 h-20">
+        {/* 썸네일 80×80 */}
+        <button type="button" onClick={onClick} className="shrink-0">
+          <Poster src={ex.thumbnail} w={80} h={80} radius={12} />
+        </button>
+
+        {/* 메타 정보 + 메뉴 버튼 */}
         <button
           type="button"
-          aria-label="전시 관리 메뉴"
-          onClick={(event) => {
-            event.stopPropagation();
-            onToggleMenu();
-          }}
-          className="mt-0.5 shrink-0 text-hint"
+          onClick={onClick}
+          className="flex min-w-0 flex-1 items-start gap-3 text-left h-full"
         >
-          <MoreHorizontal className="size-5" />
+          <ExhibitionMeta ex={ex} />
         </button>
-      )}
 
+        {/* ... 메뉴 버튼 */}
+        {canShowMenu && (
+          <button
+            type="button"
+            aria-label="전시 관리 메뉴"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleMenu();
+            }}
+            className="shrink-0 self-start text-neutral-500"
+          >
+            <MoreHorizontal className="size-5" />
+          </button>
+        )}
+      </div>
+
+      {/* 드롭다운 메뉴 */}
       {menuOpen && canShowMenu && (
-        <div className="absolute top-9 right-3 z-20 w-34 overflow-hidden rounded-lg bg-card shadow-[0px_4px_18px_rgba(6,3,45,0.12)]">
+        <div className="absolute top-9 right-3 z-20 flex w-34 flex-col overflow-hidden rounded-2xl bg-neutral-50 shadow-[2px_4px_18px_0px_rgba(67,0,209,0.05)] outline outline-1 outline-offset-[-1px] outline-stone-300">
           {canEditArtistName && (
             <button
               type="button"
               onClick={onEditArtistName}
-              className="typo-body-xs-regular w-full px-3 py-2.5 text-left text-main hover:bg-box"
+              className="flex h-10 w-full items-center justify-start px-3.5 typo-body-xs-regular text-main hover:bg-box"
             >
               전시 작가명 수정
             </button>
           )}
-          {canDelete && (
+          {isLeader ? (
+            canDelete && (
+              <button
+                type="button"
+                onClick={onDelete}
+                className="flex h-10 w-full items-center justify-start border-t border-gray-200 px-3.5 typo-body-xs-regular text-error hover:bg-box"
+              >
+                삭제하기
+              </button>
+            )
+          ) : (
             <button
               type="button"
-              onClick={onDelete}
-              className="typo-body-xs-regular w-full px-3 py-2.5 text-left text-error hover:bg-box"
+              onClick={onLeave}
+              className="flex h-10 w-full items-center justify-start border-t border-gray-200 px-3.5 typo-body-xs-regular text-error hover:bg-box"
             >
-              삭제하기
+              전시 나가기
             </button>
           )}
         </div>

--- a/src/components/display-manage/ExhibitionMeta.tsx
+++ b/src/components/display-manage/ExhibitionMeta.tsx
@@ -1,35 +1,38 @@
 import type { ExhibitionItem } from '@/types/mypage';
 
-export function ExhibitionMeta({ ex }: { ex: ExhibitionItem }) {
-  /* 역할 레이블: isLeader 값 있으면 대표자/팀원, 없으면 공백 */
+export function ExhibitionMeta({
+  ex,
+  showBadge = true,
+}: {
+  ex: ExhibitionItem;
+  showBadge?: boolean;
+}) {
   const roleLabel = ex.isLeader === true ? '대표자' : ex.isLeader === false ? '팀원' : null;
-
-  /* 발행 상태 레이블: publishedStatus 값 있으면 표시, 없으면 공백 */
   const statusLabel =
-    ex.publishedStatus === 'PUBLISHED'
+    ex.publishStatus === 'PUBLISHED'
       ? '등록완료'
-      : ex.publishedStatus === 'DRAFT'
+      : ex.publishStatus === 'DRAFT'
         ? '임시저장'
         : null;
-
-  const isDraft = ex.publishedStatus === 'DRAFT';
+  const isDraft = ex.publishStatus === 'DRAFT';
 
   return (
-    <div className="flex-1 min-w-0 flex flex-col gap-2">
+    <div className="flex-1 min-w-0 flex flex-col gap-1">
       {/* 제목 */}
-      <h3 className="typo-body-md-bold text-main leading-6 truncate">{ex.title}</h3>
+      <h3 className="typo-body-md-bold text-main leading-snug truncate">{ex.title}</h3>
 
       {/* 날짜 · 장소 */}
-      <div className="flex flex-col gap-1">
-        <p className="typo-body-xs-regular text-neutral-800">{ex.period}</p>
-        <p className="typo-body-xs-regular text-neutral-800">{ex.place}</p>
+      <div className="flex flex-col typo-body-xs-regular text-neutral-800">
+        <p className="truncate">{ex.period}</p>
+        <p className="truncate">{ex.place}</p>
       </div>
 
       {/* 역할 | 상태 */}
-      {(roleLabel !== null || statusLabel !== null) && (
-        <div className="flex items-center h-4">
+      {showBadge && (roleLabel !== null || statusLabel !== null) && (
+        <div className="flex items-center">
           <p className="typo-body-xs-regular text-faint truncate">
-            {roleLabel && <span>{roleLabel}ㅣ</span>}
+            {roleLabel && <span>{roleLabel}</span>}
+            {roleLabel && statusLabel && <span> ㅣ </span>}
             {statusLabel && (
               <span className={isDraft ? 'underline text-faint' : 'text-faint'}>{statusLabel}</span>
             )}

--- a/src/components/display-manage/ExhibitionMeta.tsx
+++ b/src/components/display-manage/ExhibitionMeta.tsx
@@ -1,3 +1,6 @@
+import { useDisplayMembers } from '@/hooks/queries/useDisplayMembers';
+import { useAuthStore } from '@/stores/authStore';
+import { useUserStore } from '@/stores/useUserStore';
 import type { ExhibitionItem } from '@/types/mypage';
 
 export function ExhibitionMeta({
@@ -7,7 +10,22 @@ export function ExhibitionMeta({
   ex: ExhibitionItem;
   showBadge?: boolean;
 }) {
-  const roleLabel = ex.isLeader === true ? '대표자' : ex.isLeader === false ? '팀원' : null;
+  const userMe = useAuthStore((s) => s.user);
+  const userStoreUserId = useUserStore((s) => s.userId);
+  const myUserId = userMe?.id ?? userStoreUserId;
+
+  const displayId = ex.displayId || Number(ex.id) || 0;
+  const { data: membersData } = useDisplayMembers(showBadge && displayId > 0 ? displayId : 0);
+
+  const currentMember = membersData?.members?.find((m) =>
+    myUserId ? m.userId === myUserId : m.loggedIn === true,
+  );
+
+  const artistName = ex.artistName || currentMember?.displayNickname;
+
+  const roleBase = ex.isLeader === true ? '대표자' : ex.isLeader === false ? '팀원' : null;
+  const roleLabel = roleBase ? (artistName ? `${roleBase}(${artistName})` : roleBase) : null;
+
   const statusLabel =
     ex.publishStatus === 'PUBLISHED'
       ? '등록완료'

--- a/src/components/display-manage/ExhibitionMeta.tsx
+++ b/src/components/display-manage/ExhibitionMeta.tsx
@@ -1,44 +1,41 @@
 import type { ExhibitionItem } from '@/types/mypage';
 
-export function ExhibitionMeta({
-  ex,
-  showBadge = true,
-}: {
-  ex: ExhibitionItem;
-  showBadge?: boolean;
-}) {
+export function ExhibitionMeta({ ex }: { ex: ExhibitionItem }) {
+  /* 역할 레이블: isLeader 값 있으면 대표자/팀원, 없으면 공백 */
+  const roleLabel = ex.isLeader === true ? '대표자' : ex.isLeader === false ? '팀원' : null;
+
+  /* 발행 상태 레이블: publishedStatus 값 있으면 표시, 없으면 공백 */
+  const statusLabel =
+    ex.publishedStatus === 'PUBLISHED'
+      ? '등록완료'
+      : ex.publishedStatus === 'DRAFT'
+        ? '임시저장'
+        : null;
+
+  const isDraft = ex.publishedStatus === 'DRAFT';
+
   return (
-    <div className="flex-1 min-w-0 flex flex-col gap-3">
-      {showBadge && (
-        <span className="typo-body-xxs-regular inline-block text-white px-2 py-0.5 rounded mb-3">
-          {ex.status}
-        </span>
-      )}
-      <div className="flex flex-col gap-2">
-        <div className="flex justify-between items-center">
-          <h3 className="typo-body-md-bold text-main">{ex.title}</h3>
-        </div>
-        <div className="flex flex-col gap-1">
-          <div className="flex flex-col gap-1">
-            <div className="flex flex-col">
-              <p className="typo-body-xs-regular text-gray-800">{ex.period}</p>
-            </div>
-            <div className="flex flex-col">
-              <p className="typo-body-xs-regular text-gray-800">{ex.place}</p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2 h-4">
-            <div className="flex items-end gap-2 h-4 flex-1 min-w-0">
-              <p className="typo-body-xs-regular text-faint truncate">
-                <span className="text-faint">{ex.org}ㅣ</span>
-                <span className={ex.status === '임시저장' ? 'underline text-faint' : 'text-faint'}>
-                  {ex.status}
-                </span>
-              </p>
-            </div>
-          </div>
-        </div>
+    <div className="flex-1 min-w-0 flex flex-col gap-2">
+      {/* 제목 */}
+      <h3 className="typo-body-md-bold text-main leading-6 truncate">{ex.title}</h3>
+
+      {/* 날짜 · 장소 */}
+      <div className="flex flex-col gap-1">
+        <p className="typo-body-xs-regular text-neutral-800">{ex.period}</p>
+        <p className="typo-body-xs-regular text-neutral-800">{ex.place}</p>
       </div>
+
+      {/* 역할 | 상태 */}
+      {(roleLabel !== null || statusLabel !== null) && (
+        <div className="flex items-center h-4">
+          <p className="typo-body-xs-regular text-faint truncate">
+            {roleLabel && <span>{roleLabel}ㅣ</span>}
+            {statusLabel && (
+              <span className={isDraft ? 'underline text-faint' : 'text-faint'}>{statusLabel}</span>
+            )}
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/display-manage/ManageScreen.tsx
+++ b/src/components/display-manage/ManageScreen.tsx
@@ -2,11 +2,7 @@ import { useState } from 'react';
 
 import { Plus } from 'lucide-react';
 
-import { BottomButton } from '@/components/common';
-import { useDisplayCreatePolicy } from '@/hooks/usePolicy';
 import type { ExhibitionItem } from '@/types/mypage';
-import { cn } from '@/utils/cn';
-import { hasPermission } from '@/utils/hasPermission';
 
 import { Header, Screen } from './Common';
 import { ExhibitionCard } from './ExhibitionCard';
@@ -15,7 +11,6 @@ export function ManageScreen({
   exhibitions,
   onOpen,
   onBack,
-  onDone,
   onDelete,
   onLeave,
   onEditArtistName,
@@ -24,15 +19,12 @@ export function ManageScreen({
   exhibitions: ExhibitionItem[];
   onOpen: (ex: ExhibitionItem) => void;
   onBack?: () => void;
-  onDone: () => void;
   onDelete: (ex: ExhibitionItem) => void;
   onLeave: (ex: ExhibitionItem) => void;
   onEditArtistName: (ex: ExhibitionItem) => void;
   onRegister: () => void;
 }) {
   const [menuId, setMenuId] = useState<string | null>(null);
-  const displayCreatePolicy = useDisplayCreatePolicy();
-  const canCreateDisplay = hasPermission(displayCreatePolicy, 'create');
 
   return (
     <Screen>
@@ -81,22 +73,7 @@ export function ManageScreen({
             />
           ))}
         </div>
-        {canCreateDisplay && (
-          <button
-            onClick={onRegister}
-            className={cn(
-              'typo-body-sm-regular w-full mt-3.5 p-4.5 rounded-xl border-none text-main cursor-pointer',
-              'flex items-center justify-center gap-2',
-              'bg-card',
-            )}
-          >
-            <Plus size={18} /> 전시 등록하기
-          </button>
-        )}
       </div>
-      <BottomButton type="button" onClick={onDone}>
-        완료
-      </BottomButton>
     </Screen>
   );
 }

--- a/src/components/display-manage/ManageScreen.tsx
+++ b/src/components/display-manage/ManageScreen.tsx
@@ -17,6 +17,7 @@ export function ManageScreen({
   onBack,
   onDone,
   onDelete,
+  onLeave,
   onEditArtistName,
   onRegister,
 }: {
@@ -25,6 +26,7 @@ export function ManageScreen({
   onBack?: () => void;
   onDone: () => void;
   onDelete: (ex: ExhibitionItem) => void;
+  onLeave: (ex: ExhibitionItem) => void;
   onEditArtistName: (ex: ExhibitionItem) => void;
   onRegister: () => void;
 }) {
@@ -49,7 +51,7 @@ export function ManageScreen({
             className="flex flex-col items-center gap-0.75 bg-transparent border-none p-0 cursor-pointer"
           >
             <div className="flex items-center justify-center overflow-hidden">
-              <Plus size={19} className="text-main" strokeWidth={2} />
+              <Plus size={25} className="text-main" strokeWidth={2} />
             </div>
             <span className="px-1.25 typo-body-xs-bold text-main leading-4">전시 추가</span>
           </button>
@@ -65,6 +67,10 @@ export function ManageScreen({
               onClick={() => onOpen(ex)}
               onDelete={() => {
                 onDelete(ex);
+                setMenuId(null);
+              }}
+              onLeave={() => {
+                onLeave(ex);
                 setMenuId(null);
               }}
               onEditArtistName={() => {

--- a/src/components/displaydetailpage/ExhibitionMeta.tsx
+++ b/src/components/displaydetailpage/ExhibitionMeta.tsx
@@ -83,7 +83,7 @@ export function ExhibitionMeta({ display: ex }: Props) {
   };
 
   return (
-    <section className="px-5 pt-6 pb-4 bg-[#f0f0f3]">
+    <section className="px-5 pt-6 pb-4 bg-page">
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1 flex flex-col gap-1.5">
           <h1 className="typo-body-xl-bold text-main">{ex.title}</h1>

--- a/src/components/setting/SettingSection.tsx
+++ b/src/components/setting/SettingSection.tsx
@@ -6,7 +6,7 @@ interface SettingSectionProps {
 export function SettingSection({ title, children }: SettingSectionProps) {
   return (
     <section className="flex flex-col gap-3">
-      <h2 className="typo-body-md-bold text-sub600">{title}</h2>
+      <h2 className="typo-body-md-bold text-sub700">{title}</h2>
       <div className="overflow-hidden rounded-xl bg-card">{children}</div>
     </section>
   );

--- a/src/hooks/queries/useArtworkFeelings.ts
+++ b/src/hooks/queries/useArtworkFeelings.ts
@@ -46,6 +46,9 @@ export const useCreateArtworkFeeling = () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.artworkFeelings.list(variables.artworkId),
       });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkFeelings.all,
+      });
     },
   });
 };
@@ -67,6 +70,9 @@ export const useUpdateArtworkFeeling = () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.artworkFeelings.list(variables.artworkId),
       });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkFeelings.all,
+      });
     },
   });
 };
@@ -80,6 +86,9 @@ export const useDeleteArtworkFeeling = () => {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.artworkFeelings.list(variables.artworkId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkFeelings.all,
       });
     },
   });

--- a/src/hooks/queries/useArtworkQuestions.ts
+++ b/src/hooks/queries/useArtworkQuestions.ts
@@ -37,6 +37,9 @@ export const useCreateArtworkQuestion = () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.artworkQuestions.list(variables.artworkId),
       });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkQuestions.all,
+      });
     },
   });
 };
@@ -50,6 +53,9 @@ export const useDeleteArtworkQuestion = () => {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.artworkQuestions.list(variables.artworkId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artworkQuestions.all,
       });
     },
   });

--- a/src/hooks/queries/useDisplayReviews.ts
+++ b/src/hooks/queries/useDisplayReviews.ts
@@ -36,6 +36,7 @@ export const useCreateDisplayReview = (displayId: number) => {
         exact: true,
       });
       queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(displayId) });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.displays.all, 'reviews'] });
     },
   });
 };
@@ -51,6 +52,7 @@ export const useDeleteDisplayReview = (displayId: number) => {
         exact: true,
       });
       queryClient.invalidateQueries({ queryKey: queryKeys.displays.detail(displayId) });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.displays.all, 'reviews'] });
     },
   });
 };

--- a/src/hooks/queries/useLounge.ts
+++ b/src/hooks/queries/useLounge.ts
@@ -51,6 +51,7 @@ export const useCreateLoungePost = () => {
     mutationFn: (body: CreateLoungePostRequestDto) => createLoungePost(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungeMe.all });
     },
   });
 };
@@ -64,6 +65,7 @@ export const useUpdateLoungePost = () => {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(variables.postId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungeMe.all });
     },
   });
 };
@@ -76,6 +78,7 @@ export const useDeleteLoungePost = () => {
     onSuccess: (_, postId) => {
       queryClient.removeQueries({ queryKey: queryKeys.loungePosts.detail(postId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungeMe.all });
     },
   });
 };
@@ -112,6 +115,7 @@ export const useScrapLoungePost = () => {
     onSuccess: (_, postId) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(postId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungeMe.all });
     },
   });
 };
@@ -124,6 +128,7 @@ export const useUnscrapLoungePost = () => {
     onSuccess: (_, postId) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(postId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungeMe.all });
     },
   });
 };

--- a/src/hooks/queries/useLoungeComments.ts
+++ b/src/hooks/queries/useLoungeComments.ts
@@ -35,6 +35,7 @@ export const useCreateLoungeComment = () => {
       });
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(variables.postId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungeMe.all });
     },
   });
 };
@@ -61,6 +62,7 @@ export const useDeleteLoungeComment = () => {
       }
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.detail(variables.postId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.loungePosts.lists() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.loungeMe.all });
     },
   });
 };

--- a/src/hooks/queries/useLoungeMyActivity.ts
+++ b/src/hooks/queries/useLoungeMyActivity.ts
@@ -14,6 +14,8 @@ export const useMyLoungePosts = ({ enabled = true }: Options = {}) =>
     initialPageParam: null as number | null,
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursorId : null),
     enabled,
+    staleTime: 0,
+    refetchOnMount: 'always',
   });
 
 export const useMyLoungeScraps = ({ enabled = true }: Options = {}) =>
@@ -23,6 +25,8 @@ export const useMyLoungeScraps = ({ enabled = true }: Options = {}) =>
     initialPageParam: null as number | null,
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursorId : null),
     enabled,
+    staleTime: 0,
+    refetchOnMount: 'always',
   });
 
 export const useMyLoungeComments = ({ enabled = true }: Options = {}) =>
@@ -32,4 +36,6 @@ export const useMyLoungeComments = ({ enabled = true }: Options = {}) =>
     initialPageParam: null as number | null,
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursorId : null),
     enabled,
+    staleTime: 0,
+    refetchOnMount: 'always',
   });

--- a/src/hooks/queries/useMyArtworkFeelings.ts
+++ b/src/hooks/queries/useMyArtworkFeelings.ts
@@ -7,4 +7,6 @@ export const useMyArtworkFeelings = (params?: { cursor?: string; size?: number }
   useQuery({
     queryKey: [...queryKeys.artworkFeelings.lists(), 'my', params],
     queryFn: () => getMyArtworkFeelings(params),
+    staleTime: 0,
+    refetchOnMount: 'always',
   });

--- a/src/hooks/queries/useMyArtworkQuestions.ts
+++ b/src/hooks/queries/useMyArtworkQuestions.ts
@@ -7,4 +7,6 @@ export const useMyArtworkQuestions = (params?: { cursor?: string; size?: number 
   useQuery({
     queryKey: [...queryKeys.artworkQuestions.lists(), 'me', params],
     queryFn: () => getMyArtworkQuestions(params),
+    staleTime: 0,
+    refetchOnMount: 'always',
   });

--- a/src/hooks/queries/useMyDisplayReviews.ts
+++ b/src/hooks/queries/useMyDisplayReviews.ts
@@ -7,4 +7,6 @@ export const useMyDisplayReviews = (params?: { cursorId?: number; size?: number 
   useQuery({
     queryKey: [...queryKeys.displays.reviews(0), 'me', params],
     queryFn: () => getMyDisplayReviews(params),
+    staleTime: 0,
+    refetchOnMount: 'always',
   });

--- a/src/hooks/queries/useMyDisplays.ts
+++ b/src/hooks/queries/useMyDisplays.ts
@@ -1,7 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { ArtistDisplayDto } from '@/api/dto';
-import { getArtistDisplays, getMyDisplays } from '@/api/endpoints';
+import { deleteDisplay, getArtistDisplays, getMyDisplays } from '@/api/endpoints';
 import { queryKeys } from '@/api/queryKeys';
 import type { ExhibitionItem } from '@/types/mypage';
 import { getDisplayStatusLabel } from '@/utils/mypage';
@@ -15,6 +15,8 @@ const toExhibitionItem = (display: ArtistDisplayDto, isOwner: boolean): Exhibiti
   id: String(display.displayId),
   displayId: display.displayId,
   isOwner,
+  isLeader: display.isLeader,
+  publishedStatus: display.publishedStatus,
   status: getDisplayStatusLabel(display.displayStatus),
   title: display.title,
   /* 학과·학회 등 소속 전시는 학교/기관명+세부소속을, 연합 전시는 주최/소속명만 저장하므로
@@ -52,3 +54,14 @@ export const useArtistDisplays = (userId: number, { enabled = true }: { enabled?
       ];
     },
   });
+
+export const useDeleteDisplay = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (displayId: number) => deleteDisplay(displayId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.displays.lists(), 'my'] });
+    },
+  });
+};

--- a/src/hooks/queries/useMyDisplays.ts
+++ b/src/hooks/queries/useMyDisplays.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { ArtistDisplayDto } from '@/api/dto';
+import type { ArtistDisplayDto, UpdateMyDisplayNicknameRequestDto } from '@/api/dto';
 import {
   deleteDisplay,
   getArtistDisplays,
@@ -76,9 +76,12 @@ export const useUpdateMyDisplayNickname = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (nickname: string) => updateMyDisplayNickname({ nickname }),
-    onSuccess: () => {
+    mutationFn: (body: UpdateMyDisplayNicknameRequestDto) => updateMyDisplayNickname(body),
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: [...queryKeys.displays.lists(), 'my'] });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.displayMembers.byDisplayId(variables.displayId),
+      });
     },
   });
 };

--- a/src/hooks/queries/useMyDisplays.ts
+++ b/src/hooks/queries/useMyDisplays.ts
@@ -1,7 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { ArtistDisplayDto } from '@/api/dto';
-import { deleteDisplay, getArtistDisplays, getMyDisplays } from '@/api/endpoints';
+import {
+  deleteDisplay,
+  getArtistDisplays,
+  getMyDisplays,
+  updateMyDisplayNickname,
+} from '@/api/endpoints';
 import { queryKeys } from '@/api/queryKeys';
 import type { ExhibitionItem } from '@/types/mypage';
 import { getDisplayStatusLabel } from '@/utils/mypage';
@@ -15,8 +20,8 @@ const toExhibitionItem = (display: ArtistDisplayDto, isOwner: boolean): Exhibiti
   id: String(display.displayId),
   displayId: display.displayId,
   isOwner,
-  isLeader: display.isLeader,
-  publishedStatus: display.publishedStatus,
+  isLeader: display.isLeader ?? isOwner,
+  publishStatus: display.publishStatus ?? 'PUBLISHED',
   status: getDisplayStatusLabel(display.displayStatus),
   title: display.title,
   /* 학과·학회 등 소속 전시는 학교/기관명+세부소속을, 연합 전시는 주최/소속명만 저장하므로
@@ -25,6 +30,7 @@ const toExhibitionItem = (display: ArtistDisplayDto, isOwner: boolean): Exhibiti
   period: `${formatDate(display.startDate)} – ${formatDate(display.endDate)}`,
   place: display.placeName,
   thumbnail: display.postImageUrl,
+  artistName: display.displayNickname ?? display.artistName,
 });
 
 export const useMyDisplays = ({ enabled = true }: { enabled?: boolean } = {}) =>
@@ -60,6 +66,17 @@ export const useDeleteDisplay = () => {
 
   return useMutation({
     mutationFn: (displayId: number) => deleteDisplay(displayId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.displays.lists(), 'my'] });
+    },
+  });
+};
+
+export const useUpdateMyDisplayNickname = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (nickname: string) => updateMyDisplayNickname({ nickname }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...queryKeys.displays.lists(), 'my'] });
     },

--- a/src/hooks/queries/usePersonalArtwork.ts
+++ b/src/hooks/queries/usePersonalArtwork.ts
@@ -111,6 +111,12 @@ const useInvalidatePersonalArtworkGuestbook = (personalArtworkId: number) => {
     queryClient.invalidateQueries({
       queryKey: [...queryKeys.personalArtworks.detail(personalArtworkId), 'questions'],
     });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.artworkFeelings.all,
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.artworkQuestions.all,
+    });
   };
 };
 

--- a/src/mocks/handlers/display.ts
+++ b/src/mocks/handlers/display.ts
@@ -49,6 +49,8 @@ const myDisplayItem = (display: any) => ({
   department: display.department,
   placeName: display.placeName,
   postImageUrl: display.posterImageUrl ?? display.posterImages?.[0]?.imageUrl ?? '',
+  displayNickname: display.displayNickname ?? display.artistName ?? '작가명',
+  artistName: display.displayNickname ?? display.artistName ?? '작가명',
 });
 
 const displayInvitationItem = (displayId: number, invitationId = displayId) => {
@@ -320,9 +322,18 @@ export const displayHandlers = [
     ),
   ),
   ...paths('/api/v1/display/me/nickname').map((path) =>
-    http.patch(path, async ({ request }) =>
-      success('/api/v1/display/me/nickname', await readJson(request)),
-    ),
+    http.patch(path, async ({ request }) => {
+      const body = await readJson<{ displayId?: number; displayNickname?: string }>(request);
+      if (body.displayId && body.displayNickname) {
+        const display = findDisplay(body.displayId);
+        display.displayNickname = body.displayNickname;
+        if (display.teamMembers) {
+          const member = display.teamMembers.find((m: any) => m.userId === mockDb.me.userId);
+          if (member) member.displayNickname = body.displayNickname;
+        }
+      }
+      return success('/api/v1/display/me/nickname', body);
+    }),
   ),
   ...paths('/api/v1/display/search').map((path) =>
     http.get(path, ({ request }) => {
@@ -461,9 +472,23 @@ export const displayHandlers = [
       const displayId = toNumber(params.displayId, 101);
       const display = findDisplay(displayId);
 
+      const members = (display.teamMembers ?? []).length
+        ? display.teamMembers
+        : [
+            {
+              teamMemberId: 150,
+              userId: mockDb.me.userId,
+              displayNickname: `${display.title}작가명`,
+              loggedIn: true,
+              artistVerified: true,
+              accepted: true,
+              role: display.isLeader ? 'TEAM_LEADER' : 'TEAM_MEM',
+            },
+          ];
+
       return success('/api/v1/display/{displayId}/members', {
         displayId,
-        members: display.teamMembers ?? [],
+        members,
       });
     }),
   ),

--- a/src/pages/EditBasicInfoPage.tsx
+++ b/src/pages/EditBasicInfoPage.tsx
@@ -210,6 +210,7 @@ function EditBasicInfoForm({ userMe }: { userMe?: UserProfileDto }) {
                   <button
                     type="button"
                     onClick={handleClearInput}
+                    aria-label="프로필 명 지우기"
                     className="size-5 bg-box200 rounded-[10px] flex justify-center items-center cursor-pointer"
                   >
                     <X className="size-2.5 text-card translate-x-[0.5px]" strokeWidth={2} />

--- a/src/pages/EditBasicInfoPage.tsx
+++ b/src/pages/EditBasicInfoPage.tsx
@@ -57,7 +57,7 @@ function ProfilePhotoField({
             <LoadingView fullScreen={false} message="" className="!bg-transparent" />
           </div>
         )}
-        <span className="absolute bottom-0 right-0 flex size-6 items-center justify-center overflow-hidden rounded-full bg-sub600">
+        <span className="absolute bottom-0 right-0 flex size-6 items-center justify-center overflow-hidden rounded-full bg-hint">
           <Plus className="text-white" strokeWidth={2} />
         </span>
       </button>
@@ -172,8 +172,8 @@ function EditBasicInfoForm({ userMe }: { userMe?: UserProfileDto }) {
         <h1 className="typo-body-xl-bold text-main">기본 정보 수정</h1>
       </header>
 
-      <main className="flex-1 min-h-0 overflow-y-auto px-5 pb-8">
-        <div className="mt-[24px] flex justify-center">
+      <main className="flex-1 min-h-0 overflow-y-auto px-5 flex flex-col">
+        <div className="mt-6 flex justify-center">
           <ProfilePhotoField
             image={profileImage}
             onChange={handleProfileImageChange}
@@ -184,29 +184,29 @@ function EditBasicInfoForm({ userMe }: { userMe?: UserProfileDto }) {
         <form
           id="edit-basic-info-form"
           onSubmit={handleSubmit(onFormSubmit)}
-          className="mt-[60px] flex flex-col gap-3"
+          className="mt-15 flex flex-col gap-3"
         >
           <label htmlFor="activityName" className="typo-body-sm-bold text-main">
             프로필 명
           </label>
-          <div className="border-b border-line flex justify-end items-start gap-3">
-            <div className="flex-1 h-9 px-3 py-2.5 flex justify-start items-center gap-2">
-              <input
-                id="activityName"
-                maxLength={15}
-                placeholder="프로필 명"
-                className="w-full typo-body-xs-regular text-main outline-none placeholder:text-hint bg-transparent"
-                {...register('nickname', {
-                  onChange: () => {
-                    setNicknameCheckResult(null);
-                    setCheckedNickname('');
-                  },
-                })}
-              />
-            </div>
-            <div className="h-9 flex justify-start items-center gap-2.5">
-              <div className="w-8 flex justify-start items-center gap-2.5">
-                {nickname && (
+          <div className="relative">
+            <div className="border-b border-line flex justify-end items-start gap-3">
+              <div className="flex-1 h-9 px-3 py-2.5 flex justify-start items-center gap-2">
+                <input
+                  id="activityName"
+                  maxLength={15}
+                  placeholder="프로필 명"
+                  className="w-full typo-body-xs-regular text-main outline-none placeholder:text-hint bg-transparent"
+                  {...register('nickname', {
+                    onChange: () => {
+                      setNicknameCheckResult(null);
+                      setCheckedNickname('');
+                    },
+                  })}
+                />
+              </div>
+              <div className="h-9 flex justify-start items-center gap-2.5">
+                <div className="w-8 flex justify-start items-center gap-2.5">
                   <button
                     type="button"
                     onClick={handleClearInput}
@@ -214,31 +214,31 @@ function EditBasicInfoForm({ userMe }: { userMe?: UserProfileDto }) {
                   >
                     <X className="size-2.5 text-card translate-x-[0.5px]" strokeWidth={2} />
                   </button>
-                )}
-                <div className="w-px h-4 bg-faint" />
+                  <div className="w-px h-4 bg-faint" />
+                </div>
+                <button
+                  type="button"
+                  onClick={handleDuplicateCheck}
+                  disabled={!isNicknameShapeValid || checkNickname.isPending}
+                  className="w-17 h-8 rounded-lg outline outline-1 outline-offset-[-1px] outline-sub600 disabled:opacity-40 flex items-center justify-center cursor-pointer"
+                >
+                  <span className="typo-body-xs-semibold text-main translate-y-px">중복 확인</span>
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={handleDuplicateCheck}
-                disabled={!isNicknameShapeValid || checkNickname.isPending}
-                className="w-17 h-8 rounded-lg outline outline-1 outline-offset-[-1px] outline-sub600 disabled:opacity-40 flex items-center justify-center cursor-pointer"
+            </div>
+            {nicknameCheckResult && !isSameAsInitial && (
+              <div
+                className={cn(
+                  'absolute left-0 top-full mt-1.5 typo-body-xxs-regular',
+                  nicknameCheckResult === 'available' ? 'text-link' : 'text-error',
+                )}
               >
-                <span className="typo-body-xs-semibold text-main translate-y-px">중복 확인</span>
-              </button>
-            </div>
+                {nicknameCheckResult === 'available'
+                  ? '사용 가능한 닉네임이에요.'
+                  : '사용 불가한 닉네임이에요.'}
+              </div>
+            )}
           </div>
-          {nicknameCheckResult && !isSameAsInitial && (
-            <div
-              className={cn(
-                'self-stretch h-4 justify-start typo-body-xxs-regular',
-                nicknameCheckResult === 'available' ? 'text-link' : 'text-error',
-              )}
-            >
-              {nicknameCheckResult === 'available'
-                ? '사용 가능한 닉네임이에요.'
-                : '사용 불가한 닉네임이에요.'}
-            </div>
-          )}
 
           {/* 실시간 개별 조건 피드백 */}
           <div className="mt-12.5 flex flex-col gap-2">
@@ -285,7 +285,7 @@ function EditBasicInfoForm({ userMe }: { userMe?: UserProfileDto }) {
           </div>
         </form>
 
-        <div className="mt-8 flex items-start gap-1 rounded-2xl bg-card p-3.5">
+        <div className="mt-auto mb-7 flex items-start gap-1 rounded-2xl bg-card p-3.5">
           <Info className="size-3 shrink-0 text-faint" strokeWidth={1.5} />
           <p className="typo-body-xs-regular text-hint">
             활동명은 댓글, 질문, 라운지 등 서비스 활동에서 사용돼요.

--- a/src/pages/ExhibitionManagePage.tsx
+++ b/src/pages/ExhibitionManagePage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { ChevronRight, Info } from 'lucide-react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
@@ -59,6 +61,15 @@ export function ExhibitionManage() {
     },
   );
   const canEditDisplay = Boolean(display) && hasPermission(displayPolicy, 'edit');
+
+  useEffect(() => {
+    if (display && !canEditDisplay) {
+      navigate(`/exhibition/${displayId}/work`, {
+        replace: true,
+        state: { ...state, displayId },
+      });
+    }
+  }, [display, canEditDisplay, displayId, navigate, state]);
 
   const createDisplayMutation = useCreateDisplay();
   const publishDisplayMutation = usePublishDisplay();

--- a/src/pages/InvitationRequestPage.tsx
+++ b/src/pages/InvitationRequestPage.tsx
@@ -11,26 +11,6 @@ import {
 import type { Invitation } from '@/types/invitation';
 import { cn } from '@/utils/cn';
 
-type InvitationApiItem = DisplayInvitationDto & {
-  displayId?: number;
-  displayTitle?: string;
-  title?: string;
-  school?: string;
-  organization?: string;
-  department?: string;
-  startDate?: string;
-  startedAt?: string;
-  endDate?: string;
-  endedAt?: string;
-  placeName?: string;
-  gallery?: string;
-  posterImageUrl?: string;
-  thumbnailUrl?: string;
-  inviterNickname?: string;
-  inviterName?: string;
-  status?: string;
-};
-
 const formatMonthDay = (date?: string) => {
   if (!date) return '-';
 
@@ -38,26 +18,17 @@ const formatMonthDay = (date?: string) => {
   return month && day ? `${month}.${day}` : date;
 };
 
-const toInvitation = (item: InvitationApiItem): Invitation => {
-  const title = item.displayTitle ?? item.title ?? '';
-  const school = item.school ?? item.organization ?? '';
-  const department = item.department ?? '';
-  const inviterName = item.inviterNickname ?? item.inviterName;
-
-  return {
-    id: String(item.invitationId),
-    invitationId: item.invitationId,
-    displayId: item.displayId,
-    title,
-    department: [school, department].filter(Boolean).join(' '),
-    period: `${formatMonthDay(item.startDate ?? item.startedAt)} - ${formatMonthDay(
-      item.endDate ?? item.endedAt,
-    )}`,
-    gallery: item.placeName ?? item.gallery ?? '',
-    inviter: inviterName ? `초대 · ${inviterName}` : '',
-    posterUrl: item.posterImageUrl ?? item.thumbnailUrl ?? null,
-  };
-};
+const toInvitation = (item: DisplayInvitationDto): Invitation => ({
+  id: String(item.invitationId),
+  invitationId: item.invitationId,
+  displayId: item.displayId,
+  title: item.title,
+  department: item.schoolDepartmentName ?? '',
+  period: `${formatMonthDay(item.startedAt)} - ${formatMonthDay(item.endedAt)}`,
+  gallery: '',
+  inviter: '',
+  posterUrl: item.posterImageUrl ?? null,
+});
 
 interface InvitationCardProps {
   item: Invitation;
@@ -89,8 +60,8 @@ function InvitationCard({ item, highlighted = false, onAccept, onReject }: Invit
             <span className="typo-body-xs-regular text-hint">{item.period}</span>
           </div>
 
-          <span className="typo-body-xxs-regular text-faint">{item.gallery}</span>
-          <span className="typo-body-sm-regular text-sub600">{item.inviter}</span>
+          {item.gallery && <span className="typo-body-xxs-regular text-faint">{item.gallery}</span>}
+          {item.inviter && <span className="typo-body-sm-regular text-sub600">{item.inviter}</span>}
         </div>
       </div>
 
@@ -169,9 +140,9 @@ export function InvitationRequestPage() {
   const rejectInvitation = useRejectDisplayInvitation();
   const [rejectModalOpen, setRejectModalOpen] = useState(false);
   const [selectedInvitation, setSelectedInvitation] = useState<Invitation | null>(null);
-  const invitations = (data?.invitations ?? [])
-    .filter((item) => (item as InvitationApiItem).status !== 'REJECTED')
-    .map((item) => toInvitation(item as InvitationApiItem));
+  const invitations = (data?.exhibitions ?? [])
+    .filter((item) => item.status !== 'REJECTED')
+    .map((item) => toInvitation(item));
 
   const handleAccept = (item: Invitation) => {
     navigate(`/invitations/${item.id}/artist-name`, { state: { invitation: item } });

--- a/src/pages/MyActivityPage.tsx
+++ b/src/pages/MyActivityPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { useLocation } from 'react-router-dom';
+import { ChevronLeft } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import type { LoungePostSummaryDto } from '@/api/dto';
 import { ErrorView, LoadingView } from '@/components/common';
-import { LoungeBoardHeader, LoungeBoardPostCard } from '@/components/lounge-board';
+import { LoungeBoardPostCard } from '@/components/lounge-board';
 import { toLoungeCategoryKey } from '@/constants/loungeCategories';
 import {
   useMyLoungeComments,
@@ -48,6 +49,7 @@ const toBoardPost = (post: LoungePostSummaryDto): LoungeBoardPost | undefined =>
 };
 
 export function MyActivityPage() {
+  const navigate = useNavigate();
   const location = useLocation();
   const [activeTab, setActiveTab] = useState<TabKey>(() => getTabFromState(location.state));
 
@@ -95,7 +97,12 @@ export function MyActivityPage() {
 
   return (
     <div className="w-full max-w-md mx-auto h-dvh bg-page flex flex-col">
-      <LoungeBoardHeader title="내 활동" showWriteButton={false} className="px-5" />
+      <header className="flex items-center gap-3 px-5 pt-4 pb-3">
+        <button type="button" onClick={() => navigate(-1)} aria-label="뒤로가기" className="-ml-1">
+          <ChevronLeft className="size-7 text-main" strokeWidth={2} />
+        </button>
+        <h1 className="typo-body-xl-bold text-main">내 라운지 활동</h1>
+      </header>
 
       <nav className="mt-[15.5px] px-5 border-b border-zinc-300 flex items-center">
         {TABS.map((tab) => {

--- a/src/pages/MyExhibitionsPage.tsx
+++ b/src/pages/MyExhibitionsPage.tsx
@@ -25,11 +25,22 @@ export function MyExhibitionsPage() {
     <div className="w-96 mx-auto h-dvh bg-page flex flex-col">
       <ManageScreen
         exhibitions={myDisplays}
-        onOpen={(exhibition) =>
-          navigate(`/exhibition/${exhibition.id}/manage`, {
-            state: { ...exhibition, displayId: Number(exhibition.id) },
-          })
-        }
+        onOpen={(exhibition) => {
+          const isLeader = exhibition.isLeader ?? exhibition.isOwner ?? false;
+          if (isLeader) {
+            navigate(`/exhibition/${exhibition.id}/manage`, {
+              state: { ...exhibition, displayId: Number(exhibition.id) },
+            });
+          } else {
+            navigate(`/exhibition/${exhibition.id}/work`, {
+              state: {
+                ...exhibition,
+                displayId: Number(exhibition.id),
+                initialExhibition: exhibition,
+              },
+            });
+          }
+        }}
         onBack={() => window.history.back()}
         onDone={() => navigate('/setting')}
         onDelete={(ex) => setDisplayToDelete(ex)}

--- a/src/pages/MyExhibitionsPage.tsx
+++ b/src/pages/MyExhibitionsPage.tsx
@@ -6,7 +6,10 @@ import { DeleteConfirmModal, LoadingView } from '@/components/common';
 import { ManageScreen } from '@/components/display-manage';
 import { useHideFooter } from '@/components/layout';
 import { useDeleteDisplay, useMyDisplays } from '@/hooks/queries/useMyDisplays';
+import { useArtistVerificationRequiredModal } from '@/hooks/usePermissionRequiredModal';
+import { useDisplayCreatePolicy } from '@/hooks/usePolicy';
 import type { ExhibitionItem } from '@/types/mypage';
+import { hasPermission } from '@/utils/hasPermission';
 
 export function MyExhibitionsPage() {
   useHideFooter();
@@ -15,7 +18,20 @@ export function MyExhibitionsPage() {
   const { data: myDisplays = [], isLoading } = useMyDisplays();
   const deleteDisplayMutation = useDeleteDisplay();
 
+  const displayCreatePolicy = useDisplayCreatePolicy();
+  const canCreateDisplay = hasPermission(displayCreatePolicy, 'create');
+  const { artistVerificationModal, openArtistVerificationModal } =
+    useArtistVerificationRequiredModal();
+
   const [displayToDelete, setDisplayToDelete] = useState<ExhibitionItem | null>(null);
+
+  const handleRegister = () => {
+    if (canCreateDisplay) {
+      navigate('/exhibition/register');
+    } else {
+      openArtistVerificationModal();
+    }
+  };
 
   if (isLoading) {
     return <LoadingView message="전시 목록을 불러오는 중..." />;
@@ -42,11 +58,10 @@ export function MyExhibitionsPage() {
           }
         }}
         onBack={() => window.history.back()}
-        onDone={() => navigate('/setting')}
         onDelete={(ex) => setDisplayToDelete(ex)}
         onLeave={() => {}}
         onEditArtistName={(ex) => navigate(`/exhibition/register/artist`, { state: ex })}
-        onRegister={() => navigate('/exhibition/register')}
+        onRegister={handleRegister}
       />
 
       {displayToDelete && (
@@ -59,6 +74,8 @@ export function MyExhibitionsPage() {
           onCancel={() => setDisplayToDelete(null)}
         />
       )}
+
+      {artistVerificationModal}
     </div>
   );
 }

--- a/src/pages/MyExhibitionsPage.tsx
+++ b/src/pages/MyExhibitionsPage.tsx
@@ -1,15 +1,21 @@
+import { useState } from 'react';
+
 import { useNavigate } from 'react-router-dom';
 
-import { LoadingView } from '@/components/common';
+import { DeleteConfirmModal, LoadingView } from '@/components/common';
 import { ManageScreen } from '@/components/display-manage';
 import { useHideFooter } from '@/components/layout';
-import { useMyDisplays } from '@/hooks/queries/useMyDisplays';
+import { useDeleteDisplay, useMyDisplays } from '@/hooks/queries/useMyDisplays';
+import type { ExhibitionItem } from '@/types/mypage';
 
 export function MyExhibitionsPage() {
   useHideFooter();
 
   const navigate = useNavigate();
   const { data: myDisplays = [], isLoading } = useMyDisplays();
+  const deleteDisplayMutation = useDeleteDisplay();
+
+  const [displayToDelete, setDisplayToDelete] = useState<ExhibitionItem | null>(null);
 
   if (isLoading) {
     return <LoadingView message="전시 목록을 불러오는 중..." />;
@@ -26,10 +32,22 @@ export function MyExhibitionsPage() {
         }
         onBack={() => window.history.back()}
         onDone={() => navigate('/setting')}
-        onDelete={() => {}}
+        onDelete={(ex) => setDisplayToDelete(ex)}
+        onLeave={() => {}}
         onEditArtistName={(ex) => navigate(`/exhibition/register/artist`, { state: ex })}
         onRegister={() => navigate('/exhibition/register')}
       />
+
+      {displayToDelete && (
+        <DeleteConfirmModal
+          onConfirm={() => {
+            deleteDisplayMutation.mutate(Number(displayToDelete.id), {
+              onSuccess: () => setDisplayToDelete(null),
+            });
+          }}
+          onCancel={() => setDisplayToDelete(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/MyQuestionsPage.tsx
+++ b/src/pages/MyQuestionsPage.tsx
@@ -7,9 +7,10 @@ import { useMyArtworkQuestions } from '@/hooks/queries/useMyArtworkQuestions';
 
 interface QuestionCardProps {
   question: MyArtworkQuestionDto;
+  onClick?: () => void;
 }
 
-function QuestionCard({ question }: QuestionCardProps) {
+function QuestionCard({ question, onClick }: QuestionCardProps) {
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     const now = new Date();
@@ -26,7 +27,12 @@ function QuestionCard({ question }: QuestionCardProps) {
   };
 
   return (
-    <article className="w-full rounded-lg bg-card px-4 py-3.5 shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)]">
+    <article
+      onClick={onClick}
+      className={`w-full rounded-lg bg-card px-4 py-3.5 shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)] ${
+        onClick ? 'cursor-pointer hover:bg-box transition-colors' : ''
+      }`}
+    >
       <div className="flex flex-col gap-2">
         <div className="flex flex-col gap-1">
           <h3 className="typo-body-sm-semibold text-link">{question.artworkName}</h3>
@@ -64,9 +70,17 @@ export function MyQuestionsPage() {
           <ErrorView fullScreen={false} message="질문을 불러오는 데 실패했습니다." />
         ) : questions.length > 0 ? (
           <div className="flex flex-col gap-3.5">
-            {questions.map((question, i) => (
-              <QuestionCard key={i} question={question} />
-            ))}
+            {questions.map((question, i) => {
+              const handleNavigation = () => {
+                if (question.artworkId) {
+                  navigate(`/artwork/${question.artworkId}`);
+                } else if (question.personalArtworkId) {
+                  navigate(`/personal-artworks/${question.personalArtworkId}`);
+                }
+              };
+
+              return <QuestionCard key={i} question={question} onClick={handleNavigation} />;
+            })}
           </div>
         ) : (
           <ErrorView fullScreen={false} message="등록된 질문이 없습니다." />

--- a/src/pages/MyReviewPage.tsx
+++ b/src/pages/MyReviewPage.tsx
@@ -12,9 +12,10 @@ interface ReviewCardProps {
   title: string;
   content: string;
   createdAt: string;
+  onClick?: () => void;
 }
 
-function ReviewCard({ title, content, createdAt }: ReviewCardProps) {
+function ReviewCard({ title, content, createdAt, onClick }: ReviewCardProps) {
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     const now = new Date();
@@ -31,7 +32,12 @@ function ReviewCard({ title, content, createdAt }: ReviewCardProps) {
   };
 
   return (
-    <div className="w-full rounded-lg bg-card px-4 py-3.5 shadow-[8px_8px_18px_rgba(67,0,209,0.04)]">
+    <div
+      onClick={onClick}
+      className={`w-full rounded-lg bg-card px-4 py-3.5 shadow-[8px_8px_18px_rgba(67,0,209,0.04)] ${
+        onClick ? 'cursor-pointer hover:bg-box transition-colors' : ''
+      }`}
+    >
       <div className="flex flex-col gap-1">
         <p className="typo-body-sm-semibold text-link">{title}</p>
         <p className="typo-body-sm-regular text-main line-clamp-2">{content}</p>
@@ -135,19 +141,31 @@ export function MyReviewPage() {
                 title={review.displayName}
                 content={review.content}
                 createdAt={review.createdAt}
+                onClick={() => navigate(`/display/${review.displayId}`)}
               />
             ))}
           </div>
         ) : activeTab === '작품' && artworkFeelings.length > 0 ? (
           <div className="flex flex-col gap-4">
-            {artworkFeelings.map((feeling: MyArtworkFeelingDto, index: number) => (
-              <ReviewCard
-                key={`${feeling.artworkId}-${feeling.personalArtworkId}-${index}`}
-                title={feeling.artworkName}
-                content={feeling.content}
-                createdAt={feeling.createdAt}
-              />
-            ))}
+            {artworkFeelings.map((feeling: MyArtworkFeelingDto, index: number) => {
+              const handleNavigation = () => {
+                if (feeling.artworkId) {
+                  navigate(`/artwork/${feeling.artworkId}`);
+                } else if (feeling.personalArtworkId) {
+                  navigate(`/personal-artworks/${feeling.personalArtworkId}`);
+                }
+              };
+
+              return (
+                <ReviewCard
+                  key={`${feeling.artworkId}-${feeling.personalArtworkId}-${index}`}
+                  title={feeling.artworkName}
+                  content={feeling.content}
+                  createdAt={feeling.createdAt}
+                  onClick={handleNavigation}
+                />
+              );
+            })}
           </div>
         ) : (
           <div className="flex items-center justify-center h-full">

--- a/src/pages/PolicyPage.tsx
+++ b/src/pages/PolicyPage.tsx
@@ -64,7 +64,7 @@ function PolicyContent({ content }: { content: string }) {
 function PolicyDetail({ agreement, onBack }: { agreement: AgreementDto; onBack: () => void }) {
   return (
     <div className="mx-auto flex min-h-dvh w-full max-w-md flex-col bg-page">
-      <header className="mt-14.5 flex items-center gap-3 px-5 pb-3 pt-4">
+      <header className="flex items-center gap-3 px-5 pt-4 pb-6">
         <button type="button" onClick={onBack} aria-label="뒤로가기" className="-ml-1">
           <ChevronLeft className="size-7 text-main" strokeWidth={2} />
         </button>
@@ -97,7 +97,7 @@ export function PolicyPage() {
   return (
     <div className="mx-auto flex min-h-dvh w-full max-w-md flex-col bg-page">
       {/* Header */}
-      <header className="mt-14.5 flex items-center gap-3 px-5 pb-3 pt-4">
+      <header className="flex items-center gap-3 px-5 pt-4 pb-6">
         <button type="button" onClick={() => navigate(-1)} aria-label="뒤로가기" className="-ml-1">
           <ChevronLeft className="size-7 text-main" strokeWidth={2} />
         </button>

--- a/src/pages/Settingpage.tsx
+++ b/src/pages/Settingpage.tsx
@@ -24,7 +24,7 @@ export function SettingPage() {
   const { data: invitationsData } = useMyDisplayInvitations();
   const { data: questionsData } = useReceivedArtworkQuestions({ answerStatus: 'WAITING' });
 
-  const invitationCount = invitationsData?.invitations?.length ?? 0;
+  const invitationCount = invitationsData?.exhibitions?.length ?? 0;
   const pendingQuestionCount = questionsData?.questions?.length ?? 0;
 
   const handleLogout = () => {

--- a/src/pages/Settingpage.tsx
+++ b/src/pages/Settingpage.tsx
@@ -55,7 +55,7 @@ export function SettingPage() {
     <div className="max-w-md mx-auto min-h-screen bg-page">
       <SettingHeader onBack={handleBack} />
 
-      <div className="flex flex-col gap-8 px-5 pb-10">
+      <div className="flex flex-col gap-6 px-5 pb-10">
         <SettingSection title="프로필 및 계정">
           <SettingRow
             title="기본 정보 수정"
@@ -137,7 +137,7 @@ export function SettingPage() {
           </button>
         </SettingSection>
 
-        <div className="mt-8 flex flex-col gap-3">
+        <div className="mt-18 flex flex-col gap-3">
           <button
             type="button"
             className="typo-body-md-semibold h-14 w-full rounded-2xl bg-card text-main"

--- a/src/pages/artist-verification/ArtistVerificationPage.tsx
+++ b/src/pages/artist-verification/ArtistVerificationPage.tsx
@@ -269,7 +269,7 @@ export function ArtistVerificationPage() {
 
   return (
     <div className="flex min-h-dvh w-full items-center justify-center bg-page">
-      <main className="flex h-dvh w-full max-w-md flex-col overflow-hidden bg-page px-5 pt-[58px]">
+      <main className="flex h-dvh w-full max-w-md flex-col overflow-hidden bg-page px-5">
         <ArtistVerificationHeader onBack={() => navigate(-1)} />
 
         <form

--- a/src/pages/exhibition-register/ArtistNameSetup.tsx
+++ b/src/pages/exhibition-register/ArtistNameSetup.tsx
@@ -10,7 +10,10 @@ import { BottomButton } from '@/components/common';
 import { ExhibitionHeader } from '@/components/ui';
 import { DISPLAY_FIELD_MAP, DISPLAY_TYPE_MAP } from '@/constants/exhibition';
 import { useCreateDisplay } from '@/hooks/queries/useDisplayBrowse';
+import { useUpdateMyDisplayNickname } from '@/hooks/queries/useMyDisplays';
 import { useExhibitionRegisterDraft } from '@/hooks/useExhibitionRegisterDraft';
+import { useAuthStore } from '@/stores/authStore';
+import { useUserStore } from '@/stores/useUserStore';
 
 import { type ArtistNameSetupFormValues, artistNameSetupSchema } from './exhibitionRegister.schema';
 
@@ -20,6 +23,10 @@ interface SummaryRowProps {
 }
 
 type ExhibitionRegisterState = {
+  id?: string | number;
+  displayId?: number;
+  isOwner?: boolean;
+  isLeader?: boolean;
   imageUrls?: string[];
   title?: string;
   subtitle?: string;
@@ -29,7 +36,9 @@ type ExhibitionRegisterState = {
   school?: string;
   department?: string;
   organizer?: string;
+  org?: string;
   period?: string;
+  role?: string;
   startDate?: string | null;
   endDate?: string | null;
   startTime?: string | null;
@@ -41,6 +50,7 @@ type ExhibitionRegisterState = {
   contact?: string;
   notice?: string;
   artistName?: string;
+  displayNickname?: string;
 };
 
 const getRegion = (address: string): CreateDisplayRequestDto['region'] => {
@@ -96,47 +106,87 @@ export function ArtistNameSetup() {
   const navigate = useNavigate();
   const { state } = useLocation();
   const { draft, hasDraft, updateDraft, resetDraft } = useExhibitionRegisterDraft();
+  const userMe = useAuthStore((s) => s.user);
+  const userStoreName = useUserStore((s) => s.displayArtistName || s.artistName);
+
+  const createDisplay = useCreateDisplay();
+  const updateNickname = useUpdateMyDisplayNickname();
+
   const shouldUseDraft = hasDraft && hasCompleteRegisterDraft(draft);
   const registerState = {
     ...(state ?? {}),
     ...(shouldUseDraft ? draft : {}),
   } as ExhibitionRegisterState;
-  const createDisplay = useCreateDisplay();
+
+  const isEditMode = Boolean(registerState.displayId || registerState.id) && !shouldUseDraft;
+
+  const isLeader = registerState.isLeader ?? registerState.isOwner ?? true;
+  const roleLabel = registerState.role ?? (isLeader ? '대표자' : '팀원');
 
   const info = {
     title: registerState.title ?? '',
-    org: registerState.school || registerState.organizer || '',
+    org:
+      registerState.org ||
+      [registerState.school, registerState.department || registerState.organizer]
+        .filter(Boolean)
+        .join(' ') ||
+      '',
     period:
       shouldUseDraft && draft.startDate && draft.endDate
         ? formatPeriodLabel(draft.startDate, draft.endDate)
         : (registerState.period ?? ''),
-    role: '대표자',
+    role: roleLabel,
   };
+
+  const initialArtistName =
+    registerState.artistName ?? registerState.displayNickname ?? (userStoreName || '');
 
   const {
     register,
     handleSubmit,
     control,
     getValues,
+    setValue,
     formState: { errors, isValid },
   } = useForm<ArtistNameSetupFormValues>({
     resolver: zodResolver(artistNameSetupSchema),
     mode: 'onChange',
     defaultValues: {
-      artistName: registerState.artistName ?? '',
+      artistName: initialArtistName,
     },
   });
   const artistName = useWatch({ control, name: 'artistName' }) ?? '';
 
+  useEffect(() => {
+    if (initialArtistName && !getValues('artistName')) {
+      setValue('artistName', initialArtistName, { shouldValidate: true });
+    }
+  }, [initialArtistName, getValues, setValue]);
+
   const saveCurrentDraft = () => {
-    updateDraft({ artistName: getValues('artistName') });
+    if (!isEditMode) {
+      updateDraft({ artistName: getValues('artistName') });
+    }
   };
 
   useEffect(() => {
-    updateDraft({ artistName });
-  }, [artistName, updateDraft]);
+    if (!isEditMode) {
+      updateDraft({ artistName });
+    }
+  }, [artistName, updateDraft, isEditMode]);
 
-  const goCreate = (data: ArtistNameSetupFormValues) => {
+  const onSubmit = (data: ArtistNameSetupFormValues) => {
+    const displayNickname = data.artistName.trim();
+
+    if (isEditMode) {
+      updateNickname.mutate(displayNickname, {
+        onSuccess: () => {
+          navigate('/my/exhibitions');
+        },
+      });
+      return;
+    }
+
     const type = registerState.type ? DISPLAY_TYPE_MAP[registerState.type] : undefined;
     const posterImageUrl = registerState.imageUrls?.[0];
 
@@ -174,7 +224,7 @@ export function ArtistNameSetup() {
       latitude: registerState.latitude,
       longitude: registerState.longitude,
       roadAddress: registerState.address.trim(),
-      displayNickname: data.artistName.trim(),
+      displayNickname,
       qnaAccount: (registerState.contact ?? '').trim(),
       schoolOrOrganization: optionalText(registerState.school || registerState.organizer) ?? '',
       departmentOrClub: optionalText(registerState.department),
@@ -193,7 +243,7 @@ export function ArtistNameSetup() {
         navigate(`/exhibition/${display.displayId}/manage`, {
           state: {
             ...registerState,
-            artistName: data.artistName.trim(),
+            artistName: displayNickname,
             displayId: display.displayId,
             posterImageUrl,
           },
@@ -202,10 +252,12 @@ export function ArtistNameSetup() {
     });
   };
 
+  const isPending = createDisplay.isPending || updateNickname.isPending;
+
   return (
     <div className="mx-auto flex h-dvh w-full max-w-md flex-col overflow-hidden bg-page">
       <ExhibitionHeader
-        title="전시 작가명 설정"
+        title={isEditMode ? '전시 작가명 수정' : '전시 작가명 설정'}
         onBack={() => {
           saveCurrentDraft();
           navigate(-1);
@@ -215,7 +267,7 @@ export function ArtistNameSetup() {
       <main className="flex min-h-0 flex-1 overflow-hidden px-5">
         <form
           id="artist-name-setup-form"
-          onSubmit={handleSubmit(goCreate)}
+          onSubmit={handleSubmit(onSubmit)}
           className="flex h-full flex-col gap-5"
         >
           {/* 안내 문구 */}
@@ -273,12 +325,14 @@ export function ArtistNameSetup() {
         </form>
       </main>
 
-      <BottomButton
-        form="artist-name-setup-form"
-        type="submit"
-        disabled={!isValid || createDisplay.isPending}
-      >
-        {createDisplay.isPending ? '전시 등록 중' : '전시 관리 페이지 만들기'}
+      <BottomButton form="artist-name-setup-form" type="submit" disabled={!isValid || isPending}>
+        {isPending
+          ? isEditMode
+            ? '수정 중'
+            : '전시 등록 중'
+          : isEditMode
+            ? '수정 완료'
+            : '전시 관리 페이지 만들기'}
       </BottomButton>
     </div>
   );

--- a/src/pages/exhibition-register/ArtistNameSetup.tsx
+++ b/src/pages/exhibition-register/ArtistNameSetup.tsx
@@ -10,6 +10,7 @@ import { BottomButton } from '@/components/common';
 import { ExhibitionHeader } from '@/components/ui';
 import { DISPLAY_FIELD_MAP, DISPLAY_TYPE_MAP } from '@/constants/exhibition';
 import { useCreateDisplay } from '@/hooks/queries/useDisplayBrowse';
+import { useDisplayMembers } from '@/hooks/queries/useDisplayMembers';
 import { useUpdateMyDisplayNickname } from '@/hooks/queries/useMyDisplays';
 import { useExhibitionRegisterDraft } from '@/hooks/useExhibitionRegisterDraft';
 import { useAuthStore } from '@/stores/authStore';
@@ -107,6 +108,8 @@ export function ArtistNameSetup() {
   const { state } = useLocation();
   const { draft, hasDraft, updateDraft, resetDraft } = useExhibitionRegisterDraft();
   const userMe = useAuthStore((s) => s.user);
+  const userStoreUserId = useUserStore((s) => s.userId);
+  const myUserId = userMe?.id ?? userStoreUserId;
   const userStoreName = useUserStore((s) => s.displayArtistName || s.artistName);
 
   const createDisplay = useCreateDisplay();
@@ -119,6 +122,14 @@ export function ArtistNameSetup() {
   } as ExhibitionRegisterState;
 
   const isEditMode = Boolean(registerState.displayId || registerState.id) && !shouldUseDraft;
+  const displayId = Number(registerState.displayId || registerState.id || 0);
+
+  const { data: membersData } = useDisplayMembers(isEditMode ? displayId : 0);
+
+  const currentMember = membersData?.members?.find((m) =>
+    myUserId ? m.userId === myUserId : m.loggedIn === true,
+  );
+  const fetchedMemberNickname = currentMember?.displayNickname;
 
   const isLeader = registerState.isLeader ?? registerState.isOwner ?? true;
   const roleLabel = registerState.role ?? (isLeader ? '대표자' : '팀원');
@@ -139,7 +150,11 @@ export function ArtistNameSetup() {
   };
 
   const initialArtistName =
-    registerState.artistName ?? registerState.displayNickname ?? (userStoreName || '');
+    fetchedMemberNickname ||
+    registerState.artistName ||
+    registerState.displayNickname ||
+    userStoreName ||
+    '';
 
   const {
     register,
@@ -158,10 +173,10 @@ export function ArtistNameSetup() {
   const artistName = useWatch({ control, name: 'artistName' }) ?? '';
 
   useEffect(() => {
-    if (initialArtistName && !getValues('artistName')) {
+    if (initialArtistName) {
       setValue('artistName', initialArtistName, { shouldValidate: true });
     }
-  }, [initialArtistName, getValues, setValue]);
+  }, [initialArtistName, setValue]);
 
   const saveCurrentDraft = () => {
     if (!isEditMode) {
@@ -179,11 +194,14 @@ export function ArtistNameSetup() {
     const displayNickname = data.artistName.trim();
 
     if (isEditMode) {
-      updateNickname.mutate(displayNickname, {
-        onSuccess: () => {
-          navigate('/my/exhibitions');
+      updateNickname.mutate(
+        { displayId, displayNickname },
+        {
+          onSuccess: () => {
+            navigate('/my/exhibitions');
+          },
         },
-      });
+      );
       return;
     }
 

--- a/src/pages/onboarding/OnboardingPage.tsx
+++ b/src/pages/onboarding/OnboardingPage.tsx
@@ -852,7 +852,7 @@ function NicknameScreen({
 
 function DoneScreen({ onNext }: { onNext: () => void }) {
   return (
-    <main className="flex h-full flex-1 flex-col bg-[#f0f0f3] px-5 pb-10">
+    <main className="flex h-full flex-1 flex-col bg-page px-5 pb-10">
       <section className="flex min-h-0 flex-1 flex-col items-center justify-center gap-[10px] text-center">
         <div className="flex size-[76px] items-center justify-center rounded-full bg-[#e6e6ee]">
           <div className="flex size-12 items-center justify-center rounded-full bg-[#111]">

--- a/src/policies/policies.ts
+++ b/src/policies/policies.ts
@@ -58,8 +58,7 @@ export const policies = {
   },
 
   displayArtistName: {
-    edit: (user: User, display: DisplayPolicyResource) =>
-      isArtistVerified(user) && isDisplayMember(user, display),
+    edit: (user: User, display: DisplayPolicyResource) => isDisplayMember(user, display),
   },
 
   displayContent: {

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -8,7 +8,7 @@ export interface ExhibitionItem {
   /* 내 전시 목록은 생성/참여를 나눠서 내려주므로 소유 여부를 그대로 담아둡니다. */
   isOwner?: boolean;
   isLeader?: boolean;
-  publishedStatus?: 'PUBLISHED' | 'DRAFT';
+  publishStatus?: 'PUBLISHED' | 'DRAFT';
   status: string;
   title: string;
   org: string;
@@ -16,6 +16,7 @@ export interface ExhibitionItem {
   place: string;
   thumbnail: string;
   memo?: string;
+  artistName?: string;
 }
 
 export interface SavedArtworkItem {

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -7,6 +7,8 @@ export interface ExhibitionItem {
   userId?: number;
   /* 내 전시 목록은 생성/참여를 나눠서 내려주므로 소유 여부를 그대로 담아둡니다. */
   isOwner?: boolean;
+  isLeader?: boolean;
+  publishedStatus?: 'PUBLISHED' | 'DRAFT';
   status: string;
   title: string;
   org: string;


### PR DESCRIPTION
## 📝 작업 내용

- 설정페이지 관련 엔드포인트와 dto를 실제 응답에 맞게 수정하였습니다.
- 규격이 안맞는 부분들을 전부 수정하였습니다.
- 내 전시 관리 화면이 이제 피그마와 같습니다.(카드 디자인, 기능)
- 내 활동이 업데이트되지 않는 문제를 해결하였습니다.
- 내 활동에서 해당 전시나 작품으로 이동되지 않는 문제를 해결하였습니다.

## 🔍 관련 이슈

- close #243 

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 전시 관리에서 전시 삭제 및 비리더의 전시 나가기 기능을 지원합니다.
  * 전시 작가명과 표시명을 수정할 수 있습니다.
  * 전시 생성 권한 및 작가 인증 상태에 따른 안내를 제공합니다.
  * 내 활동의 질문·감상·리뷰 항목을 클릭해 관련 상세 화면으로 이동할 수 있습니다.
  * 삭제 전 확인 모달을 제공합니다.

* **개선**
  * 전시 역할, 공개 상태, 작가명 정보를 카드에서 확인할 수 있습니다.
  * 라운지와 작품 활동 정보가 변경 후 최신 상태로 표시됩니다.
  * 주요 화면의 여백, 색상, 헤더 및 버튼 디자인을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->