### PR TITLE
fix: 탐색페이지 무한스크롤 및 작품 미리보기 오류 해결

### DIFF
--- a/src/api/dto/displayArtwork.dto.ts
+++ b/src/api/dto/displayArtwork.dto.ts
@@ -403,6 +403,7 @@ export type DeleteArtworkResponseDto = ApiResponseDto<DeleteArtworkResponseDataD
 
 export interface GetArtworkPreviewRequestDto extends Partial<OffsetPageRequestDto> {
   type?: string;
+  field?: string;
 }
 
 export interface ArtworkPreviewExhibitionInfoDto {

--- a/src/components/homepage/ArtworkPreviewMoreView.tsx
+++ b/src/components/homepage/ArtworkPreviewMoreView.tsx
@@ -17,15 +17,21 @@ type Props = {
 };
 
 export function ArtworkPreviewMoreView({ onClose }: Props) {
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
 
-  // 카테고리 칩 선택 값에 해당하는 API 파라미터 값 추출
-  const apiType = selectedCategory
-    ? CATEGORY_OPTIONS.find((opt) => opt.label === selectedCategory)?.value || undefined
-    : 'RECOMMEND';
+  // 카테고리 칩 선택 값들에 해당하는 API 파라미터 값 추출 (콤마로 구분된 문자열)
+  const selectedFieldValue =
+    selectedCategories.length > 0
+      ? selectedCategories
+          .map((label) => CATEGORY_OPTIONS.find((opt) => opt.label === label)?.value)
+          .filter((val): val is string => Boolean(val))
+          .join(',')
+      : undefined;
+
+  const queryParams = selectedFieldValue ? { field: selectedFieldValue } : { type: 'RECOMMEND' };
 
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isPending, isError } =
-    useInfiniteArtworkPreview({ type: apiType });
+    useInfiniteArtworkPreview(queryParams);
 
   const artworks = data?.pages.flatMap((page) => page.artworks) ?? [];
 
@@ -40,19 +46,21 @@ export function ArtworkPreviewMoreView({ onClose }: Props) {
     window.scrollTo(0, 0);
   }, []);
 
-  // 카테고리 단일 선택 토글 핸들러
+  // 카테고리 다중 선택 토글 핸들러
   const handleToggleCategory = (label: string) => {
-    setSelectedCategory((prev) => (prev === label ? null : label));
+    setSelectedCategories((prev) =>
+      prev.includes(label) ? prev.filter((item) => item !== label) : [...prev, label],
+    );
   };
 
