### PR TITLE
fix: 작품 카드 메모 버튼 하단 정렬

### DIFF
--- a/src/components/mypage/ArtworkCard.tsx
+++ b/src/components/mypage/ArtworkCard.tsx
@@ -81,7 +81,7 @@ export function ArtworkCard({
 
       {!isArtistView && (
         <MemoFooter
-          className="px-2.5 py-2"
+          className="mt-auto px-2.5 py-2"
           memo={item.memo}
           userId={item.userId}
           onSave={(memo) => onSaveMemo?.(item, memo)}


### PR DESCRIPTION
## 📝 작업 내용

- 마이페이지 작품 카드의 메모 footer에 `mt-auto`를 적용해 카드가 그리드 행 높이에 맞춰 늘어나도 메모 영역이 항상 카드 하단에 붙도록 수정했습니다.

## 🔍 관련 이슈

- closes #306

## 🖼️ 스크린샷

- 사용자 제보 화면 기준으로 메모 버튼이 카드 하단에 붙도록 수정

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

`pnpm lint` 실행 완료: 에러 없음, 기존 경고 8개 확인
`pnpm build` 실행 완료: 성공, 기존 chunk size 경고 확인

## 💬 기타 참고 사항

- 기존 작업 트리에 있던 `src/pages/ForbiddenPage.tsx` 변경은 이번 커밋/PR에 포함하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 아트워크 카드의 메모 영역이 카드 하단에 일관되게 배치되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->