### PR TITLE
fix: 전시 등록 시간 선택 시트 모바일 UX 개선

### DIFF
--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { X } from 'lucide-react';
 
@@ -7,10 +7,20 @@ interface BottomSheetProps {
   onClose: () => void;
   title: string;
   subtitle?: string;
+  keyboardAvoiding?: boolean;
   children: React.ReactNode;
 }
 
-export function BottomSheet({ open, onClose, title, subtitle, children }: BottomSheetProps) {
+export function BottomSheet({
+  open,
+  onClose,
+  title,
+  subtitle,
+  keyboardAvoiding = false,
+  children,
+}: BottomSheetProps) {
+  const [keyboardOffset, setKeyboardOffset] = useState(0);
+
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
@@ -22,6 +32,30 @@ export function BottomSheet({ open, onClose, title, subtitle, children }: Bottom
     };
   }, [open, onClose]);
 
+  useEffect(() => {
+    if (!open || !keyboardAvoiding || !window.visualViewport) {
+      return;
+    }
+
+    const viewport = window.visualViewport;
+    const updateKeyboardOffset = () => {
+      const offset = Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop);
+      setKeyboardOffset(offset);
+    };
+
+    const frame = requestAnimationFrame(updateKeyboardOffset);
+    viewport.addEventListener('resize', updateKeyboardOffset);
+    viewport.addEventListener('scroll', updateKeyboardOffset);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      viewport.removeEventListener('resize', updateKeyboardOffset);
+      viewport.removeEventListener('scroll', updateKeyboardOffset);
+    };
+  }, [open, keyboardAvoiding]);
+
+  const offset = open && keyboardAvoiding ? keyboardOffset : 0;
+
   if (!open) return null;
 
   return (
@@ -31,6 +65,10 @@ export function BottomSheet({ open, onClose, title, subtitle, children }: Bottom
     >
       <div
         className="flex max-h-[85dvh] w-full flex-col rounded-t-2xl bg-page pb-safe-bottom"
+        style={{
+          transform: offset ? `translateY(-${offset}px)` : undefined,
+          transition: 'transform 180ms ease-out',
+        }}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between px-5 pb-2 pt-6">

--- a/src/components/ui/TimeSheet.tsx
+++ b/src/components/ui/TimeSheet.tsx
@@ -176,7 +176,13 @@ export function TimeSheet({
   };
 
   return (
-    <BottomSheet open={open} onClose={onClose} title="시간 선택" subtitle={subtitle ?? label}>
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      title="시간 선택"
+      subtitle={subtitle ?? label}
+      keyboardAvoiding
+    >
       <div className="flex min-w-0 flex-col items-center gap-10 px-5 py-13">
         {/* 디지털 표시 — 탭해서 대상 전환 + 숫자 직접 입력 */}
         <div className="flex w-full min-w-0 flex-col items-center gap-3">


### PR DESCRIPTION
## 📝 작업 내용

- 모바일 키보드가 올라올 때 바텀 시트가 키보드 높이만큼 위로 이동하도록 `BottomSheet`에 키보드 회피 옵션을 추가했습니다.
- 시간 선택 시트에만 키보드 회피 옵션을 적용해 Safari/PWA 환경에서 시간 입력 영역과 선택 완료 버튼이 더 잘 보이도록 개선했습니다.
- 기존 시간 입력, 필드 자동 이동, 시작/종료 시간 순서 보정 로직은 유지했습니다.

## 🔍 관련 이슈

- close #262

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

검증 명령어
- `pnpm lint`
- `pnpm build`

## 💬 기타 참고 사항

- `keyboardAvoiding` 옵션은 시간 선택 시트에서만 사용하도록 적용 범위를 제한했습니다.
