### PR TITLE
chore: 초대 수락시 경로 수정 및 화면 수정

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "worktree": {
+    "bgIsolation": "none"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 대학생의 전시 경험을 하나로 연결하는 플랫폼
 **DisplayU의 프론트엔드 웹입니다.**
 
-[서비스 바로가기](https://www.displayu.co.kr) · [Wiki](https://github.com/UMC-DISPLAYU/Frontend/wiki) · [Backend](https://github.com/UMC-DISPLAYU/Backend)
+[서비스 바로가기](https://www.displayu.co.kr) · [Backend](https://github.com/UMC-DISPLAYU/Backend)
 
 ## ✨ DisplayU
 

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,6 +5,7 @@ import { AuthGuard } from './components/guards/AuthGuard';
 import {
   ArtistPermissionGuard,
   ArtworkPermissionGuard,
+  DisplayArtistNamePermissionGuard,
   DisplayContentPermissionGuard,
   DisplayCreatePermissionGuard,
   DisplayInvitationPermissionGuard,
@@ -266,6 +267,14 @@ export const router = createBrowserRouter([
                       <ExhibitionBasicInfo />
                     </GuardedFlowStep>
                   </DisplayPermissionGuard>
+                ),
+              },
+              {
+                path: 'edit/artist',
+                element: (
+                  <DisplayArtistNamePermissionGuard action="edit">
+                    <ArtistNameSetup />
+                  </DisplayArtistNamePermissionGuard>
                 ),
               },
               {

--- a/src/components/team-manage/MemberRow.tsx
+++ b/src/components/team-manage/MemberRow.tsx
@@ -20,6 +20,8 @@ interface MemberRowProps {
 }
 
 export function MemberRow({ member, onInvite, inviteDisabled, inviteLabel }: MemberRowProps) {
+  const isOwner = member.status === 'owner';
+
   return (
     <li className="flex items-center gap-3 rounded-[20px] bg-card px-3 py-5">
       <div className="flex min-w-0 flex-1 items-center gap-3">
@@ -32,15 +34,24 @@ export function MemberRow({ member, onInvite, inviteDisabled, inviteLabel }: Mem
           }}
         />
         <div className="flex min-w-0 flex-col gap-2">
-          <span className="typo-body-sm-bold truncate text-main">{member.name}</span>
-          <span className="typo-body-xs-regular truncate text-hint">{member.nickname}</span>
+          {isOwner ? (
+            <div className="inline-flex min-w-0 items-end gap-2">
+              <span className="typo-body-sm-bold truncate text-main">{member.name}</span>
+              <span className="typo-body-xs-regular shrink-0 text-link">대표자</span>
+            </div>
+          ) : (
+            <span className="typo-body-sm-bold truncate text-main">{member.name}</span>
+          )}
+          {member.nickname && (
+            <span className="typo-body-xs-regular truncate text-hint">{member.nickname}</span>
+          )}
         </div>
       </div>
       {onInvite && inviteLabel ? (
         <InviteButton label={inviteLabel} onClick={onInvite} disabled={inviteDisabled} />
-      ) : (
+      ) : !isOwner ? (
         <StatusBadge status={member.status} />
-      )}
+      ) : null}
     </li>
   );
 }

--- a/src/components/team-manage/StatusBadge.tsx
+++ b/src/components/team-manage/StatusBadge.tsx
@@ -2,7 +2,7 @@ type MemberStatus = 'owner' | 'member' | 'pending' | 'unverified';
 
 const STATUS_LABEL: Record<MemberStatus, string> = {
   owner: '대표자',
-  member: '팀원',
+  member: '작가 인증',
   pending: '초대대기',
   unverified: '작가미인증',
 };
@@ -14,11 +14,13 @@ interface StatusBadgeProps {
 }
 
 export function StatusBadge({ status }: StatusBadgeProps) {
+  if (status === 'pending') return null;
+
   const accent = isAccent(status);
   return (
     <span
       className={`typo-body-xs-regular shrink-0 rounded-sm px-2.5 py-1 text-center ${
-        accent ? 'bg-tag-bg text-link' : 'bg-box200 text-main'
+        accent ? 'bg-[#DBEAFE] text-link' : 'bg-box200 text-main'
       }`}
     >
       {STATUS_LABEL[status]}

--- a/src/pages/DisplayAcceptPage.tsx
+++ b/src/pages/DisplayAcceptPage.tsx
@@ -1,5 +1,7 @@
+import { Check } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { BottomButton } from '@/components/common';
 import type { Invitation } from '@/types/invitation';
 
 type InfoRow = { label: string; value: string };
@@ -13,6 +15,15 @@ function buildExhibitionInfo(invitation?: Invitation): InfoRow[] {
   ];
 }
 
+function SummaryRow({ label, value }: InfoRow) {
+  return (
+    <div className="grid grid-cols-[auto_1fr] items-start gap-3">
+      <span className="typo-body-xs-regular w-10 shrink-0 text-faint">{label}</span>
+      <span className="typo-body-xs-regular min-w-0 truncate text-main">{value}</span>
+    </div>
+  );
+}
+
 const VERIFIED_CHECKLIST = ['전시 콘텐츠 추가', '전시작 등록', 'Q&A 담당자 지정 가능'];
 
 export function DisplayAcceptPage() {
@@ -23,110 +34,48 @@ export function DisplayAcceptPage() {
   const invitation = state?.invitation;
   const isVerified = state?.isVerified ?? false;
 
-  const exhibitionInfo = buildExhibitionInfo(invitation);
+  const [titleRow, departmentRow, periodRow, roleRow] = buildExhibitionInfo(invitation);
 
   const handleGoManage = () => {
-    if (invitation?.displayId) {
-      navigate(`/exhibition/${invitation.displayId}/manage`);
-    } else {
-      navigate('/my/exhibitions');
-    }
+    navigate('/my/exhibitions');
   };
 
   return (
     <div className="w-96 mx-auto h-dvh bg-page flex flex-col">
-      <div className="flex-1 min-h-0 overflow-y-auto px-5 pt-16">
-        <div className="flex flex-col items-center gap-1.5">
-          <div className="flex size-14 items-center justify-center rounded-full bg-[var(--palette-green-50)] text-[var(--palette-green-500)]">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true">
-              <circle cx="14" cy="14" r="11" stroke="currentColor" strokeWidth="2" />
-              <path
-                d="M9.3 14.4L12.4 17.4L18.7 10.8"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </div>
-          <div className="flex flex-col items-center gap-1">
-            <h1 className="typo-body-xl-bold text-center text-main">전시 참여가 완료되었어요</h1>
-            <p className="typo-body-xs-regular text-center text-faint">
-              이제 이 전시가 내 전시 관리에 추가돼요.
-            </p>
+      <div className="flex-1 min-h-0 overflow-y-auto px-5 pt-38.5">
+        <div className="items-center justify-center translate-y-30">
+          <div className="mx-auto w-49.5 flex flex-col items-center justify-center gap-1.5">
+            <div className="flex size-20 items-center justify-center rounded-full bg-box200">
+              <div className="flex size-12 items-center justify-center rounded-full bg-dark">
+                <Check className="size-6 text-white" strokeWidth={2.8} />
+              </div>
+            </div>
+            <div className="flex flex-col items-center gap-1">
+              <h1 className="typo-body-xl-bold text-center text-main">전시 참여가 완료되었어요</h1>
+              <p className="typo-body-xs-regular text-center text-faint">
+                이제 이 전시가 내 전시 관리에 추가돼요.
+              </p>
+            </div>
           </div>
         </div>
 
-        <section className="mt-10 flex flex-col gap-5">
-          <dl className="flex flex-col gap-1.5 rounded-2xl bg-card px-4 py-3.5">
-            {exhibitionInfo.map((row) => (
-              <div key={row.label} className="flex items-start gap-5">
-                <dt className="typo-body-xs-regular w-10 shrink-0 text-faint">{row.label}</dt>
-                <dd className="typo-body-xs-regular text-main">{row.value}</dd>
-              </div>
-            ))}
-          </dl>
-
-          {isVerified ? (
-            <ul className="flex flex-col gap-1">
-              {VERIFIED_CHECKLIST.map((label) => (
-                <li key={label} className="flex items-center gap-2 text-hint">
-                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-                    <circle cx="6" cy="6" r="5" stroke="currentColor" strokeWidth="1" />
-                    <path
-                      d="M3.9 6.1L5.4 7.6L8.1 4.7"
-                      stroke="currentColor"
-                      strokeWidth="1"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                  <span className="typo-body-xs-regular text-hint">{label}</span>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <div className="flex flex-col gap-3">
-              <p className="typo-body-xs-regular text-center text-sub600">
-                전시작 등록은 학교 이메일 인증 후 가능해요.
-              </p>
-              <div className="flex gap-2 rounded-xl bg-box100 px-4 py-4">
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  aria-hidden="true"
-                  className="mt-0.5 shrink-0 text-faint"
-                >
-                  <circle cx="8" cy="8" r="6.25" stroke="currentColor" strokeWidth="1.3" />
-                  <path
-                    d="M8 7.2V11"
-                    stroke="currentColor"
-                    strokeWidth="1.3"
-                    strokeLinecap="round"
-                  />
-                  <circle cx="8" cy="5" r="0.85" fill="currentColor" />
-                </svg>
-                <p className="typo-body-xs-regular text-hint">
-                  인증 전에도 전시 콘텐츠는 추가할 수 있어요. 작품을 등록하려면 학교 이메일 인증이
-                  필요해요.
-                </p>
-              </div>
-            </div>
-          )}
-        </section>
+       <section className="mt-35 pb-15 flex flex-col gap-5 translate-x-2">
+        <div className="flex items-start gap-1.5 rounded-2xl px-4 py-3.5">
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <SummaryRow {...titleRow} />
+            <SummaryRow {...departmentRow} />
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <SummaryRow {...periodRow} />
+            <SummaryRow {...roleRow} />
+          </div>
+        </div>
+      </section>
       </div>
 
-      <div className="flex flex-col gap-2 px-5 pb-8 pt-4">
-        <button
-          type="button"
-          onClick={handleGoManage}
-          className="typo-body-sm-semibold w-full rounded-xl border border-line-soft bg-card py-3.5 text-main"
-        >
-          내 전시 관리로 이동
-        </button>
-      </div>
+      <BottomButton type="button" onClick={handleGoManage}>
+        내 전시 관리로 이동
+      </BottomButton>
     </div>
   );
 }

--- a/src/pages/MyExhibitionsPage.tsx
+++ b/src/pages/MyExhibitionsPage.tsx
@@ -65,7 +65,7 @@ export function MyExhibitionsPage() {
         onDelete={(ex) => setDisplayToDelete(ex)}
         onLeave={(ex) => setDisplayToLeave(ex)}
         onEditArtistName={(ex) =>
-          navigate(`/exhibition/register/artist`, {
+          navigate(`/exhibition/${ex.id}/edit/artist`, {
             state: {
               ...ex,
               displayId: Number(ex.id),

--- a/src/pages/MyExhibitionsPage.tsx
+++ b/src/pages/MyExhibitionsPage.tsx
@@ -103,3 +103,4 @@ export function MyExhibitionsPage() {
     </div>
   );
 }
+

--- a/src/pages/TeamManagePage.tsx
+++ b/src/pages/TeamManagePage.tsx
@@ -61,22 +61,30 @@ export function TeamManage() {
   };
 
   /*
-   * 스웨거 TeamMemberResponse에는 이름/프로필 이미지/작가 인증 여부가 없어 displayNickname과 role만 사용합니다.
+   * 스웨거 TeamMemberResponse에는 이름/프로필 이미지가 없어 displayNickname과 role만 사용합니다.
    * 프로필 이미지가 없으므로 기본 프로필 아이콘이 표시됩니다.
    * 대표자 판정은 전시 상세의 ownerUserId와 대조합니다.
    */
   const ownerUserId = (display as { ownerUserId?: number } | undefined)?.ownerUserId;
-  const members: Member[] = (memberList?.members ?? []).map((member) => ({
-    id: String(member.teamMemberId),
-    name: member.displayNickname,
-    nickname: member.displayNickname,
-    status:
-      member.role === 'LEADER' || member.userId === ownerUserId
-        ? 'owner'
-        : member.accepted === false
-          ? 'pending'
-          : 'unverified',
-  }));
+  const members: Member[] = (memberList?.members ?? [])
+    .map((member) => {
+      const isPending = member.accepted === false;
+
+      return {
+        id: String(member.teamMemberId),
+        name: member.displayNickname,
+        nickname: isPending ? '아직 초대를 수락하지 않았어요' : member.displayNickname,
+        status:
+          member.role === 'LEADER' || member.userId === ownerUserId
+            ? 'owner'
+            : isPending
+              ? 'pending'
+              : member.artistVerified
+                ? 'member'
+                : 'unverified',
+      } satisfies Member;
+    })
+    .sort((a, b) => (a.status === 'owner' ? -1 : b.status === 'owner' ? 1 : 0));
 
   const [invitedUserIds, setInvitedUserIds] = useState<Set<number>>(new Set());
 
@@ -147,8 +155,8 @@ export function TeamManage() {
                     key={user.userId}
                     member={{
                       id: String(user.userId),
-                      name: user.name,
-                      nickname: user.nickname,
+                      name: user.nickname,
+                      nickname: '',
                       status: 'unverified',
                     }}
                     onInvite={() => handleInvite(user.userId)}


### PR DESCRIPTION
## 📝 작업 내용

- 초대 수락시 경로 수정 및 화면 수정

## 🔍 관련 이슈

- close #299 



## 🧪 테스트 결과

- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 전시 수정 과정에서 아티스트 이름을 별도 편집 화면에서 변경할 수 있습니다.
  * 팀 대표자에게 ‘대표자’ 라벨이 표시됩니다.
  * 팀원 상태에 따라 ‘작가 인증’ 및 대기 상태가 구분됩니다.

* **개선 사항**
  * 전시 승인 완료 화면과 전시 정보 요약 레이아웃을 개선했습니다.
  * 대표자는 팀 목록에서 우선 표시되며, 초대 대기 및 인증 상태 안내가 명확해졌습니다.
  * 전시 관리 이동 경로를 단순화했습니다.

* **문서**
  * README에서 Wiki 링크를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->