### PR TITLE
refactor: 이미지 요청 최적화 적용

### DIFF
--- a/src/components/artworkdetailpage/ArtworkIntroTab.tsx
+++ b/src/components/artworkdetailpage/ArtworkIntroTab.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 
 import type { ArtworkCoAuthorDto } from '@/api/dto';
 import { LoginConfirmModal } from '@/components/common/LoginConfirmModal';
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { FALLBACK_PROFILE_IMAGE } from '@/constants';
 import {
   useArchiveArtist,
@@ -82,8 +83,9 @@ function ArtworkArtistRow({ userId, displayName }: ArtworkArtistRowProps) {
         disabled={!userId || !profile}
         className="flex min-w-0 items-center gap-2 text-left disabled:cursor-default"
       >
-        <img
+        <OptimizedImage
           src={profile?.profileImageUrl || FALLBACK_PROFILE_IMAGE}
+          displayWidth={39}
           alt={primaryName}
           className="size-[39px] shrink-0 rounded-full object-cover"
           onError={(event) => {
@@ -212,9 +214,10 @@ export function ArtworkIntroTab({ artwork, artistUserId, coAuthors = [] }: Props
               style={{ scrollbarWidth: 'none' }}
             >
               {processImages.map((img, idx) => (
-                <img
+                <OptimizedImage
                   key={idx}
                   src={img.imageUrl}
+                  displayWidth={119}
                   alt={`작업과정 ${idx + 1}`}
                   className="h-[152px] w-[119px] shrink-0 rounded-[13px] bg-[rgba(161,156,156,0.5)] object-cover shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)]"
                 />

--- a/src/components/artworks-manage/Common.tsx
+++ b/src/components/artworks-manage/Common.tsx
@@ -1,7 +1,9 @@
+import { OptimizedImage } from '@/components/common/OptimizedImage';
+
 export function Thumbnail({ src, className = 'size-20' }: { src?: string; className?: string }) {
   return (
     <div className={`${className} shrink-0 overflow-hidden rounded-xl bg-box200`}>
-      {src && <img src={src} alt="" className="size-full object-cover" />}
+      <OptimizedImage src={src} displayWidth={100} alt="" className="size-full object-cover" />
     </div>
   );
 }

--- a/src/components/artworks-manage/ContentCard.tsx
+++ b/src/components/artworks-manage/ContentCard.tsx
@@ -1,5 +1,6 @@
 import { MoreHorizontal } from 'lucide-react';
 
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { FALLBACK_POSTER_IMAGE } from '@/constants';
 import type { Content } from '@/types';
 import { cn } from '@/utils/cn';
@@ -9,7 +10,7 @@ function Thumbnail({ src }: { src?: string }) {
   return (
     <div className="size-20 shrink-0 overflow-hidden rounded-xl bg-box200">
       {src ? (
-        <img src={src} alt="" className="size-full object-cover" />
+        <OptimizedImage src={src} displayWidth={80} alt="" className="size-full object-cover" />
       ) : (
         <div className="grid size-full place-items-center bg-box200 p-3">
           <img src={FALLBACK_POSTER_IMAGE} alt="" className="w-full opacity-40" />

--- a/src/components/common/OptimizedImage.tsx
+++ b/src/components/common/OptimizedImage.tsx
@@ -1,0 +1,29 @@
+import type { ImgHTMLAttributes } from 'react';
+
+import { type ImageOptimizationFormat, optimizeImageUrl } from '@/utils/imageOptimization';
+
+type OptimizedImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'> & {
+  src?: string | null;
+  displayWidth: number;
+  format?: ImageOptimizationFormat;
+};
+
+export function OptimizedImage({
+  src,
+  displayWidth,
+  format = 'webp',
+  loading = 'lazy',
+  decoding = 'async',
+  ...props
+}: OptimizedImageProps) {
+  if (!src) return null;
+
+  return (
+    <img
+      src={optimizeImageUrl(src, displayWidth, format)}
+      loading={loading}
+      decoding={decoding}
+      {...props}
+    />
+  );
+}

--- a/src/components/display-manage/ArtworkCard.tsx
+++ b/src/components/display-manage/ArtworkCard.tsx
@@ -1,3 +1,5 @@
+import { OptimizedImage } from '@/components/common/OptimizedImage';
+
 interface ArtworkCardProps {
   art: {
     id: string;
@@ -11,7 +13,12 @@ export function ArtworkCard({ art }: ArtworkCardProps) {
   return (
     <div className="h-[158px] w-[118px] shrink-0 overflow-hidden rounded-xl border border-line-soft bg-card">
       {art.image ? (
-        <img src={art.image} alt={art.title} className="block h-[98px] w-full object-cover" />
+        <OptimizedImage
+          src={art.image}
+          displayWidth={118}
+          alt={art.title}
+          className="block h-[98px] w-full object-cover"
+        />
       ) : (
         <div
           className="relative h-[98px]"

--- a/src/components/display-manage/Poster.tsx
+++ b/src/components/display-manage/Poster.tsx
@@ -1,3 +1,4 @@
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { FALLBACK_POSTER_IMAGE } from '@/constants';
 
 export function Poster({
@@ -14,8 +15,9 @@ export function Poster({
   const isFallback = !src;
 
   return (
-    <img
+    <OptimizedImage
       src={isFallback ? FALLBACK_POSTER_IMAGE : src}
+      displayWidth={w}
       alt="poster"
       className={`shrink-0 shadow-[2px_4px_18px_rgba(6,3,45,0.06)] ${
         isFallback ? 'bg-box object-contain p-3' : 'object-cover'

--- a/src/components/displaydetailpage/ArtworkTab.tsx
+++ b/src/components/displaydetailpage/ArtworkTab.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
 import type { DisplayArtworkDto } from '@/api/dto';
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { useDisplayArtworks } from '@/hooks/queries/useDisplayArtworks';
 
 type ArtworkCardProps = {
@@ -16,8 +17,9 @@ function ArtworkCard({ item }: ArtworkCardProps) {
       onClick={() => navigate(`/artwork/${item.artworkId}`)}
     >
       <div className="aspect-square w-full rounded-xl overflow-hidden bg-page border  border-line-soft">
-        <img
+        <OptimizedImage
           src={item.artworkImageUrl}
+          displayWidth={170}
           alt={item.artworkName}
           className="w-full h-full object-cover"
         />

--- a/src/components/displaydetailpage/HeroSlider.tsx
+++ b/src/components/displaydetailpage/HeroSlider.tsx
@@ -1,6 +1,7 @@
 import { BackButton } from '@/components/ui/BackButton';
 import { useSwipeSlider } from '@/hooks/useSwipeSlider';
 import { cn } from '@/utils/cn';
+import { optimizeImageUrl } from '@/utils/imageOptimization';
 
 type Props = {
   images: string[];
@@ -29,7 +30,7 @@ export function HeroSlider({ images, onBack }: Props) {
         {images.map((src, idx) => (
           <div key={src || idx} className="relative h-full w-full shrink-0">
             <img
-              src={src}
+              src={optimizeImageUrl(src, 430)}
               alt={`전시 이미지 ${idx + 1}`}
               draggable={false}
               className="h-full w-full object-cover select-none"

--- a/src/components/exhibition-manage/ExhibitionCard.tsx
+++ b/src/components/exhibition-manage/ExhibitionCard.tsx
@@ -1,3 +1,5 @@
+import { OptimizedImage } from '@/components/common/OptimizedImage';
+
 interface ExhibitionCardProps {
   title: string;
   org: string;
@@ -11,7 +13,12 @@ export function ExhibitionCard({ title, org, period, place, thumbnail }: Exhibit
     <div className="flex h-32 gap-3 overflow-hidden rounded-2xl bg-box100 px-4 py-3.5 shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04),inset_1px_1px_4px_0px_rgba(1,8,21,0.2),inset_-2px_-2px_2px_0px_rgba(255,255,255,0.9)]">
       <div className="h-[101px] w-[72px] shrink-0 overflow-hidden rounded-xl bg-box">
         {thumbnail && (
-          <img src={thumbnail} alt="전시 포스터" className="h-full w-full object-cover" />
+          <OptimizedImage
+            src={thumbnail}
+            displayWidth={72}
+            alt="전시 포스터"
+            className="h-full w-full object-cover"
+          />
         )}
       </div>
       <div className="flex min-w-0 flex-col gap-2.5">

--- a/src/components/homepage/ArtworkPreviewSection.tsx
+++ b/src/components/homepage/ArtworkPreviewSection.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import { Link } from 'react-router-dom';
 
 import type { ArtworkPreviewItemDto } from '@/api/dto';
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { SectionHeader } from '@/components/homepage/SectionHeader';
 
 type Props = {
@@ -36,13 +37,12 @@ export function ArtworkPreviewSection({ items, onMoreClick }: Props) {
             to={`/artwork/${item.artworkId}`}
             className="relative shrink-0 w-34 h-55 rounded-xl overflow-hidden bg-box200 cursor-pointer hover:opacity-90 active:scale-95 transition-all block focus:outline-none focus-visible:ring-2 focus-visible:ring-main"
           >
-            {item.artworkImageUrl && (
-              <img
-                src={item.artworkImageUrl}
-                alt={item.artworkName}
-                className="absolute inset-0 w-full h-full object-cover"
-              />
-            )}
+            <OptimizedImage
+              src={item.artworkImageUrl}
+              displayWidth={136}
+              alt={item.artworkName}
+              className="absolute inset-0 w-full h-full object-cover"
+            />
             <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/15 to-transparent" />
 
             <div className="absolute left-3 right-3 bottom-3">

--- a/src/components/homepage/DuPickBanner.tsx
+++ b/src/components/homepage/DuPickBanner.tsx
@@ -1,4 +1,5 @@
 import type { DuPickDto } from '@/api/dto';
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { useSwipeSlider } from '@/hooks/useSwipeSlider';
 import type { DuPickItem } from '@/types/exhibition';
 import { cn } from '@/utils/cn';
@@ -50,8 +51,9 @@ function CardItem({ item, isActive }: CardProps) {
     <div className="relative w-full h-full rounded-xl overflow-hidden bg-box200 select-none transition-all duration-300 ease-out">
       {/* 배경 이미지 */}
       {item.bannerImageUrl ? (
-        <img
+        <OptimizedImage
           src={item.bannerImageUrl}
+          displayWidth={360}
           alt={title}
           draggable={false}
           className="absolute inset-0 h-full w-full object-cover object-center select-none"

--- a/src/components/homepage/ExhibitionSection.tsx
+++ b/src/components/homepage/ExhibitionSection.tsx
@@ -2,6 +2,7 @@ import { Bookmark } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import type { HomeExhibitionDto } from '@/api/dto';
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { SectionHeader } from '@/components/homepage/SectionHeader';
 import {
   useArchivedExhibitions,
@@ -47,9 +48,12 @@ function ExhibitionCard({
       }}
     >
       <div className="w-full aspect-3/4 rounded-xl shrink-0 overflow-hidden bg-box200 relative">
-        {item.posterImageUrl ? (
-          <img src={item.posterImageUrl} alt={item.title} className="w-full h-full object-cover" />
-        ) : null}
+        <OptimizedImage
+          src={item.posterImageUrl}
+          displayWidth={120}
+          alt={item.title}
+          className="w-full h-full object-cover"
+        />
         <button
           type="button"
           aria-label={isSaved ? '북마크 취소' : '북마크'}

--- a/src/components/lounge-board/LoungeBoardPostCard.tsx
+++ b/src/components/lounge-board/LoungeBoardPostCard.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { LOUNGE_CATEGORY_TAGS } from '@/constants/loungeCategories';
 import type { LoungeBoardPost } from '@/types/exhibition';
 
@@ -46,7 +47,12 @@ export function LoungeBoardPostCard({ post, tagLabel }: Props) {
                   key={`${src}-${index}`}
                   className="w-27 h-32.5 shrink-0 rounded-sm overflow-hidden"
                 >
-                  <img alt="" className="w-full h-full object-cover" src={src} />
+                  <OptimizedImage
+                    alt=""
+                    className="w-full h-full object-cover"
+                    src={src}
+                    displayWidth={108}
+                  />
                 </div>
               ))}
             </div>

--- a/src/components/lounge-board/LoungeBoardPostDetail.tsx
+++ b/src/components/lounge-board/LoungeBoardPostDetail.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import type { LoungePostDetailDto } from '@/api/dto/lounge.dto';
 import { ImageModal } from '@/components/common/ImageModal';
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { FALLBACK_PROFILE_IMAGE } from '@/constants';
 import { useLoungePostPolicy } from '@/hooks/usePolicy';
 import { formatFullDate } from '@/utils/date';
@@ -27,10 +28,11 @@ export function LoungeBoardPostDetail({ post, onEdit, onDelete }: Props) {
     <div className="w-full flex flex-col gap-4">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <img
+          <OptimizedImage
             alt=""
             className="size-10 rounded-full shrink-0 object-cover"
             src={post.writer.profileImageUrl || FALLBACK_PROFILE_IMAGE}
+            displayWidth={40}
             onError={(e) => {
               (e.currentTarget as HTMLImageElement).src = FALLBACK_PROFILE_IMAGE;
             }}
@@ -59,7 +61,12 @@ export function LoungeBoardPostDetail({ post, onEdit, onDelete }: Props) {
                 className="w-[112px] h-[136px] shrink-0 rounded-sm overflow-hidden cursor-pointer"
                 aria-label="이미지 크게 보기"
               >
-                <img alt="" className="w-full h-full object-cover" src={src} />
+                <OptimizedImage
+                  alt=""
+                  className="w-full h-full object-cover"
+                  src={src}
+                  displayWidth={112}
+                />
               </button>
             ))}
           </div>

--- a/src/components/mypage/ArtistCard.tsx
+++ b/src/components/mypage/ArtistCard.tsx
@@ -1,5 +1,6 @@
 import { Bookmark, ChevronRight } from 'lucide-react';
 
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { FALLBACK_PROFILE_IMAGE } from '@/constants';
 import type { ArtistItem } from '@/types/mypage';
 
@@ -31,9 +32,10 @@ export function ArtistCard({ item, onUnarchive, onOpen }: ArtistCardProps) {
         className={`flex items-center gap-3.5 px-3 py-3.5 ${onOpen ? 'cursor-pointer' : ''}`}
       >
         <div className="size-12 rounded-full bg-box200 overflow-hidden shrink-0">
-          <img
+          <OptimizedImage
             className="w-full h-full object-cover"
             src={item.thumbnail || FALLBACK_PROFILE_IMAGE}
+            displayWidth={48}
             alt={item.name}
             onError={(event) => {
               event.currentTarget.src = FALLBACK_PROFILE_IMAGE;

--- a/src/components/mypage/ArtworkCard.tsx
+++ b/src/components/mypage/ArtworkCard.tsx
@@ -1,5 +1,6 @@
 import { Bookmark } from 'lucide-react';
 
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import type { SavedArtworkItem } from '@/types/mypage';
 
 import { MemoFooter } from './MemoFooter';
@@ -42,9 +43,10 @@ export function ArtworkCard({
         <div className="relative rounded-xl overflow-hidden">
           <div className="w-full h-44 bg-box200">
             {item.thumbnail && (
-              <img
+              <OptimizedImage
                 className="block w-full h-full object-cover"
                 src={item.thumbnail}
+                displayWidth={170}
                 alt={item.title}
               />
             )}

--- a/src/components/mypage/ExhibitionCard.tsx
+++ b/src/components/mypage/ExhibitionCard.tsx
@@ -1,5 +1,6 @@
 import { Bookmark } from 'lucide-react';
 
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import type { ExhibitionItem } from '@/types/mypage';
 import { cn } from '@/utils/cn';
 import { statusBadgeClass } from '@/utils/mypage';
@@ -48,9 +49,10 @@ export function ExhibitionCard({
       >
         <div className="w-24 h-32 rounded-xl overflow-hidden bg-box200 shadow-[2px_4px_18px_0px_rgba(67,0,209,0.04)] shrink-0">
           {item.thumbnail && (
-            <img
+            <OptimizedImage
               className="block w-full h-full object-cover"
               src={item.thumbnail}
+              displayWidth={96}
               alt={item.title}
             />
           )}

--- a/src/components/mypage/MyPageHeader.tsx
+++ b/src/components/mypage/MyPageHeader.tsx
@@ -2,6 +2,7 @@ import { ExternalLink, Menu, RefreshCcw } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import Share from '@/assets/mypage/share.svg';
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { FALLBACK_PROFILE_IMAGE } from '@/constants';
 import { useArtistPolicy, usePersonalArtworkPolicy } from '@/hooks/usePolicy';
 import type { UserProfile } from '@/hooks/useUserProfile';
@@ -59,59 +60,63 @@ export function MyPageHeader({
       {isArtistView ? (
         <div className="px-5 pt-5 pb-2.75 flex flex-col gap-3.5">
           <div className="flex items-center">
-            <img
+            <OptimizedImage
               className="size-22 rounded-full border-[2.67px] border-line object-cover shrink-0"
               src={profile.avatar || FALLBACK_PROFILE_IMAGE}
+              displayWidth={88}
               alt={profile.name}
               onError={(event) => {
                 event.currentTarget.src = FALLBACK_PROFILE_IMAGE;
               }}
             />
-          <div>
-            <span className="w-fit inline-flex items-center ml-2.5 px-1.5 py-0.5 bg-[#DBEAFE] rounded-full">
-              <span className="text-line-active typo-body-xxs-regular uppercase">
-                작가 프로필
+            <div>
+              <span className="w-fit inline-flex items-center ml-2.5 px-1.5 py-0.5 bg-[#DBEAFE] rounded-full">
+                <span className="text-line-active typo-body-xxs-regular uppercase">
+                  작가 프로필
+                </span>
               </span>
-             </span>
 
-            <div className="flex-1 min-w-0 px-4 flex flex-col gap-1.5">
+              <div className="flex-1 min-w-0 px-4 flex flex-col gap-1.5">
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-0.5">
+                    <div className="flex-1 w-42 flex flex-col">
+                      <div className="typo-body-xl-bold text-main truncate">{profile.name}</div>
+                      <div className="typo-body-xs-regular text-hint truncate">
+                        {profile.school}
+                      </div>
+                    </div>
 
-              <div className="flex flex-col gap-1">
-                <div className="flex items-center gap-0.5">
-                  <div className="flex-1 w-42 flex flex-col">
-                    <div className="typo-body-xl-bold text-main truncate">{profile.name}</div>
-                    <div className="typo-body-xs-regular text-hint truncate">{profile.school}</div>
+                    <div className="flex items-center shrink-0">
+                      <div className="w-11.5 flex flex-col items-center">
+                        <span className="typo-body-xl-bold text-main">
+                          {profile.exhibitionCount}
+                        </span>
+                        <span className="typo-body-xs-regular text-faint">전시</span>
+                      </div>
+                      <div className="w-px h-7 bg-line" />
+                      <div className="w-11 flex flex-col items-center">
+                        <span className="typo-body-xl-bold text-main">{profile.artworkCount}</span>
+                        <span className="typo-body-xs-regular text-faint">작품</span>
+                      </div>
+                    </div>
                   </div>
 
-                  <div className="flex items-center shrink-0">
-                    <div className="w-11.5 flex flex-col items-center">
-                      <span className="typo-body-xl-bold text-main">{profile.exhibitionCount}</span>
-                      <span className="typo-body-xs-regular text-faint">전시</span>
+                  {profile.fields && profile.fields.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-1">
+                      {profile.fields.map((field) => (
+                        <span
+                          key={field}
+                          className="px-1.5 rounded-sm border border-line typo-body-xxs-regular text-hint"
+                        >
+                          {field}
+                        </span>
+                      ))}
                     </div>
-                    <div className="w-px h-7 bg-line" />
-                    <div className="w-11 flex flex-col items-center">
-                      <span className="typo-body-xl-bold text-main">{profile.artworkCount}</span>
-                      <span className="typo-body-xs-regular text-faint">작품</span>
-                    </div>
-                  </div>
+                  )}
                 </div>
-
-                {profile.fields && profile.fields.length > 0 && (
-                  <div className="flex flex-wrap items-center gap-1">
-                    {profile.fields.map((field) => (
-                      <span
-                        key={field}
-                        className="px-1.5 rounded-sm border border-line typo-body-xxs-regular text-hint"
-                      >
-                        {field}
-                      </span>
-                    ))}
-                  </div>
-                )}
               </div>
             </div>
           </div>
-        </div>
 
           {(profile.bio || profile.portfolioUrl) && (
             <div className="flex flex-col gap-2">
@@ -167,9 +172,10 @@ export function MyPageHeader({
       ) : (
         <div className="px-5 py-4 flex flex-col gap-3.5">
           <div className="flex items-center gap-3">
-            <img
+            <OptimizedImage
               className="size-22 rounded-full object-cover shrink-0"
               src={profile.avatar || FALLBACK_PROFILE_IMAGE}
+              displayWidth={88}
               alt={profile.name}
               onError={(event) => {
                 event.currentTarget.src = FALLBACK_PROFILE_IMAGE;

--- a/src/components/search/list/ExhibitionCard.tsx
+++ b/src/components/search/list/ExhibitionCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { formatDate } from '@/utils/date';
 
 import type { Exhibition } from '../types';
@@ -18,10 +19,11 @@ export function ExhibitionCard({ exhibition }: ExhibitionCardProps) {
       className="flex flex-col overflow-hidden rounded-xl bg-neutral-50 no-underline"
     >
       <div className="flex flex-col items-start gap-2.5 px-2 py-3 shadow-[0px_4px_18px_0px_rgba(67,0,209,0.04)]">
-        <img
+        <OptimizedImage
           alt=""
           className="h-55 w-full rounded-xl bg-neutral-200 object-cover shadow-[2px_4px_18px_0px_rgba(67,0,209,0.04)]"
           src={exhibition.posterImageUrl}
+          displayWidth={200}
         />
 
         <div className="flex w-full flex-col gap-0.5">

--- a/src/components/search/map/ExhibitionMapCard.tsx
+++ b/src/components/search/map/ExhibitionMapCard.tsx
@@ -1,5 +1,6 @@
 import { Bookmark } from 'lucide-react';
 
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import {
   useArchivedExhibitions,
   useArchiveExhibition,
@@ -74,8 +75,9 @@ export function ExhibitionMapCard({
           <div className="flex flex-1 items-start gap-3 min-w-0 h-32">
             {/* 포스터 이미지 */}
             <div className="relative h-33 w-24 shrink-0 overflow-hidden rounded-xl bg-box200 shadow-[2px_4px_18px_0px_rgba(67,0,209,0.04)]">
-              <img
+              <OptimizedImage
                 src={exhibition.posterImageUrl}
+                displayWidth={96}
                 alt={exhibition.title}
                 className="size-full object-cover"
               />

--- a/src/components/search/map/ExhibitionMapMarker.tsx
+++ b/src/components/search/map/ExhibitionMapMarker.tsx
@@ -1,6 +1,7 @@
 import { MapPin, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import type { NearbyDisplay } from '@/hooks/useNearbyDisplays';
 
 interface ExhibitionMapMarkerProps {
@@ -51,8 +52,9 @@ export function ExhibitionMapSelectedOverlay({
       {/* 1. 포스터 이미지 & 닫기 버튼 */}
       <div className="relative h-20 w-full bg-box200">
         {exhibition.posterImageUrl ? (
-          <img
+          <OptimizedImage
             src={exhibition.posterImageUrl}
+            displayWidth={152}
             alt={exhibition.title}
             className="size-full object-cover"
           />

--- a/src/pages/DisplayContentsPage.tsx
+++ b/src/pages/DisplayContentsPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import type { DisplayContentCategoryDto } from '@/api/dto/display.dto';
 import DUfontlogo from '@/assets/brand/DUfontlogo.svg';
 import { ErrorView, LoadingView } from '@/components/common';
+import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
 import { parseDisplayId } from '@/utils/parseDisplayId';
 
@@ -69,8 +70,9 @@ export function DisplayContentsPage() {
           <div className="mt-[17px] flex flex-col w-full gap-0 px-5">
             {selectedCategory.contents.map((item) => (
               <div key={item.contentId} className="w-full bg-box overflow-hidden">
-                <img
+                <OptimizedImage
                   src={item.imageUrl}
+                  displayWidth={360}
                   alt={selectedCategory.name}
                   className="w-full h-auto object-cover block"
                 />
@@ -125,8 +127,9 @@ export function DisplayContentsPage() {
                 {/* 좌측 카테고리 썸네일 카드 */}
                 <div className="w-[282px] h-[152px] relative rounded-xl overflow-hidden bg-box shadow-xs shrink-0">
                   {firstImg ? (
-                    <img
+                    <OptimizedImage
                       src={firstImg}
+                      displayWidth={282}
                       alt={category.name}
                       className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
                     />

--- a/src/utils/imageOptimization.ts
+++ b/src/utils/imageOptimization.ts
@@ -1,0 +1,77 @@
+export type ImageOptimizationFormat = 'webp' | 'original';
+
+type OptimizeImageUrlOptions = {
+  format?: ImageOptimizationFormat;
+  quality?: number;
+  maxScale?: number;
+};
+
+const VERCEL_IMAGE_ENDPOINT = '/_vercel/image';
+const DEFAULT_QUALITY = 75;
+const DEFAULT_MAX_SCALE = 2.6;
+const MAX_REQUEST_WIDTH = 3840;
+const OPTIMIZABLE_HOST_KEYWORDS = ['cloudfront.net', 'amazonaws.com'];
+const NON_OPTIMIZABLE_EXTENSIONS = /\.(svg|gif)(?:[?#].*)?$/i;
+
+const canUseVercelImageOptimization = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const { hostname } = window.location;
+
+  return hostname.endsWith('.vercel.app') || hostname === 'displayu.co.kr';
+};
+
+const getRequestWidth = (displayWidth: number, maxScale = DEFAULT_MAX_SCALE) => {
+  if (!Number.isFinite(displayWidth) || displayWidth <= 0) {
+    return undefined;
+  }
+
+  return Math.min(Math.ceil(displayWidth * maxScale), MAX_REQUEST_WIDTH);
+};
+
+const isHttpUrl = (url: string) => /^https?:\/\//i.test(url);
+
+export const isOptimizableImageUrl = (url?: string | null) => {
+  if (!url || !isHttpUrl(url) || NON_OPTIMIZABLE_EXTENSIONS.test(url)) {
+    return false;
+  }
+
+  try {
+    const { hostname } = new URL(url);
+
+    return OPTIMIZABLE_HOST_KEYWORDS.some((keyword) => hostname.includes(keyword));
+  } catch {
+    return false;
+  }
+};
+
+export const optimizeImageUrl = (
+  originalUrl: string,
+  displayWidth: number,
+  format: ImageOptimizationFormat = 'webp',
+  options: OptimizeImageUrlOptions = {},
+) => {
+  if (
+    format === 'original' ||
+    !canUseVercelImageOptimization() ||
+    !isOptimizableImageUrl(originalUrl)
+  ) {
+    return originalUrl;
+  }
+
+  const requestWidth = getRequestWidth(displayWidth, options.maxScale);
+
+  if (!requestWidth) {
+    return originalUrl;
+  }
+
+  const params = new URLSearchParams({
+    url: originalUrl,
+    w: String(requestWidth),
+    q: String(options.quality ?? DEFAULT_QUALITY),
+  });
+
+  return `${VERCEL_IMAGE_ENDPOINT}?${params.toString()}`;
+};


### PR DESCRIPTION
## 📝 작업 내용

- S3/CloudFront 원본 이미지 URL을 Vercel Image Optimization URL로 변환하는 공용 유틸을 추가했습니다.
- 공용 `OptimizedImage` 컴포넌트를 추가해 일반 렌더링 이미지는 표시 영역 기준 width와 webp 우선 정책을 적용했습니다.
- 홈, 검색/지도, 전시/작품 상세, 라운지, 마이페이지, 관리 화면의 주요 썸네일/콘텐츠 이미지를 최적화 컴포넌트로 교체했습니다.
- SVG/GIF, 로컬 에셋, 업로드 미리보기, 확대보기 원본 이미지는 기존 동작을 유지하도록 했습니다.

## 🔍 관련 이슈

- close #265

## 🖼️ 스크린샷

파일이 너무 커서 영상 첨부 불가능

### 변경 전

### 변경 후

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

```bash
pnpm build
pnpm lint
```

## 💬 기타 참고 사항

- Vite + React 구조라 Next.js `Image` 컴포넌트 대신 Vercel 이미지 최적화 프록시 URL을 직접 생성하는 방식으로 적용했습니다.
- CloudFront/S3 계열 URL만 최적화 대상으로 보고, 그 외 URL은 원본을 그대로 반환합니다.
- Vercel 배포 환경에서 CloudFront 도메인의 이미지 최적화 허용 설정이 필요할 수 있습니다.
