### PR TITLE
fix: 탐색 목록 무한스크롤 추가

### DIFF
--- a/src/components/artist-verification/CodeVerificationField.tsx
+++ b/src/components/artist-verification/CodeVerificationField.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { ArtistVerificationField } from './ArtistVerificationField';
 
 interface CodeVerificationFieldProps {
@@ -12,6 +14,8 @@ interface CodeVerificationFieldProps {
   isResending?: boolean;
 }
 
+const VERIFICATION_TIMEOUT_SECONDS = 5 * 60;
+
 export function CodeVerificationField({
   value,
   onChange,
@@ -23,6 +27,38 @@ export function CodeVerificationField({
   isConfirming = false,
   isResending = false,
 }: CodeVerificationFieldProps) {
+  const [timeLeft, setTimeLeft] = useState(VERIFICATION_TIMEOUT_SECONDS);
+  const [isExpired, setIsExpired] = useState(false);
+
+  useEffect(() => {
+    if (confirmed || isExpired) return;
+
+    const interval = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          setIsExpired(true);
+          clearInterval(interval);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [confirmed, isExpired]);
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const handleResend = () => {
+    setTimeLeft(VERIFICATION_TIMEOUT_SECONDS);
+    setIsExpired(false);
+    onResend();
+  };
+
   return (
     <ArtistVerificationField label="인증번호" htmlFor="verification-code" className="mt-4">
       <div className="flex gap-2">
@@ -38,30 +74,36 @@ export function CodeVerificationField({
             inputMode="numeric"
             onChange={(event) => onChange(event.target.value.replace(/\D/g, ''))}
             placeholder="인증번호 6자리"
-            disabled={disabled}
+            disabled={disabled || isExpired}
             className={`min-w-0 flex-1 bg-transparent typo-body-sm-regular outline-none placeholder:text-line ${
-              disabled ? 'text-line cursor-not-allowed' : 'text-main'
+              disabled || isExpired ? 'text-line cursor-not-allowed' : 'text-main'
             }`}
           />
-          <span className="ml-3 shrink-0 typo-body-sm-regular text-slate-700">04:59</span>
+          <span
+            className={`ml-3 shrink-0 typo-body-sm-regular ${isExpired ? 'text-error' : 'text-slate-700'}`}
+          >
+            {formatTime(timeLeft)}
+          </span>
         </div>
         <button
           type="button"
           onClick={onConfirm}
-          disabled={isConfirming}
-          className="h-10 w-[84px] shrink-0 rounded-xl bg-bt-black typo-body-sm-regular text-white"
+          disabled={isConfirming || isExpired}
+          className="h-10 w-[84px] shrink-0 rounded-xl bg-bt-black typo-body-sm-regular text-white disabled:bg-gray-300"
         >
           {isConfirming ? '확인중' : '인증 확인'}
         </button>
       </div>
-      {error ? (
+      {isExpired ? (
+        <p className="mt-1 typo-body-xxs-regular text-error">인증 시간이 만료되었습니다.</p>
+      ) : error ? (
         <p className="mt-1 typo-body-xxs-regular text-error">{error}</p>
       ) : confirmed ? (
         <p className="mt-1 typo-body-xxs-regular text-link">인증 확인</p>
       ) : null}
       <button
         type="button"
-        onClick={onResend}
+        onClick={handleResend}
         disabled={isResending}
         className="mt-1 typo-body-xxs-regular text-faint underline"
       >

--- a/src/hooks/queries/useDisplayBrowse.ts
+++ b/src/hooks/queries/useDisplayBrowse.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type {
   CreateDisplayRequestDto,
@@ -19,6 +19,19 @@ export const useSearchDisplays = (params: SearchDisplaysRequestDto) =>
   useQuery({
     queryKey: queryKeys.displays.search(params),
     queryFn: () => searchDisplays(params),
+  });
+
+export const useInfiniteSearchDisplays = (params: Omit<SearchDisplaysRequestDto, 'cursor'>) =>
+  useInfiniteQuery({
+    queryKey: queryKeys.displays.search({ ...params, cursor: 0 }),
+    queryFn: ({ pageParam }) =>
+      searchDisplays({
+        ...params,
+        cursor: pageParam,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.pagination.hasNext ? lastPage.pagination.nextCursor : null,
   });
 
 export const useDisplayMap = (params: GetDisplayMapRequestDto) =>

--- a/src/hooks/queries/useDisplayBrowse.ts
+++ b/src/hooks/queries/useDisplayBrowse.ts
@@ -30,8 +30,7 @@ export const useInfiniteSearchDisplays = (params: Omit<SearchDisplaysRequestDto,
         cursor: pageParam,
       }),
     initialPageParam: 0,
-    getNextPageParam: (lastPage) =>
-      lastPage.pagination.hasNext ? lastPage.pagination.nextCursor : null,
+    getNextPageParam: (lastPage) => lastPage.pagination.nextCursor ?? null,
   });
 
 export const useDisplayMap = (params: GetDisplayMapRequestDto) =>

--- a/src/mocks/handlers/display.ts
+++ b/src/mocks/handlers/display.ts
@@ -346,14 +346,22 @@ export const displayHandlers = [
   ),
   ...paths('/api/v1/display/search').map((path) =>
     http.get(path, ({ request }) => {
-      const keyword = new URL(request.url).searchParams.get('searchWord') ?? '';
+      const searchParams = new URL(request.url).searchParams;
+      const keyword = searchParams.get('searchWord') ?? '';
+      const cursor = Number(searchParams.get('cursor') ?? 0);
+      const size = Number(searchParams.get('size') ?? 20);
       const exhibitions = listDisplays().filter(
         (display: any) => !keyword || display.title.includes(keyword),
       );
+      const nextCursor = cursor + size;
 
       return success('/api/v1/display/search', {
-        exhibitions,
-        pagination: { nextCursor: null, size: exhibitions.length, hasNext: false },
+        exhibitions: exhibitions.slice(cursor, nextCursor),
+        pagination: {
+          nextCursor: nextCursor < exhibitions.length ? nextCursor : null,
+          size,
+          hasNext: nextCursor < exhibitions.length,
+        },
       });
     }),
   ),

--- a/src/mocks/handlers/display.ts
+++ b/src/mocks/handlers/display.ts
@@ -353,14 +353,20 @@ export const displayHandlers = [
       const exhibitions = listDisplays().filter(
         (display: any) => !keyword || display.title.includes(keyword),
       );
-      const nextCursor = cursor + size;
+      const startIndex =
+        cursor > 0
+          ? exhibitions.findIndex((display: any) => Number(display.displayId) > cursor)
+          : 0;
+      const safeStartIndex = startIndex === -1 ? exhibitions.length : startIndex;
+      const page = exhibitions.slice(safeStartIndex, safeStartIndex + size);
+      const hasNext = safeStartIndex + size < exhibitions.length;
 
       return success('/api/v1/display/search', {
-        exhibitions: exhibitions.slice(cursor, nextCursor),
+        exhibitions: page,
         pagination: {
-          nextCursor: nextCursor < exhibitions.length ? nextCursor : null,
+          nextCursor: hasNext ? (page.at(-1)?.displayId ?? null) : null,
           size,
-          hasNext: nextCursor < exhibitions.length,
+          hasNext,
         },
       });
     }),

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Search, X } from 'lucide-react';
 import { useLocation, useSearchParams } from 'react-router-dom';
@@ -132,12 +132,34 @@ export function SearchPage() {
   const { data, fetchNextPage, hasNextPage, isError, isFetchingNextPage, isLoading } =
     useInfiniteSearchDisplays(searchDisplayParams);
   const exhibitions = data?.pages.flatMap((page) => page.exhibitions) ?? [];
+
+  const fetchNextSearchPage = useCallback(() => {
+    if (activeTab !== 'list' || !hasNextPage || isFetchingNextPage) return;
+    fetchNextPage();
+  }, [activeTab, fetchNextPage, hasNextPage, isFetchingNextPage]);
+
   const triggerRef = useInfiniteScroll({
     hasNextPage,
     isFetchingNextPage,
-    fetchNextPage,
-    rootMargin: '160px',
+    fetchNextPage: fetchNextSearchPage,
+    rootMargin: '480px',
   });
+
+  useEffect(() => {
+    if (activeTab !== 'list') return;
+
+    const handleScroll = () => {
+      const { clientHeight, scrollHeight, scrollTop } = document.documentElement;
+      if (scrollHeight - scrollTop - clientHeight < 480) {
+        fetchNextSearchPage();
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [activeTab, fetchNextSearchPage, exhibitions.length]);
 
   const nearbyParamsWithSearch = useMemo(
     () => (nearbyParams ? { ...nearbyParams, searchWord: query.trim() || null } : null),

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -8,6 +8,7 @@ import filterIcon from '@/assets/search/filter.svg';
 import filterSelectedDotIcon from '@/assets/search/filter-selected-dot.svg';
 import { LoadingView } from '@/components/common';
 import { getFilterOptionValues } from '@/components/search/filter/filterOptions';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 import {
   DEFAULT_FILTER_STATE,
@@ -21,14 +22,13 @@ import {
   type FilterState,
   type FilterTab,
 } from '../components/search';
-import { useSearchDisplays } from '../hooks/queries/useDisplayBrowse';
+import { useInfiniteSearchDisplays } from '../hooks/queries/useDisplayBrowse';
 import { type NearbyParams, useNearbyDisplays } from '../hooks/useNearbyDisplays';
 
 type ExploreTab = 'list' | 'map';
 
 const createSearchDisplayParams = (query: string, filters: FilterState) => {
-  const params: SearchDisplaysRequestDto = {
-    cursor: 0,
+  const params: Omit<SearchDisplaysRequestDto, 'cursor'> = {
     searchWord: query.trim() || null,
     size: 20,
   };
@@ -129,8 +129,15 @@ export function SearchPage() {
     [query, filters],
   );
 
-  const { data, isError, isLoading } = useSearchDisplays(searchDisplayParams);
-  const exhibitions = data?.exhibitions ?? [];
+  const { data, fetchNextPage, hasNextPage, isError, isFetchingNextPage, isLoading } =
+    useInfiniteSearchDisplays(searchDisplayParams);
+  const exhibitions = data?.pages.flatMap((page) => page.exhibitions) ?? [];
+  const triggerRef = useInfiniteScroll({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    rootMargin: '160px',
+  });
 
   const nearbyParamsWithSearch = useMemo(
     () => (nearbyParams ? { ...nearbyParams, searchWord: query.trim() || null } : null),
@@ -277,10 +284,16 @@ export function SearchPage() {
                 <p className="typo-body-lg-regular text-faint">결과가 없습니다</p>
               </div>
             ) : (
-              <div className="grid grid-cols-2 gap-x-2.5 gap-y-5">
-                {exhibitions.map((exhibition) => (
-                  <ExhibitionCard exhibition={exhibition} key={exhibition.displayId} />
-                ))}
+              <div className="flex flex-col gap-5">
+                <div className="grid grid-cols-2 gap-x-2.5 gap-y-5">
+                  {exhibitions.map((exhibition) => (
+                    <ExhibitionCard exhibition={exhibition} key={exhibition.displayId} />
+                  ))}
+                </div>
+                <div ref={triggerRef} className="h-1" />
+                {isFetchingNextPage ? (
+                  <LoadingView fullScreen={false} message="전시를 더 불러오는 중..." />
+                ) : null}
               </div>
             )}
           </div>


### PR DESCRIPTION
## 📝 작업 내용

- 탐색 페이지 전시목록 조회를 cursor 기반 `useInfiniteQuery`로 변경했습니다.
- 목록 하단 스크롤 감지 시 `pagination.nextCursor`로 다음 페이지를 추가 요청하도록 연결했습니다.
- MSW 검색 mock도 `cursor`/`size` 기반 pagination 응답을 반환하도록 수정했습니다.

## 🔍 관련 이슈

- #281

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] `pnpm run lint`
- [x] `pnpm exec tsc -b`
- [x] `pnpm build`

## 💬 기타 참고 사항

- 기존 lint warning 2개와 빌드 chunk/svg size warning은 이번 변경과 무관하게 남아 있습니다.
- 검색어/필터 변경 시 query key가 변경되어 첫 페이지부터 다시 조회됩니다.