### PR TITLE
fix: 이미지 최적화 도메인 조건 보정

### DIFF
--- a/src/utils/imageOptimization.ts
+++ b/src/utils/imageOptimization.ts
@@ -12,6 +12,7 @@ const DEFAULT_MAX_SCALE = 2.6;
 const MAX_REQUEST_WIDTH = 3840;
 const OPTIMIZABLE_HOST_KEYWORDS = ['cloudfront.net', 'amazonaws.com'];
 const NON_OPTIMIZABLE_EXTENSIONS = /\.(svg|gif)(?:[?#].*)?$/i;
+const VERCEL_OPTIMIZATION_HOSTS = ['displayu.co.kr'];
 
 const canUseVercelImageOptimization = () => {
   if (typeof window === 'undefined') {
@@ -20,7 +21,10 @@ const canUseVercelImageOptimization = () => {
 
   const { hostname } = window.location;
 
-  return hostname.endsWith('.vercel.app') || hostname === 'displayu.co.kr';
+  return (
+    hostname.endsWith('.vercel.app') ||
+    VERCEL_OPTIMIZATION_HOSTS.some((host) => hostname === host || hostname.endsWith(`.${host}`))
+  );
 };
 
 const getRequestWidth = (displayWidth: number, maxScale = DEFAULT_MAX_SCALE) => {


### PR DESCRIPTION
## 📝 작업 내용

- Vercel Image Optimization 적용 도메인 조건에 `www.displayu.co.kr` 같은 하위 도메인도 포함되도록 보정했습니다.
- 기존에는 `displayu.co.kr` 정확히 일치하는 경우만 허용되어 운영 `www` 도메인에서 `/_vercel/image` 요청이 발생하지 않았습니다.

## 🔍 관련 이슈

- #265

## 🖼️ 스크린샷

- 별도 스크린샷 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

```bash
pnpm lint
pnpm build
```

## 💬 기타 참고 사항

- `localhost`는 계속 Vercel 이미지 최적화를 우회합니다.
- `*.vercel.app`, `displayu.co.kr`, `*.displayu.co.kr`에서 최적화 URL 변환이 허용됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 이미지 최적화 기능이 `displayu.co.kr` 및 하위 도메인에서도 정상적으로 적용되도록 지원 범위를 확대했습니다.
  * 허용된 호스트 목록을 기반으로 이미지 최적화 사용 여부를 보다 유연하게 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->