### PR TITLE
feat: 아티스트 검증 5분 타이머 구현

### DIFF
--- a/src/components/artist-verification/CodeVerificationField.tsx
+++ b/src/components/artist-verification/CodeVerificationField.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { ArtistVerificationField } from './ArtistVerificationField';
 
 interface CodeVerificationFieldProps {
@@ -12,6 +14,8 @@ interface CodeVerificationFieldProps {
   isResending?: boolean;
 }
 
+const VERIFICATION_TIMEOUT_SECONDS = 5 * 60;
+
 export function CodeVerificationField({
   value,
   onChange,
@@ -23,6 +27,38 @@ export function CodeVerificationField({
   isConfirming = false,
   isResending = false,
 }: CodeVerificationFieldProps) {
+  const [timeLeft, setTimeLeft] = useState(VERIFICATION_TIMEOUT_SECONDS);
+  const [isExpired, setIsExpired] = useState(false);
+
+  useEffect(() => {
+    if (confirmed || isExpired) return;
+
+    const interval = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          setIsExpired(true);
+          clearInterval(interval);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [confirmed, isExpired]);
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const handleResend = () => {
+    setTimeLeft(VERIFICATION_TIMEOUT_SECONDS);
+    setIsExpired(false);
+    onResend();
+  };
+
   return (
     <ArtistVerificationField label="인증번호" htmlFor="verification-code" className="mt-4">
       <div className="flex gap-2">
@@ -38,30 +74,36 @@ export function CodeVerificationField({
             inputMode="numeric"
             onChange={(event) => onChange(event.target.value.replace(/\D/g, ''))}
             placeholder="인증번호 6자리"
-            disabled={disabled}
+            disabled={disabled || isExpired}
             className={`min-w-0 flex-1 bg-transparent typo-body-sm-regular outline-none placeholder:text-line ${
-              disabled ? 'text-line cursor-not-allowed' : 'text-main'
+              disabled || isExpired ? 'text-line cursor-not-allowed' : 'text-main'
             }`}
           />
-          <span className="ml-3 shrink-0 typo-body-sm-regular text-slate-700">04:59</span>
+          <span
+            className={`ml-3 shrink-0 typo-body-sm-regular ${isExpired ? 'text-error' : 'text-slate-700'}`}
+          >
+            {formatTime(timeLeft)}
+          </span>
         </div>
         <button
           type="button"
           onClick={onConfirm}
-          disabled={isConfirming}
-          className="h-10 w-[84px] shrink-0 rounded-xl bg-bt-black typo-body-sm-regular text-white"
+          disabled={isConfirming || isExpired}
+          className="h-10 w-[84px] shrink-0 rounded-xl bg-bt-black typo-body-sm-regular text-white disabled:bg-gray-300"
         >
           {isConfirming ? '확인중' : '인증 확인'}
         </button>
       </div>
-      {error ? (
+      {isExpired ? (
+        <p className="mt-1 typo-body-xxs-regular text-error">인증 시간이 만료되었습니다.</p>
+      ) : error ? (
         <p className="mt-1 typo-body-xxs-regular text-error">{error}</p>
       ) : confirmed ? (
         <p className="mt-1 typo-body-xxs-regular text-link">인증 확인</p>
       ) : null}
       <button
         type="button"
-        onClick={onResend}
+        onClick={handleResend}
         disabled={isResending}
         className="mt-1 typo-body-xxs-regular text-faint underline"
       >


### PR DESCRIPTION
## Summary

아티스트 검증 플로우에서 5분 타이머를 구현했습니다. 인증번호 입력 시 5분 제한 시간을 표시하고, 시간이 만료되면 입력과 확인을 차단합니다.

### 주요 변경 사항

- ⏱️ 5분 타이머 카운트다운 구현
- 🔒 시간 만료 시 인증번호 입력 비활성화
- ⛔ 시간 만료 시 인증 확인 버튼 비활성화  
- 🔴 만료 시 에러 메시지 표시
- 🔄 재발송 시 타이머 자동 리셋

## Test plan

- [x] 인증번호 입력 후 타이머가 5분부터 카운트다운 되는지 확인
- [x] 5분 후 입력창이 비활성화되는지 확인
- [x] 5분 후 확인 버튼이 비활성화되는지 확인
- [x] 만료 메시지가 표시되는지 확인
- [x] 재발송 클릭 시 타이머가 5분으로 리셋되는지 확인

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 인증 코드 입력 화면에 5분 제한 타이머를 추가했습니다.
  * 남은 시간이 실시간 `MM:SS` 형식으로 표시됩니다.
  * 인증 코드가 만료되면 입력 및 확인 버튼이 비활성화되고 만료 안내가 표시됩니다.
  * 인증 코드 재발송 시 타이머가 자동으로 초기화됩니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->