### PR TITLE
fix: 전시 작가명 수정 페이지 이동 오류 해결

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,6 +5,7 @@ import { AuthGuard } from './components/guards/AuthGuard';
 import {
   ArtistPermissionGuard,
   ArtworkPermissionGuard,
+  DisplayArtistNamePermissionGuard,
   DisplayContentPermissionGuard,
   DisplayCreatePermissionGuard,
   DisplayInvitationPermissionGuard,
@@ -266,6 +267,14 @@ export const router = createBrowserRouter([
                       <ExhibitionBasicInfo />
                     </GuardedFlowStep>
                   </DisplayPermissionGuard>
+                ),
+              },
+              {
+                path: 'edit/artist',
+                element: (
+                  <DisplayArtistNamePermissionGuard action="edit">
+                    <ArtistNameSetup />
+                  </DisplayArtistNamePermissionGuard>
                 ),
               },
               {

--- a/src/pages/MyExhibitionsPage.tsx
+++ b/src/pages/MyExhibitionsPage.tsx
@@ -65,10 +65,10 @@ export function MyExhibitionsPage() {
         onDelete={(ex) => setDisplayToDelete(ex)}
         onLeave={(ex) => setDisplayToLeave(ex)}
         onEditArtistName={(ex) =>
-          navigate(`/exhibition/register/artist`, {
+          navigate(`/exhibition/${ex.displayId ?? ex.id}/edit/artist`, {
             state: {
               ...ex,
-              displayId: Number(ex.id),
+              displayId: ex.displayId ?? Number(ex.id),
               artistName: ex.artistName,
               displayNickname: ex.artistName,
             },


### PR DESCRIPTION
## 📝 작업 내용

- 전시 수정 플로우 하위에 `edit/artist` 라우트를 추가했습니다.
- 내 전시 관리의 `전시 작가명 수정` 메뉴가 `/exhibition/:displayId/edit/artist`로 이동하도록 수정했습니다.
- 작가명 수정 전용 권한 가드(`DisplayArtistNamePermissionGuard`)를 적용했습니다.

## 🔍 관련 이슈

- closes #299

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

`pnpm lint` 실행 완료: 에러 없음, 기존 경고 5개 확인
`pnpm build` 실행 완료: 성공, 기존 chunk size 경고 확인

## 💬 기타 참고 사항

- 기존 작업 트리에 있던 `src/pages/ForbiddenPage.tsx` 변경은 이번 커밋/PR에 포함하지 않았습니다.