-  // 개별 카테고리 삭제
-  const handleRemoveCategory = () => {
-    setSelectedCategory(null);
+  // 개별 카테고리 태그 삭제
+  const handleRemoveCategory = (label: string) => {
+    setSelectedCategories((prev) => prev.filter((item) => item !== label));
   };
 
   // 전체 선택 해제 (초기화)
   const handleResetCategories = () => {
-    setSelectedCategory(null);
+    setSelectedCategories([]);
   };
 
   return (
@@ -80,7 +88,7 @@ export function ArtworkPreviewMoreView({ onClose }: Props) {
         {/* 칩 스크롤 영역 */}
         <div className="flex gap-1.5 overflow-x-auto scrollbar-none select-none">
           {CATEGORY_OPTIONS.map((opt) => {
-            const isSelected = selectedCategory === opt.label;
+            const isSelected = selectedCategories.includes(opt.label);
             return (
               <button
                 key={opt.label}
@@ -107,19 +115,22 @@ export function ArtworkPreviewMoreView({ onClose }: Props) {
         </div>
 
         {/* 선택된 필터 태그 & 초기화 버튼 */}
-        {selectedCategory && (
+        {selectedCategories.length > 0 && (
           <div className="w-full flex justify-between items-center select-none">
             <div className="flex items-center gap-2.5 flex-wrap">
-              <button
-                type="button"
-                onClick={handleRemoveCategory}
-                className="flex items-center gap-1 cursor-pointer group"
-              >
-                <span className="typo-body-xs-regular text-sub700 group-hover:text-main">
-                  {selectedCategory}
-                </span>
-                <X className="size-3 text-sub700 group-hover:text-main" />
-              </button>
+              {selectedCategories.map((label) => (
+                <button
+                  key={label}
+                  type="button"
+                  onClick={() => handleRemoveCategory(label)}
+                  className="flex items-center gap-1 cursor-pointer group"
+                >
+                  <span className="typo-body-xs-regular text-sub700 group-hover:text-main">
+                    {label}
+                  </span>
+                  <X className="size-3 text-sub700 group-hover:text-main" />
+                </button>
+              ))}
             </div>
 
             <button

--- a/src/hooks/queries/useDisplayBrowse.ts
+++ b/src/hooks/queries/useDisplayBrowse.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type {
   CreateDisplayRequestDto,
@@ -19,6 +19,22 @@ export const useSearchDisplays = (params: SearchDisplaysRequestDto) =>
   useQuery({
     queryKey: queryKeys.displays.search(params),
     queryFn: () => searchDisplays(params),
+  });
+
+export const useInfiniteSearchDisplays = (params: Omit<SearchDisplaysRequestDto, 'cursor'>) =>
+  useInfiniteQuery({
+    queryKey: queryKeys.displays.search(params as SearchDisplaysRequestDto),
+    queryFn: ({ pageParam = 0 }) =>
+      searchDisplays({
+        ...params,
+        cursor: pageParam,
+        size: params.size ?? 20,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.pagination?.hasNext && lastPage.pagination?.nextCursor !== null
+        ? lastPage.pagination.nextCursor
+        : undefined,
   });
 
 export const useDisplayMap = (params: GetDisplayMapRequestDto) =>

--- a/src/mocks/handlers/artwork.ts
+++ b/src/mocks/handlers/artwork.ts
@@ -137,14 +137,24 @@ export const artworkHandlers = [
       const url = new URL(request.url);
       const page = Number(url.searchParams.get('page') ?? 0);
       const size = Number(url.searchParams.get('size') ?? mockDb.artworks.length);
+      const fieldParam = url.searchParams.get('field');
+      const fields = fieldParam ? fieldParam.split(',').filter(Boolean) : [];
+
+      const filteredArtworks =
+        fields.length > 0
+          ? mockDb.artworks.filter(
+              (artwork: any) => fields.includes(artwork.type) || fields.includes(artwork.field),
+            )
+          : mockDb.artworks;
+
       const start = page * size;
-      const artworks = mockDb.artworks.slice(start, start + size);
+      const artworks = filteredArtworks.slice(start, start + size);
 
       return success('/api/v1/artworks/preview', {
         artworks,
         page,
         size: artworks.length,
-        isLast: start + size >= mockDb.artworks.length,
+        isLast: start + size >= filteredArtworks.length,
       });
     }),
   ),

--- a/src/mocks/handlers/display.ts
+++ b/src/mocks/handlers/display.ts
@@ -346,14 +346,20 @@ export const displayHandlers = [
   ),
   ...paths('/api/v1/display/search').map((path) =>
     http.get(path, ({ request }) => {
-      const keyword = new URL(request.url).searchParams.get('searchWord') ?? '';
-      const exhibitions = listDisplays().filter(
+      const url = new URL(request.url);
+      const keyword = url.searchParams.get('searchWord') ?? '';
+      const cursor = Number(url.searchParams.get('cursor') ?? 0);
+      const size = Number(url.searchParams.get('size') ?? 20);
+
+      const allExhibitions = listDisplays().filter(
         (display: any) => !keyword || display.title.includes(keyword),
       );
+      const exhibitions = allExhibitions.slice(cursor, cursor + size);
+      const nextCursor = cursor + size < allExhibitions.length ? cursor + size : null;
 
       return success('/api/v1/display/search', {
         exhibitions,
-        pagination: { nextCursor: null, size: exhibitions.length, hasNext: false },
+        pagination: { nextCursor, size: exhibitions.length, hasNext: nextCursor !== null },
       });
     }),
   ),

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -8,6 +8,7 @@ import filterIcon from '@/assets/search/filter.svg';
 import filterSelectedDotIcon from '@/assets/search/filter-selected-dot.svg';
 import { LoadingView } from '@/components/common';
 import { getFilterOptionValues } from '@/components/search/filter/filterOptions';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 import {
   DEFAULT_FILTER_STATE,
@@ -21,14 +22,13 @@ import {
   type FilterState,
   type FilterTab,
 } from '../components/search';
-import { useSearchDisplays } from '../hooks/queries/useDisplayBrowse';
+import { useInfiniteSearchDisplays } from '../hooks/queries/useDisplayBrowse';
 import { type NearbyParams, useNearbyDisplays } from '../hooks/useNearbyDisplays';
 
 type ExploreTab = 'list' | 'map';
 
 const createSearchDisplayParams = (query: string, filters: FilterState) => {
-  const params: SearchDisplaysRequestDto = {
-    cursor: 0,
+  const params: Omit<SearchDisplaysRequestDto, 'cursor'> = {
     searchWord: query.trim() || null,
     size: 20,
   };
@@ -129,8 +129,16 @@ export function SearchPage() {
     [query, filters],
   );
 
-  const { data, isError, isLoading } = useSearchDisplays(searchDisplayParams);
-  const exhibitions = data?.exhibitions ?? [];
+  const { data, isError, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useInfiniteSearchDisplays(searchDisplayParams);
+
+  const exhibitions = useMemo(() => data?.pages.flatMap((page) => page.exhibitions) ?? [], [data]);
+
+  const triggerRef = useInfiniteScroll({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   const nearbyParamsWithSearch = useMemo(
     () => (nearbyParams ? { ...nearbyParams, searchWord: query.trim() || null } : null),
@@ -277,11 +285,19 @@ export function SearchPage() {
                 <p className="typo-body-lg-regular text-faint">결과가 없습니다</p>
               </div>
             ) : (
-              <div className="grid grid-cols-2 gap-x-2.5 gap-y-5">
-                {exhibitions.map((exhibition) => (
-                  <ExhibitionCard exhibition={exhibition} key={exhibition.displayId} />
-                ))}
-              </div>
+              <>
+                <div className="grid grid-cols-2 gap-x-2.5 gap-y-5">
+                  {exhibitions.map((exhibition) => (
+                    <ExhibitionCard exhibition={exhibition} key={exhibition.displayId} />
+                  ))}
+                </div>
+                <div ref={triggerRef} className="h-4" />
+                {isFetchingNextPage ? (
+                  <div className="py-4 text-center typo-body-xs-regular text-hint">
+                    더 많은 전시를 불러오는 중...
+                  </div>
+                ) : null}
+              </>
             )}
           </div>
         </div>


### PR DESCRIPTION
## 📝 작업 내용

- 탐색페이지에 작품 20개만 불러오고 더 안불러와 지는 문제를 해결하였습니다.(무한스크롤적용)
- 작품 미리보기 페이지에서 필터 설정 관련 오류를 해결하였습니다.
- 탐색페이지 필터 선택 오류를 해결하였습니다.

## 🔍 관련 이슈

- close #279 

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)
