### PR TITLE
fix: 작품상세페이지, 전시상세페이지 수정 가능하도록 반영

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -72,12 +72,18 @@ axiosInstance.interceptors.response.use(
     const originalRequest = error.config as typeof error.config & { _retry?: boolean };
     const data = error.response?.data;
 
-    // 401 에러이고 refresh 요청이 아니며, 아직 재시도하지 않은 경우 토큰 갱신 시도
+    /*
+     * 401 에러이고 refresh 요청이 아니며, 아직 재시도하지 않은 경우 토큰 갱신 시도.
+     * 단, 애초에 accessToken이 없던 요청(로그인한 적 없는 게스트)은 세션 만료가 아니므로
+     * refresh나 로그인 페이지 강제 이동 없이 그냥 에러로 흘려보냅니다 — 그래야 공개 페이지가
+     * 비로그인 상태에서도 로그인 화면으로 튕기지 않고 정상적으로 보여집니다.
+     */
     if (
       error.response?.status === 401 &&
       originalRequest &&
       !originalRequest.url?.includes('/v1/auth/refresh') &&
-      !originalRequest._retry
+      !originalRequest._retry &&
+      useAuthStore.getState().accessToken
     ) {
       if (!isRefreshing) {
         isRefreshing = true;

--- a/src/api/dto/displayArtwork.dto.ts
+++ b/src/api/dto/displayArtwork.dto.ts
@@ -395,6 +395,21 @@ export interface ArtworkCoAuthorsDto {
   rawNames: string[];
 }
 
+export interface UpdateDisplayArtworkRequestDto {
+  artworkName: string;
+  content: string;
+  type: string;
+  productionYear: number;
+  materialMedia: string;
+  size: string;
+  point: string;
+  images: ImageRequestDto[];
+  artistName?: string;
+  artistUserId?: number;
+  coAuthors: ArtworkCoAuthorsDto;
+  qaHandlerUserIds: number[];
+}
+
 export interface DeleteArtworkResponseDataDto {
   deletedArtworkId: number;
   message: string;

--- a/src/api/endpoints/displayArtwork.ts
+++ b/src/api/endpoints/displayArtwork.ts
@@ -30,6 +30,7 @@ import type {
   UpdateArtworkFeelingResponseDataDto,
   UpdateArtworkOrderRequestDto,
   UpdateArtworkOrderResponseDataDto,
+  UpdateDisplayArtworkRequestDto,
 } from '@/api/dto';
 
 import { apiRequest } from '../client';
@@ -170,6 +171,12 @@ export const createExhibitionArtwork = async (
   body: CreateExhibitionArtworkRequestDto,
 ): Promise<CreateExhibitionArtworkResponseDataDto> =>
   apiRequest('/v1/artworks', { method: 'POST', body });
+
+// PATCH /v1/artworks/:artworkId
+export const updateDisplayArtwork = async (
+  artworkId: number,
+  body: UpdateDisplayArtworkRequestDto,
+): Promise<unknown> => apiRequest(`/v1/artworks/${artworkId}`, { method: 'PATCH', body });
 
 // DELETE /v1/artworks/:artworkId
 export const deleteArtwork = async (artworkId: number): Promise<DeleteArtworkResponseDataDto> =>

--- a/src/components/common/ShareBottomSheet.tsx
+++ b/src/components/common/ShareBottomSheet.tsx
@@ -124,7 +124,9 @@ export function ShareBottomSheet({
         objectType: 'feed',
         content: {
           title,
-          description,
+          /* description은 undefined로 키만 남아 있으면 카카오 SDK가 유효성 검사에서
+           * "Illegal argument"로 거부해, 값이 없을 땐 키 자체를 안 넣습니다. */
+          ...(description ? { description } : {}),
           imageUrl: imageUrl || FALLBACK_SHARE_IMAGE,
           link: { mobileWebUrl: shareUrl, webUrl: shareUrl },
         },

--- a/src/hooks/queries/useDisplayArtworks.ts
+++ b/src/hooks/queries/useDisplayArtworks.ts
@@ -1,12 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { CreateExhibitionArtworkRequestDto } from '@/api/dto';
+import type { CreateExhibitionArtworkRequestDto, UpdateDisplayArtworkRequestDto } from '@/api/dto';
 import {
   createExhibitionArtwork,
   deleteArtwork,
   getArtistArtworks,
   getDisplayArtworks,
   updateArtworkOrder,
+  updateDisplayArtwork,
 } from '@/api/endpoints';
 import { getPersonalArtworks } from '@/api/endpoints/personalArtwork';
 import { queryKeys } from '@/api/queryKeys';
@@ -39,6 +40,21 @@ export const useCreateDisplayArtwork = (displayId: number) => {
     mutationFn: (body: CreateExhibitionArtworkRequestDto) =>
       createExhibitionArtwork(displayId, body),
     onSuccess: invalidate,
+  });
+};
+
+// PATCH /v1/artworks/{artworkId}
+export const useUpdateDisplayArtwork = (displayId: number, artworkId: number) => {
+  const queryClient = useQueryClient();
+  const invalidate = useInvalidateDisplayArtworks(displayId);
+
+  return useMutation({
+    mutationFn: (body: UpdateDisplayArtworkRequestDto) => updateDisplayArtwork(artworkId, body),
+    onSuccess: () => {
+      /* 수정한 작품 자체의 상세 캐시(작품상세페이지, 수정 폼 미리채움)도 같이 갱신합니다. */
+      queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.detail(artworkId) });
+      invalidate();
+    },
   });
 };
 

--- a/src/mocks/handlers/artwork.ts
+++ b/src/mocks/handlers/artwork.ts
@@ -193,6 +193,33 @@ export const artworkHandlers = [
     ),
   ),
   ...paths('/api/v1/artworks/{artworkId}').map((path) =>
+    http.patch(path, async ({ params, request }) => {
+      const artworkId = toNumber(params.artworkId);
+      const artwork = findArtwork(artworkId);
+      const body = await readJson<Record<string, any>>(request);
+      const imageUrl = body.images?.[0]?.imageUrl ?? artwork.imageUrl ?? '';
+      const artworkName = body.artworkName !== undefined ? String(body.artworkName) : artwork.title;
+
+      Object.assign(artwork, {
+        ...body,
+        artworkId,
+        artworkName,
+        title: artworkName,
+        artist: body.artistName ?? artwork.artist,
+        content: body.content ?? artwork.content,
+        description: body.content ?? artwork.description,
+        materialMedia: body.materialMedia ?? artwork.materialMedia,
+        material: body.materialMedia ?? artwork.material,
+        images: body.images ?? artwork.images,
+        artworkImageUrl: imageUrl,
+        thumbnailUrl: imageUrl,
+        imageUrl,
+      });
+
+      return success('/api/v1/artworks/{artworkId}', artwork);
+    }),
+  ),
+  ...paths('/api/v1/artworks/{artworkId}').map((path) =>
     http.delete(path, ({ params }) => {
       const artworkId = toNumber(params.artworkId);
       mockDb.artworks = mockDb.artworks.filter((artwork: any) => artwork.artworkId !== artworkId);

--- a/src/pages/artwork-register/ArtworkRegisterPage.tsx
+++ b/src/pages/artwork-register/ArtworkRegisterPage.tsx
@@ -31,7 +31,11 @@ import {
   type ArtworkRegisterMode,
 } from '@/contexts/artworkRegisterDraftState';
 import { useArtworkDetail } from '@/hooks/queries/useArtworkDetail';
-import { useCreateDisplayArtwork, useDisplayArtworks } from '@/hooks/queries/useDisplayArtworks';
+import {
+  useCreateDisplayArtwork,
+  useDisplayArtworks,
+  useUpdateDisplayArtwork,
+} from '@/hooks/queries/useDisplayArtworks';
 import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
 import { useDisplayMembers } from '@/hooks/queries/useDisplayMembers';
 import { useArtworkRegisterDraft } from '@/hooks/useArtworkRegisterDraft';
@@ -100,8 +104,12 @@ function ArtworkRegisterPageContent() {
     maxImages: MAX_ARTWORK_PROGRESS_IMAGES,
   });
   const createArtwork = useCreateDisplayArtwork(displayId);
+  const updateArtwork = useUpdateDisplayArtwork(displayId, artworkId);
   const isSubmitting =
-    artworkUpload.isUploading || processUpload.isUploading || createArtwork.isPending;
+    artworkUpload.isUploading ||
+    processUpload.isUploading ||
+    createArtwork.isPending ||
+    updateArtwork.isPending;
   const artworkImages = artworkUpload.images;
   const processImages = processUpload.images;
   const setUploadedArtworkImages = artworkUpload.setUploadedImages;
@@ -403,6 +411,40 @@ function ArtworkRegisterPageContent() {
   ]);
 
   /*
+   * 수정 모드에서는 기존 작품 이미지도 미리 채워야 다시 첨부하지 않고 그대로 수정할 수 있습니다.
+   * 대표 이미지(isThumbnail)를 맨 앞에 두고 나머지는 sortOrder 순으로 둡니다.
+   */
+  useEffect(() => {
+    if (!isEditMode || !artworkDetail) return;
+    if (artworkImages.length > 0 || processImages.length > 0) return;
+
+    const workImages = artworkDetail.images
+      .filter((image) => image.imageType !== 'WORK_PROCESS')
+      .sort((a, b) => a.sortOrder - b.sortOrder);
+    const thumbnail = workImages.find((image) => image.isThumbnail);
+    const orderedWorkImageUrls = thumbnail
+      ? [
+          thumbnail.imageUrl,
+          ...workImages.filter((image) => image !== thumbnail).map((image) => image.imageUrl),
+        ]
+      : workImages.map((image) => image.imageUrl);
+    const processImageUrls = artworkDetail.images
+      .filter((image) => image.imageType === 'WORK_PROCESS')
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((image) => image.imageUrl);
+
+    if (orderedWorkImageUrls.length > 0) setUploadedArtworkImages(orderedWorkImageUrls);
+    if (processImageUrls.length > 0) setUploadedProcessImages(processImageUrls);
+  }, [
+    isEditMode,
+    artworkDetail,
+    artworkImages.length,
+    processImages.length,
+    setUploadedArtworkImages,
+    setUploadedProcessImages,
+  ]);
+
+  /*
    * 전시 팀원 목록. 초대를 수락한 팀원만 작가로 지정할 수 있습니다.
    * 스웨거 TeamMemberResponse에는 작가 인증 여부가 없어 초대 수락 여부로 대신 판정합니다.
    */
@@ -414,8 +456,10 @@ function ArtworkRegisterPageContent() {
   const { data: display } = useDisplayDetail(displayId);
 
   /* 작가 인증 + 전시 소속인만 전시작을 등록할 수 있습니다. */
-  const artworkPolicy = useArtworkPolicy(display);
+  const artworkPolicy = useArtworkPolicy(display, artworkDetail);
   const canCreateArtwork = hasPermission(artworkPolicy, 'create');
+  /* 수정은 그 작품의 작가/공동 작업자이거나 전시를 관리할 수 있는 사람만 할 수 있습니다. */
+  const canEditArtwork = hasPermission(artworkPolicy, 'edit');
 
   const exhibition = useMemo(
     () => ({
@@ -670,17 +714,12 @@ function ArtworkRegisterPageContent() {
     return { artworkImageUrls, processImageUrls };
   };
 
-  /* 이미지를 업로드한 뒤 작품을 등록합니다. */
+  /* 이미지를 업로드한 뒤 작품을 등록하거나(신규) 수정합니다(기존 작품). */
   const handleSubmit = async () => {
     if (isSubmitting) return;
 
-    if (isEditMode) {
-      navigate(`/exhibition/${displayId}/artworks`, { replace: true });
-      return;
-    }
-
-    if (!canCreateArtwork) {
-      setSubmitError('작품을 등록할 권한이 없어요.');
+    if (isEditMode ? !canEditArtwork : !canCreateArtwork) {
+      setSubmitError(isEditMode ? '작품을 수정할 권한이 없어요.' : '작품을 등록할 권한이 없어요.');
       return;
     }
 
@@ -726,53 +765,65 @@ function ArtworkRegisterPageContent() {
       return;
     }
 
-    createArtwork.mutate(
-      {
-        displayId,
-        artworkName: title.trim(),
-        content: description.trim(),
-        type: artworkType,
-        productionYear: toArtworkRegisterProductionYear(year),
-        materialMedia: medium.trim(),
-        size: size.trim(),
-        point: point.trim(),
-        /*
-         * 작품 이미지와 작업과정 이미지를 imageType으로 구분해 보냅니다.
-         * 서버가 width/height를 @Positive 원시 int로 받아 0이나 누락은 거절되어 고정값을 씁니다.
-         */
-        images: [
-          ...artworkImageUrls.map((imageUrl, index) => ({
-            imageUrl,
-            /* 대표 이미지는 작품 이미지 중 첫 장만 지정합니다. */
-            isThumbnail: index === 0,
-            imageType: 'ARTWORK',
-            width: DEFAULT_ARTWORK_IMAGE_WIDTH,
-            height: DEFAULT_ARTWORK_IMAGE_HEIGHT,
-            sortOrder: index + 1,
-          })),
-          ...processImageUrls.map((imageUrl, index) => ({
-            imageUrl,
-            isThumbnail: false,
-            imageType: 'WORK_PROCESS',
-            width: DEFAULT_ARTWORK_IMAGE_WIDTH,
-            height: DEFAULT_ARTWORK_IMAGE_HEIGHT,
-            sortOrder: index + 1,
-          })),
-        ],
-        artistName: displayAuthor.name.trim(),
-        artistUserId,
-        /* 계정이 연결된 팀원은 userIds로, 직접 입력한 작가는 rawNames로 보냅니다. */
-        coAuthors: {
-          userIds: collaborators
-            .map((person) => person.userId)
-            .filter((coAuthorUserId) => coAuthorUserId !== userId)
-            .filter((userId): userId is number => typeof userId === 'number'),
-          rawNames: collaborators
-            .filter((person) => typeof person.userId !== 'number')
-            .map((person) => person.name),
-        },
-        qaHandlerUserIds,
+    const artworkPayload = {
+      artworkName: title.trim(),
+      content: description.trim(),
+      type: artworkType,
+      productionYear: toArtworkRegisterProductionYear(year),
+      materialMedia: medium.trim(),
+      size: size.trim(),
+      point: point.trim(),
+      /*
+       * 작품 이미지와 작업과정 이미지를 imageType으로 구분해 보냅니다.
+       * 서버가 width/height를 @Positive 원시 int로 받아 0이나 누락은 거절되어 고정값을 씁니다.
+       */
+      images: [
+        ...artworkImageUrls.map((imageUrl, index) => ({
+          imageUrl,
+          /* 대표 이미지는 작품 이미지 중 첫 장만 지정합니다. */
+          isThumbnail: index === 0,
+          imageType: 'ARTWORK',
+          width: DEFAULT_ARTWORK_IMAGE_WIDTH,
+          height: DEFAULT_ARTWORK_IMAGE_HEIGHT,
+          sortOrder: index + 1,
+        })),
+        ...processImageUrls.map((imageUrl, index) => ({
+          imageUrl,
+          isThumbnail: false,
+          imageType: 'WORK_PROCESS',
+          width: DEFAULT_ARTWORK_IMAGE_WIDTH,
+          height: DEFAULT_ARTWORK_IMAGE_HEIGHT,
+          sortOrder: index + 1,
+        })),
+      ],
+      artistName: displayAuthor.name.trim(),
+      artistUserId,
+      /* 계정이 연결된 팀원은 userIds로, 직접 입력한 작가는 rawNames로 보냅니다. */
+      coAuthors: {
+        userIds: collaborators
+          .map((person) => person.userId)
+          .filter((coAuthorUserId) => coAuthorUserId !== userId)
+          .filter((userId): userId is number => typeof userId === 'number'),
+        rawNames: collaborators
+          .filter((person) => typeof person.userId !== 'number')
+          .map((person) => person.name),
       },
+      qaHandlerUserIds,
+    };
+
+    if (isEditMode) {
+      updateArtwork.mutate(artworkPayload, {
+        onSuccess: () => {
+          resetDraft();
+          navigate(`/exhibition/${displayId}/artworks`, { replace: true });
+        },
+        onError: () => setSubmitError('작품 수정에 실패했어요. 잠시 후 다시 시도해주세요.'),
+      });
+      return;
+    }
+
+    createArtwork.mutate(
+      { displayId, ...artworkPayload },
       {
         onSuccess: () => {
           const primaryQnaAssignee =


### PR DESCRIPTION
## 📝 작업 내용

- 전시상세페이지, 작품상세페이지에서 수정 후 수정된 이후 내용으로 잘 적용되도록

## 🔍 관련 이슈

- #이슈번호

## 🖼️ 스크린샷

- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.

## 🧪 테스트 결과

- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 기존 작품 정보를 불러와 작품명, 설명, 재료, 이미지, 작가 및 공동 작업자 정보를 수정할 수 있습니다.
  - 작품 수정 권한을 확인하고, 수정 완료 후 작품 목록으로 이동합니다.
  - 수정 실패 시 오류 안내를 제공합니다.

- **버그 수정**
  - 로그인하지 않은 게스트의 401 오류가 불필요한 토큰 갱신이나 로그인 화면 이동으로 이어지지 않습니다.
  - 카카오 공유 시 설명이 없는 경우 불필요한 값이 전송되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->