### PR TITLE
fix: 전시 상태 라벨에서 '임시저장' 문구 제거

### DIFF
--- a/src/components/display-manage/ExhibitionMeta.tsx
+++ b/src/components/display-manage/ExhibitionMeta.tsx
@@ -28,12 +28,7 @@ export function ExhibitionMeta({
   const roleBase = ex.isLeader === true ? '대표자' : ex.isLeader === false ? '팀원' : null;
   const roleLabel = roleBase ? (artistName ? `${roleBase}(${artistName})` : roleBase) : null;
 
-  const statusLabel =
-    ex.publishStatus === 'PUBLISHED'
-      ? '등록완료'
-      : ex.publishStatus === 'DRAFT'
-        ? '임시저장'
-        : null;
+  const statusLabel = ex.publishStatus === 'PUBLISHED' ? '등록완료' : null;
   const isDraft = ex.publishStatus === 'DRAFT';
 
   return (


### PR DESCRIPTION
## 📝 작업 내용

- 전시 목록/상세의 상태 라벨에서 DRAFT 상태일 때 노출되던 "임시저장" 문구를 제거함

## 🔍 관련 이슈

- close #291

## 🖼️ 스크린샷

- 텍스트 라벨 제거로 별도 시각 변화 없음 (DRAFT 상태 시 라벨 미노출)

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- `isDraft` 값은 밑줄 스타일 조건으로 계속 사용됨