### PR TITLE
Fix/작품 상세 페이지 수정

### DIFF
--- a/src/components/common/ShareBottomSheet.tsx
+++ b/src/components/common/ShareBottomSheet.tsx
@@ -135,7 +135,9 @@ export function ShareBottomSheet({
         objectType: 'feed',
         content: {
           title,
-          description,
+          /* description 키가 존재하면 카카오 SDK가 문자열 타입을 강제해서,
+           * 값이 없을 땐 undefined를 넣지 말고 키 자체를 빼야 합니다. */
+          ...(description ? { description } : {}),
           imageUrl: shareImageUrl,
           link: { mobileWebUrl: shareUrl, webUrl: shareUrl },
         },

--- a/src/components/displaydetailpage/ArtworkTab.tsx
+++ b/src/components/displaydetailpage/ArtworkTab.tsx
@@ -1,15 +1,18 @@
 import { useNavigate } from 'react-router-dom';
 
-import type { DisplayArtworkDto } from '@/api/dto';
+import type { DisplayArtworkDto, DisplayTeamMemberDto } from '@/api/dto';
 import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { useDisplayArtworks } from '@/hooks/queries/useDisplayArtworks';
+import { getExhibitionArtistName } from '@/utils/artist';
 
 type ArtworkCardProps = {
   item: DisplayArtworkDto;
+  teamMembers: DisplayTeamMemberDto[] | undefined;
 };
 
-function ArtworkCard({ item }: ArtworkCardProps) {
+function ArtworkCard({ item, teamMembers }: ArtworkCardProps) {
   const navigate = useNavigate();
+  const artistDisplayName = getExhibitionArtistName(item.artistName, item.artistUserId, teamMembers);
 
   return (
     <article
@@ -26,7 +29,7 @@ function ArtworkCard({ item }: ArtworkCardProps) {
       </div>
       <div className="pt-3 flex flex-col">
         <p className="typo-body-sm-bold truncate text-main">{item.artworkName}</p>
-        <p className="typo-body-xs-regular truncate text-main">{item.artistName}</p>
+        <p className="typo-body-xs-regular truncate text-main">{artistDisplayName}</p>
       </div>
     </article>
   );
@@ -34,9 +37,10 @@ function ArtworkCard({ item }: ArtworkCardProps) {
 
 type Props = {
   displayId: number;
+  teamMembers?: DisplayTeamMemberDto[];
 };
 
-export function ArtworkTab({ displayId }: Props) {
+export function ArtworkTab({ displayId, teamMembers }: Props) {
   const { data, isPending, isError } = useDisplayArtworks(displayId);
   const artworks = data?.artworks ?? [];
 
@@ -56,7 +60,7 @@ export function ArtworkTab({ displayId }: Props) {
       ) : (
         <div className="grid grid-cols-2 gap-3">
           {artworks.map((item) => (
-            <ArtworkCard key={item.artworkId} item={item} />
+            <ArtworkCard key={item.artworkId} item={item} teamMembers={teamMembers} />
           ))}
         </div>
       )}

--- a/src/components/displaydetailpage/IntroTab.tsx
+++ b/src/components/displaydetailpage/IntroTab.tsx
@@ -187,7 +187,12 @@ export function IntroTab({ display: ex }: Props) {
         <section className="px-5 mt-6 flex flex-col items-start gap-3">
           <h2 className="typo-body-xl-bold text-main">위치안내</h2>
           <div className="w-full flex flex-col overflow-hidden rounded-[14px] border border-[#e5e7eb]">
-            <div className="relative h-[140px] w-full shrink-0 self-stretch">
+            <a
+              href={`https://map.kakao.com/link/map/${encodeURIComponent(ex.location.placeName)},${ex.location.latitude},${ex.location.longitude}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="relative block h-[140px] w-full shrink-0 self-stretch cursor-pointer"
+            >
               <img
                 src={LocationMapPlaceholder}
                 alt="위치 지도"
@@ -203,16 +208,21 @@ export function IntroTab({ display: ex }: Props) {
                   </span>
                 </span>
               </div>
-            </div>
+            </a>
             <div className="flex items-center justify-between gap-3 shrink-0 bg-white px-4 py-3.5">
-              <div className="flex flex-col gap-0.5 min-w-0">
+              <a
+                href={`https://map.kakao.com/link/map/${encodeURIComponent(ex.location.placeName)},${ex.location.latitude},${ex.location.longitude}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex flex-col gap-0.5 min-w-0 cursor-pointer"
+              >
                 <p className="text-[#111] text-sm font-semibold leading-[21px] break-words">
                   {ex.location.placeName}
                 </p>
                 <p className="text-[#9ca3af] text-xs font-normal leading-[18px]">
                   {ex.location.roadAddress}
                 </p>
-              </div>
+              </a>
               <a
                 href={`https://map.kakao.com/link/map/${encodeURIComponent(ex.location.placeName)},${ex.location.latitude},${ex.location.longitude}`}
                 target="_blank"

--- a/src/components/mypage/AuthPageHeader.tsx
+++ b/src/components/mypage/AuthPageHeader.tsx
@@ -103,7 +103,7 @@ export function AuthPageHeader({
               className="flex items-center gap-1 typo-body-xs-regular text-[#2563EB]"
             >
               <ExternalLink className="size-4" />
-              {profile.portfolioUrl}
+              개인 포트폴리오
             </a>
           )}
         </div>

--- a/src/components/mypage/MyPageHeader.tsx
+++ b/src/components/mypage/MyPageHeader.tsx
@@ -123,7 +123,7 @@ export function MyPageHeader({
                   className="flex items-center gap-1 typo-body-xs-regular text-[#2563EB]"
                 >
                   <ExternalLink className="size-4" />
-                  {profile.portfolioUrl}
+                  개인 포트폴리오
                 </a>
               )}
             </div>

--- a/src/pages/ArtworkDetailPage.tsx
+++ b/src/pages/ArtworkDetailPage.tsx
@@ -32,6 +32,7 @@ import { useFlowBack } from '@/hooks/useFlowBack';
 import { useLoginRequiredModal } from '@/hooks/usePermissionRequiredModal';
 import { useFeelingPolicy, useFeelingReplyPolicy, useQuestionPolicy } from '@/hooks/usePolicy';
 import type { ArtworkDetail, GuestbookQuestion } from '@/types/exhibition';
+import { getExhibitionArtistName } from '@/utils/artist';
 import { parseServerDate } from '@/utils/date';
 import { hasPermission } from '@/utils/hasPermission';
 
@@ -230,14 +231,11 @@ export function ArtworkDetailPage() {
     );
   }
 
-  /*
-   * 작가명은 작품 등록 시점에 기록된 값(detail.artistName) 대신, 팀원이 그 전시에 참여할 때
-   * 정한 전시 작가명(teamMembers[].displayNickname)이 있으면 그걸 우선 보여줍니다.
-   * 초대받아 들어간 전시에서 원래 이름이 아니라 그 전시용 작가명이 나와야 하기 때문입니다.
-   */
-  const artistDisplayName =
-    display?.teamMembers?.find((member) => member.userId === detail.artistUserId)
-      ?.displayNickname || detail.artistName;
+  const artistDisplayName = getExhibitionArtistName(
+    detail.artistName,
+    detail.artistUserId,
+    display?.teamMembers,
+  );
 
   /* 화면이 쓰는 ArtworkDetail 형태로 변환합니다. */
   const artwork: ArtworkDetail = {

--- a/src/pages/DisplayDetailPage.tsx
+++ b/src/pages/DisplayDetailPage.tsx
@@ -64,7 +64,7 @@ export function DisplayDetailPage() {
       )}
       {activeTab === 'artwork' && (
         <div className="pb-bottom-bar-offset">
-          <ArtworkTab displayId={display.displayId} />
+          <ArtworkTab displayId={display.displayId} teamMembers={display.teamMembers} />
         </div>
       )}
       {activeTab === 'review' && <ReviewTab display={display} displayId={display.displayId} />}

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -1,0 +1,15 @@
+import type { DisplayTeamMemberDto } from '@/api/dto';
+
+/*
+ * 작품 등록 시점의 artistName 대신, 팀원이 그 전시에 참여하며 정한 전시용 작가명
+ * (teamMembers[].displayNickname)이 있으면 그걸 우선 보여줍니다.
+ * 초대받아 들어간 전시에서 원래 이름이 아니라 그 전시용 작가명이 나와야 하기 때문입니다.
+ */
+export function getExhibitionArtistName(
+  artistName: string,
+  artistUserId: number | null | undefined,
+  teamMembers: DisplayTeamMemberDto[] | undefined,
+): string {
+  const member = teamMembers?.find((teamMember) => teamMember.userId === artistUserId);
+  return member?.displayNickname || artistName;
+}


### PR DESCRIPTION
## 📝 작업 내용

- 전시상세 아래 내리면 나오는 지도에서 “지도보기” 버튼 말고도 지도 중앙 핀, 장소이름 클릭 시에도 지도로 이동 되게 하기
- 작품 카카오톡 공유하기 활성화
- 전시 상세 작품 탭에 작품 카드에 써있는 이름과 실제 작품 상세에 써있는 이름이 다르게 보이는 것 수정

## 🔍 관련 이슈

- close #309 

## 🧪 테스트 결과

- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 카카오톡 공유 시 설명이 없는 경우 불필요한 값이 전송되지 않도록 개선했습니다.
  - 위치 안내의 지도 미리보기와 장소 정보 영역을 클릭하면 Kakao Map이 새 탭에서 열리도록 변경했습니다.
  - 외부 링크에 안전한 브라우저 보안 설정을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->