### PR TITLE
fix: 작가 프로필 공유 경로 수정

### DIFF
--- a/src/components/artworkdetailpage/ArtworkIntroTab.tsx
+++ b/src/components/artworkdetailpage/ArtworkIntroTab.tsx
@@ -79,7 +79,7 @@ export function ArtworkArtistRow({ userId, displayName }: ArtworkArtistRowProps)
       <LoginConfirmModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
       <button
         type="button"
-        onClick={() => userId && profile && navigate(`/auth/${userId}`)}
+        onClick={() => userId && profile && navigate(`/artist/${userId}`)}
         disabled={!userId || !profile}
         className="flex min-w-0 items-center gap-2 text-left disabled:cursor-default"
       >

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -117,7 +117,7 @@ export function AuthPage() {
   };
 
   const handleShareProfile = async () => {
-    const url = `${window.location.origin}/auth/${userId}`;
+    const url = `${window.location.origin}/artist/${userId}`;
     await handleShare(url, `${profile.name} 작가님`);
   };
 
@@ -139,7 +139,7 @@ export function AuthPage() {
       <LoginConfirmModal
         isOpen={isLoginModalOpen}
         onClose={() => setIsLoginModalOpen(false)}
-        redirectPath={`/auth/${userId}`}
+        redirectPath={`/artist/${userId}`}
       />
 
       <AuthPageHeader


### PR DESCRIPTION
## 📝 작업 내용

- 작가 프로필 화면(`/artist/:userId`)의 공유 URL이 `/auth/:userId`로 생성되던 문제를 수정했습니다.
- 현재 라우터에 존재하는 작가 프로필 경로인 `/artist/:userId`를 사용하도록 변경했습니다.
- 같은 낡은 경로를 쓰던 작가 프로필 로그인 복귀 경로와 작품 상세 작가명 클릭 이동 경로도 함께 정리했습니다.

## 🔍 관련 이슈

- close #286

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] `pnpm run lint`
- [x] `pnpm exec tsc -b`
- [x] `pnpm build`

## 💬 기타 참고 사항

- 기존 lint warning과 빌드 chunk/svg size warning은 이번 변경과 무관하게 남아 있습니다.