### PR TITLE
fix: 작품 공유 시 에러 해결

### DIFF
--- a/src/components/common/ShareBottomSheet.tsx
+++ b/src/components/common/ShareBottomSheet.tsx
@@ -40,7 +40,7 @@ type ShareBottomSheetProps = {
   imageUrl?: string;
 };
 
-const FALLBACK_SHARE_IMAGE = 'https://displayu.co.kr/favicon.svg';
+const FALLBACK_SHARE_IMAGE = `${window.location.origin}/icon.png`;
 const KAKAO_SDK_URL = 'https://t1.kakaocdn.net/kakao_js_sdk/2.7.4/kakao.min.js';
 
 let kakaoSdkPromise: Promise<void> | null = null;
@@ -61,6 +61,16 @@ function loadKakaoSdk() {
   });
 
   return kakaoSdkPromise;
+}
+
+function resolveShareImageUrl(imageUrl?: string) {
+  if (!imageUrl) return FALLBACK_SHARE_IMAGE;
+
+  try {
+    return new URL(imageUrl, window.location.origin).href;
+  } catch {
+    return FALLBACK_SHARE_IMAGE;
+  }
 }
 
 export function ShareBottomSheet({
@@ -106,6 +116,7 @@ export function ShareBottomSheet({
   if (!isOpen) return null;
 
   const shareUrl = url ?? window.location.href;
+  const shareImageUrl = resolveShareImageUrl(imageUrl);
 
   const handleKakaoShare = async () => {
     setErrorMessage(null);
@@ -125,7 +136,7 @@ export function ShareBottomSheet({
         content: {
           title,
           description,
-          imageUrl: imageUrl || FALLBACK_SHARE_IMAGE,
+          imageUrl: shareImageUrl,
           link: { mobileWebUrl: shareUrl, webUrl: shareUrl },
         },
         buttons: [


### PR DESCRIPTION
## 📝 작업 내용

- 공유 이미지 URL을 카카오 공유에 전달하기 전 절대 URL로 정규화했습니다.
- 작품 이미지가 없거나 잘못된 이미지 URL이 들어온 경우 `/icon.png` PNG fallback을 사용하도록 수정했습니다.
- 기존 SVG fallback 공유 이미지 사용으로 인한 카카오 공유 실패 가능성을 제거했습니다.

## 🔍 관련 이슈

- closes #296

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

`pnpm lint` 실행 완료: 에러 없음, 기존 경고 5개 확인
`pnpm build` 실행 완료: 성공, 기존 chunk size 경고 확인

## 💬 기타 참고 사항

- 기존 작업 트리에 있던 `src/pages/ForbiddenPage.tsx` 변경은 이번 커밋/PR에 포함하지 않았습니다.