### PR TITLE
fix: 자잘한 버그들 수정

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -165,11 +165,7 @@ export const router = createBrowserRouter([
           // 내 전시 관리 목록
           {
             path: 'my/exhibitions',
-            element: (
-              <ArtistPermissionGuard>
-                <MyExhibitionsPage />
-              </ArtistPermissionGuard>
-            ),
+            element: <MyExhibitionsPage />,
           },
 
           // 1. 전시 등록 플로우

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -21,12 +21,31 @@ export const createQueryString = (query?: QueryParams): string => {
 
   const searchParams = new URLSearchParams();
 
-  Object.entries(query as Record<string, QueryValue>).forEach(([key, value]) => {
+  Object.entries(query as Record<string, unknown>).forEach(([key, value]) => {
     if (value === undefined || value === null || value === '') {
       return;
     }
 
-    searchParams.set(key, String(value));
+    if (Array.isArray(value)) {
+      value.forEach((v) => {
+        if (v !== undefined && v !== null && v !== '') {
+          searchParams.append(key, String(v));
+        }
+      });
+    } else if (
+      typeof value === 'string' &&
+      value.includes(',') &&
+      ['field', 'status', 'region', 'type', 'fields'].includes(key)
+    ) {
+      value.split(',').forEach((v) => {
+        const trimmed = v.trim();
+        if (trimmed) {
+          searchParams.append(key, trimmed);
+        }
+      });
+    } else {
+      searchParams.set(key, String(value));
+    }
   });
 
   const queryString = searchParams.toString();

--- a/src/api/dto/display.dto.ts
+++ b/src/api/dto/display.dto.ts
@@ -392,6 +392,7 @@ export type GetMyDisplayReviewsResponseDto = ApiResponseDto<GetMyDisplayReviewsR
 export interface CreateDisplayRequestDto {
   title: string;
   posterImageUrl: string;
+  displayImageUrl?: string[];
   type: string;
   fields: string[];
   region: string;

--- a/src/components/artwork-register/RegisterArtworkPage.tsx
+++ b/src/components/artwork-register/RegisterArtworkPage.tsx
@@ -131,9 +131,16 @@ function RegisterArtworkPage({
           <RequiredLabel required>작품분야</RequiredLabel>
           <ChipGroup
             options={Object.keys(ARTWORK_FIELD_MAP)}
-            selected={field ? [field] : []}
-            onChange={(next) => onChangeField(next[0] ?? '')}
-            maxSelect={1}
+            selected={
+              field
+                ? field
+                    .split(',')
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                : []
+            }
+            onChange={(next) => onChangeField(next.join(', '))}
+            maxSelect={2}
             aria-label="작품분야"
             className="flex flex-wrap gap-2"
           />

--- a/src/mocks/handlers/display.ts
+++ b/src/mocks/handlers/display.ts
@@ -351,9 +351,47 @@ export const displayHandlers = [
       const cursor = Number(url.searchParams.get('cursor') ?? 0);
       const size = Number(url.searchParams.get('size') ?? 20);
 
-      const allExhibitions = listDisplays().filter(
-        (display: any) => !keyword || display.title.includes(keyword),
-      );
+      const getParams = (key: string) =>
+        url.searchParams
+          .getAll(key)
+          .flatMap((v) => v.split(','))
+          .map((v) => v.trim())
+          .filter(Boolean);
+
+      const fieldParams = getParams('field');
+      const statusParams = getParams('status');
+      const regionParams = getParams('region');
+      const typeParams = getParams('type');
+
+      const allExhibitions = listDisplays().filter((display: any) => {
+        const matchesKeyword =
+          !keyword ||
+          display.title?.includes(keyword) ||
+          display.schoolDepartmentName?.includes(keyword);
+
+        const matchesField =
+          fieldParams.length === 0 ||
+          fieldParams.some(
+            (f) =>
+              display.displayFields?.includes(f) ||
+              display.field === f ||
+              display.department?.includes(f),
+          );
+
+        const matchesStatus =
+          statusParams.length === 0 ||
+          statusParams.some((s) => display.status === s || display.exhibitionStatus === s);
+
+        const matchesRegion =
+          regionParams.length === 0 ||
+          regionParams.some((r) => display.region === r || display.locationRegion === r);
+
+        const matchesType =
+          typeParams.length === 0 ||
+          typeParams.some((t) => display.type === t || display.exhibitionType === t);
+
+        return matchesKeyword && matchesField && matchesStatus && matchesRegion && matchesType;
+      });
       const exhibitions = allExhibitions.slice(cursor, cursor + size);
       const nextCursor = cursor + size < allExhibitions.length ? cursor + size : null;
 

--- a/src/pages/ArtworkDetailPage.tsx
+++ b/src/pages/ArtworkDetailPage.tsx
@@ -239,11 +239,12 @@ export function ArtworkDetailPage() {
     isArchived: detail.isArchived ?? false,
   };
 
-  /* 썸네일로 지정된 이미지를 앞에 두고, 없으면 등록 순서대로 보여줍니다. */
-  const heroImages = (detail.images ?? [])
+  /* 히어로는 작품 이미지만 사용합니다(작업과정 이미지는 소개 탭에서 별도로 씁니다). 썸네일로 지정된 이미지를 앞에 두고, 없으면 등록 순서대로 보여줍니다. */
+  const artworkImages = (detail.images ?? []).filter((image) => image.imageType !== 'WORK_PROCESS');
+  const heroImages = artworkImages
     .map((image) => image.imageUrl)
     .filter((imageUrl): imageUrl is string => Boolean(imageUrl));
-  const thumbnailUrl = detail.images?.find((image) => image.isThumbnail)?.imageUrl;
+  const thumbnailUrl = artworkImages.find((image) => image.isThumbnail)?.imageUrl;
   const orderedHeroImages = thumbnailUrl
     ? [thumbnailUrl, ...heroImages.filter((imageUrl) => imageUrl !== thumbnailUrl)]
     : heroImages;

--- a/src/pages/artwork-register/ArtworkRegisterPage.tsx
+++ b/src/pages/artwork-register/ArtworkRegisterPage.tsx
@@ -719,7 +719,14 @@ function ArtworkRegisterPageContent() {
       return;
     }
 
-    const artworkType = ARTWORK_FIELD_MAP[field];
+    const selectedFieldLabels = field
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const artworkType = selectedFieldLabels
+      .map((label) => ARTWORK_FIELD_MAP[label])
+      .filter((val): val is string => Boolean(val))
+      .join(',');
 
     if (!artworkType) {
       setSubmitError('작품분야를 선택해주세요.');

--- a/src/pages/artwork-register/artworkRegister.schema.ts
+++ b/src/pages/artwork-register/artworkRegister.schema.ts
@@ -19,9 +19,20 @@ function isArtworkRegisterYearValid(value: string): boolean {
   return year >= 1000 && year < 9999;
 }
 
-const artworkFieldSchema = z.enum(Object.keys(ARTWORK_FIELD_MAP) as [string, ...string[]], {
-  message: '작품분야를 선택해주세요.',
-});
+const artworkFieldSchema = z.string().refine(
+  (val) => {
+    const selected = val
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return (
+      selected.length >= 1 &&
+      selected.length <= 2 &&
+      selected.every((item) => item in ARTWORK_FIELD_MAP)
+    );
+  },
+  { message: '작품분야를 선택해주세요.' },
+);
 
 export const artworkRegisterSchema = z.object({
   artworkImageCount: z.number().min(1, { message: '작품 이미지를 1개 이상 업로드해주세요.' }),

--- a/src/pages/exhibition-register/ArtistNameSetup.tsx
+++ b/src/pages/exhibition-register/ArtistNameSetup.tsx
@@ -215,6 +215,7 @@ export function ArtistNameSetup() {
 
     const type = registerState.type ? DISPLAY_TYPE_MAP[registerState.type] : undefined;
     const posterImageUrl = registerState.imageUrls?.[0];
+    const displayImageUrl = registerState.imageUrls?.slice(1).filter(Boolean) ?? [];
 
     if (
       !type ||
@@ -238,6 +239,7 @@ export function ArtistNameSetup() {
     const requestBody: CreateDisplayRequestDto = {
       title: registerState.title.trim(),
       posterImageUrl,
+      ...(displayImageUrl.length > 0 ? { displayImageUrl } : {}),
       type,
       fields: registerState.field?.map((field) => DISPLAY_FIELD_MAP[field]).filter(Boolean) ?? [],
       region: getRegion(registerState.address),

--- a/src/pages/personal-artworks-register/PersonalArtworksRegister.tsx
+++ b/src/pages/personal-artworks-register/PersonalArtworksRegister.tsx
@@ -142,11 +142,21 @@ export function PersonalArtworksRegister() {
       sortOrder: index + 1,
     });
 
+    const selectedFieldLabels = field
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const artworkType =
+      selectedFieldLabels
+        .map((label) => ARTWORK_FIELD_MAP[label])
+        .filter((val): val is string => Boolean(val))
+        .join(',') || ARTWORK_FIELD_MAP['기타'];
+
     createPersonalArtwork.mutate(
       {
         artworkName: title.trim(),
         content: intro.trim(),
-        type: ARTWORK_FIELD_MAP[field] ?? ARTWORK_FIELD_MAP['기타'],
+        type: artworkType,
         productionYear: toPersonalArtworkProductionYear(year),
         materialMedia: material.trim(),
         size: size.trim(),
@@ -232,9 +242,24 @@ export function PersonalArtworksRegister() {
             <RequiredLabel required>작품분야</RequiredLabel>
             <ChipGroup
               options={Object.keys(ARTWORK_FIELD_MAP)}
-              selected={[field]}
-              onChange={(next) => setField(next[0] ?? field)}
-              maxSelect={1}
+              selected={
+                field
+                  ? field
+                      .split(',')
+                      .map((s) => s.trim())
+                      .filter(Boolean)
+                  : []
+              }
+              onChange={(next) => {
+                const nextStr = next.join(', ');
+                setValue('field', nextStr, {
+                  shouldDirty: true,
+                  shouldTouch: true,
+                  shouldValidate: true,
+                });
+                setField(nextStr);
+              }}
+              maxSelect={2}
               aria-label="작품분야"
               className="flex flex-wrap gap-2"
             />

--- a/src/pages/personal-artworks-register/personalArtworksRegister.schema.ts
+++ b/src/pages/personal-artworks-register/personalArtworksRegister.schema.ts
@@ -21,9 +21,20 @@ export const personalArtworkRegisterSchema = z.object({
   artworkImageCount: z.number().min(1, { message: '작품 이미지를 1개 이상 업로드해주세요.' }),
   title: z.string().trim().min(1, { message: '작품명을 입력해주세요.' }),
   intro: z.string().trim().optional(),
-  field: z.enum(Object.keys(ARTWORK_FIELD_MAP) as [string, ...string[]], {
-    message: '작품분야를 선택해주세요.',
-  }),
+  field: z.string().refine(
+    (val) => {
+      const selected = val
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      return (
+        selected.length >= 1 &&
+        selected.length <= 2 &&
+        selected.every((item) => item in ARTWORK_FIELD_MAP)
+      );
+    },
+    { message: '작품분야를 선택해주세요.' },
+  ),
   year: z.string().refine(isPersonalArtworkYearValid, {
     message: '제작연도는 4자리 숫자로 입력해주세요.',
   }),


### PR DESCRIPTION
## 📝 작업 내용

- 전시/작품 상세 사진 관련 문제 해결
- 보호라우트 문제 해결
- 탐색필터 오류 해결

## 🔍 관련 이슈

- close #288

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 작품 분야를 최대 2개까지 선택하고 등록할 수 있습니다.
  - 전시 등록 시 포스터 외 추가 이미지를 함께 등록할 수 있습니다.
  - 전시 검색에서 분야, 상태, 지역, 유형별 다중 필터를 사용할 수 있습니다.
  - 인증된 사용자는 추가 권한 확인 없이 내 전시를 확인할 수 있습니다.

- **개선 사항**
  - 작품 상세 화면의 대표 이미지와 슬라이더에서 작업 과정 이미지를 제외합니다.
  - 작품 분야 입력값의 유효성 검사가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->