### PR TITLE
fix: 다른 작가 프로필 전시 카드 상세 이동

### DIFF
--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -164,7 +164,14 @@ export function AuthPage() {
           ) : (exhibitionsQuery.data ?? []).length > 0 ? (
             <div className="flex flex-col gap-4">
               {(exhibitionsQuery.data ?? []).map((item) => (
-                <ExhibitionCard key={item.id} item={item} isArtistView />
+                <ExhibitionCard
+                  key={item.id}
+                  item={item}
+                  isArtistView
+                  onOpen={(exhibition) =>
+                    navigate(`/display/${exhibition.displayId ?? exhibition.id}`)
+                  }
+                />
               ))}
             </div>
           ) : (


### PR DESCRIPTION
## 📝 작업 내용

- 다른 작가 프로필(`/artist/:userId`)의 전시 탭에서 전시 카드 선택 시 전시 상세 페이지(`/display/:id`)로 이동하도록 `onOpen`을 연결했습니다.
- 기존 `ExhibitionCard`의 클릭/키보드 접근 처리 흐름을 그대로 사용했습니다.

## 🔍 관련 이슈

- closes #294

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

`pnpm lint` 실행 완료: 에러 없음, 기존 경고 5개 확인

## 💬 기타 참고 사항

- 기존 작업 트리에 있던 `src/pages/ForbiddenPage.tsx` 변경은 이번 커밋/PR에 포함하지 않았습니다.