### PR TITLE
fix: 전시 수정 페이지 초기값 표시 오류 수정

### DIFF
--- a/src/constants/exhibition.ts
+++ b/src/constants/exhibition.ts
@@ -45,6 +45,19 @@ export const DISPLAY_TYPE_MAP: Record<string, CreateDisplayRequestDto['type']> =
   '기타 단체 전시': 'ETC',
 } satisfies Record<ExhibitionType, CreateDisplayRequestDto['type']>;
 
+export const DISPLAY_TYPE_REVERSE_MAP: Record<string, string> = {
+  GRADUATION: '졸업 전시',
+  TASK: '과제 전시',
+  ASSIGNMENTS: '과제 전시',
+  CLUB: '학과·학회 전시',
+  DEPARTMENTS: '학과·학회 전시',
+  SMALL_GROUP: '소모임·동아리 전시',
+  JOINT: '연합 전시',
+  INTER_GROUP: '연합 전시',
+  ETC: '기타 단체 전시',
+  OTHERS: '기타 단체 전시',
+};
+
 /*
  * 전시 등록은 작가 활동분야와 다른 enum을 씁니다.
  * 영상은 MEDIA로 보내야 하고 ILLUSTRATION은 서버에 없어 DESIGN으로 대체합니다.
@@ -55,14 +68,32 @@ export const DISPLAY_FIELD_MAP: Record<string, string> = {
   DESIGN: 'DESIGN',
   PHOTOGRAPHY: 'PHOTOGRAPHY',
   ARCHITECTURE: 'ARCHITECTURE',
+  VIDEO: 'MEDIA',
+  SCULPTURE: 'SCULPTURE',
+  FASHION: 'FASHION',
+  ILLUSTRATION: 'DESIGN',
+  CRAFT: 'CRAFT',
+  COMPLEX: 'COMPLEX',
+  ETC: 'ETC',
+} satisfies Record<ExhibitionField, string>;
+
+export const DISPLAY_FIELD_REVERSE_MAP: Record<string, ExhibitionField> = {
+  PAINTING: 'PAINTING',
+  DESIGN: 'DESIGN',
+  PHOTOGRAPHY: 'PHOTOGRAPHY',
+  ARCHITECTURE: 'ARCHITECTURE',
+  MEDIA: 'VIDEO',
   VIDEO: 'VIDEO',
   SCULPTURE: 'SCULPTURE',
   FASHION: 'FASHION',
-  ILLUSTRATION: 'INTERDISCIPLINARY',
-  CRAFT: 'CRAFTS',
+  INTERDISCIPLINARY: 'ILLUSTRATION',
+  ILLUSTRATION: 'ILLUSTRATION',
+  CRAFT: 'CRAFT',
+  CRAFTS: 'CRAFT',
   COMPLEX: 'COMPLEX',
-  ETC: 'OTHERS',
-} satisfies Record<ExhibitionField, string>;
+  ETC: 'ETC',
+  OTHERS: 'ETC',
+};
 
 export type ArtistFieldCode =
   | 'PAINTING'

--- a/src/pages/InteriorPhotosPage.tsx
+++ b/src/pages/InteriorPhotosPage.tsx
@@ -263,7 +263,7 @@ function InteriorPhotos({
 
         {/* 액션 */}
         {!isReorderMode && canShowActions && (
-          <div className="flex gap-2 px-5">
+          <div className="mt-3.5 flex gap-2 px-5">
             <input
               ref={fileInputRef}
               type="file"
@@ -296,11 +296,11 @@ function InteriorPhotos({
 
         {/* 그리드 */}
         {photos.length === 0 ? (
-          <p className="typo-body-sm-regular px-5 text-hint">
+          <p className="typo-body-sm-regular mt-6 px-5 text-hint">
             아직 사진이 없어요. 사진 추가로 첫 장을 올려보세요.
           </p>
         ) : (
-          <ul className="grid grid-cols-3 gap-x-2.5 gap-y-3 px-5">
+          <ul className="mt-6 grid grid-cols-3 gap-x-2.5 gap-y-3 px-5">
             {photos.map((photo, index) => (
               <li
                 key={photo.id}

--- a/src/pages/exhibition-register/ExhibitionBasicInfo.tsx
+++ b/src/pages/exhibition-register/ExhibitionBasicInfo.tsx
@@ -11,6 +11,7 @@ import { AddressSearchModal } from '@/components/exhibition-basic-info';
 import { ExhibitionHeader } from '@/components/ui';
 import { CalenderSheet } from '@/components/ui/CalenderSheet';
 import { type TimeRangeValue, TimeSheet } from '@/components/ui/TimeSheet';
+import { DISPLAY_FIELD_MAP, DISPLAY_TYPE_MAP } from '@/constants/exhibition';
 import { useUpdateDisplay } from '@/hooks/queries/useDisplayBrowse';
 import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
 import { useExhibitionRegisterDraft } from '@/hooks/useExhibitionRegisterDraft';
@@ -19,6 +20,7 @@ import { useFlowBack } from '@/hooks/useFlowBack';
 import {
   type ExhibitionBasicInfoFormValues,
   exhibitionBasicInfoSchema,
+  type ExhibitionRegisterFormValues,
 } from './exhibitionRegister.schema';
 
 interface DateValue {
@@ -71,6 +73,20 @@ export function ExhibitionBasicInfo() {
   const navigate = useNavigate();
   const flowBack = useFlowBack();
   const { state } = useLocation();
+  const locationState = useMemo(
+    () =>
+      (state ?? {}) as Partial<
+        ExhibitionRegisterFormValues &
+          ExhibitionBasicInfoFormValues & {
+            displayDetail: DisplayDetailDto;
+            imageUrls: string[];
+            intro: string;
+            periodValue: DateValue;
+            operatingHoursValue: TimeRangeValue;
+          }
+      >,
+    [state],
+  );
   const { draft, hasDraft, updateDraft } = useExhibitionRegisterDraft();
   const { displayId: paramDisplayId } = useParams();
   const displayId = Number(paramDisplayId ?? 0);
@@ -78,13 +94,13 @@ export function ExhibitionBasicInfo() {
   const updateDisplay = useUpdateDisplay(displayId);
 
   const { data: fetchedDetail, isPending: isDetailPending } = useDisplayDetail(displayId);
-  const isFetchingDetail = displayId > 0 && !state?.displayDetail && isDetailPending;
+  const isFetchingDetail = displayId > 0 && !locationState.displayDetail && isDetailPending;
 
   const restored = useMemo(() => {
-    return displayId > 0 && !state?.displayDetail ? {} : (state ?? {});
-  }, [displayId, state]);
+    return displayId > 0 && !locationState.displayDetail ? {} : locationState;
+  }, [displayId, locationState]);
 
-  const displayDetail = (state?.displayDetail as DisplayDetailDto) || fetchedDetail || null;
+  const displayDetail = locationState.displayDetail || fetchedDetail || null;
 
   const parseDate = (d?: string) => (d ? new Date(d) : new Date());
 
@@ -154,7 +170,9 @@ export function ExhibitionBasicInfo() {
       placeName: shouldUseDraft
         ? draft.placeName
         : ((restored.placeName as string) ?? displayDetail?.location?.placeName ?? ''),
-      address: shouldUseDraft ? draft.address : ((restored.address as string) ?? ''),
+      address: shouldUseDraft
+        ? draft.address
+        : ((restored.address as string) ?? displayDetail?.location?.roadAddress ?? ''),
       latitude: shouldUseDraft
         ? (draft.latitude ?? undefined)
         : ((restored.latitude as number) ?? displayDetail?.location?.latitude ?? undefined),
@@ -203,7 +221,7 @@ export function ExhibitionBasicInfo() {
       return;
     }
 
-    if (displayId > 0 && !state?.displayDetail && fetchedDetail) {
+    if (displayId > 0 && !locationState.displayDetail && fetchedDetail) {
       const restoredPeriod =
         (restored.periodValue as DateValue) ??
         (fetchedDetail.period
@@ -226,7 +244,8 @@ export function ExhibitionBasicInfo() {
             }
           : null);
 
-      const restoredAddress = (restored.address as string) ?? '';
+      const restoredAddress =
+        (restored.address as string) ?? fetchedDetail.location?.roadAddress ?? '';
 
       reset({
         startDate: restoredPeriod ? formatDate(restoredPeriod.start) : '',
@@ -325,13 +344,20 @@ export function ExhibitionBasicInfo() {
     if (displayId > 0) {
       updateDisplay.mutate(
         {
-          title: state?.title ?? fetchedDetail?.title ?? '',
-          subtitle: state?.subtitle ?? fetchedDetail?.subtitle ?? null,
-          description: state?.intro ?? fetchedDetail?.content ?? null,
-          type: state?.type ?? fetchedDetail?.displayType ?? 'PERSONAL',
-          fields: state?.field ?? fetchedDetail?.displayFields ?? [],
-          schoolOrOrganization: state?.school ?? fetchedDetail?.organization ?? '',
-          departmentOrClub: state?.department ?? fetchedDetail?.department ?? null,
+          title: locationState.title ?? fetchedDetail?.title ?? '',
+          subtitle: locationState.subtitle ?? fetchedDetail?.subtitle ?? null,
+          description: locationState.intro ?? fetchedDetail?.content ?? null,
+          type:
+            (locationState.type ? DISPLAY_TYPE_MAP[locationState.type] : undefined) ??
+            fetchedDetail?.displayType ??
+            'PERSONAL',
+          fields:
+            locationState.field?.map((f) => DISPLAY_FIELD_MAP[f]).filter(Boolean) ??
+            fetchedDetail?.displayFields ??
+            [],
+          schoolOrOrganization:
+            locationState.school || locationState.organizer || fetchedDetail?.organization || '',
+          departmentOrClub: locationState.department ?? fetchedDetail?.department ?? null,
           placeName: data.placeName.trim(),
           precautions: data.notice?.trim() || null,
           startDate: data.startDate,
@@ -339,7 +365,7 @@ export function ExhibitionBasicInfo() {
           openTime: data.startTime,
           closeTime: data.endTime,
           posterImageUrl:
-            state?.imageUrls?.[0] ?? fetchedDetail?.images?.[0]?.imageUrl ?? undefined,
+            locationState.imageUrls?.[0] ?? fetchedDetail?.images?.[0]?.imageUrl ?? undefined,
         },
         {
           onSuccess: () => navigate(`/exhibition/${displayId}/manage`, { replace: true }),

--- a/src/pages/exhibition-register/ExhibitionRegister.tsx
+++ b/src/pages/exhibition-register/ExhibitionRegister.tsx
@@ -10,6 +10,8 @@ import { BottomFixedBar, ImageUploader } from '@/components/common';
 import { AffiliationInput } from '@/components/exhibition-register';
 import { ChipGroup, ExhibitionHeader, RequiredLabel } from '@/components/ui';
 import {
+  DISPLAY_FIELD_REVERSE_MAP,
+  DISPLAY_TYPE_REVERSE_MAP,
   EXHIBITION_FIELD_LABELS,
   EXHIBITION_FIELDS,
   EXHIBITION_TYPE_LABELS,
@@ -61,14 +63,14 @@ export function ExhibitionRegister() {
   const initialIntro = shouldUseDraft
     ? draft.intro
     : ((restored.intro as string) ?? displayDetail?.content ?? '');
-  const initialType = shouldUseDraft
-    ? draft.type
-    : ((restored.type as string) ?? displayDetail?.displayType ?? '');
+  const rawType = (restored.type as string) ?? displayDetail?.displayType ?? '';
+  const initialType = shouldUseDraft ? draft.type : (DISPLAY_TYPE_REVERSE_MAP[rawType] ?? rawType);
+  const rawFields = (restored.field as string[]) ?? displayDetail?.displayFields ?? [];
   const initialField = shouldUseDraft
     ? (draft.field as ExhibitionRegisterFormValues['field'])
-    : ((restored.field as ExhibitionRegisterFormValues['field']) ??
-      (displayDetail?.displayFields as ExhibitionRegisterFormValues['field']) ??
-      []);
+    : (rawFields.map(
+        (f) => DISPLAY_FIELD_REVERSE_MAP[f] ?? f,
+      ) as ExhibitionRegisterFormValues['field']);
   const initialSchool = shouldUseDraft
     ? draft.school
     : ((restored.school as string) ??
@@ -88,6 +90,7 @@ export function ExhibitionRegister() {
     control,
     setValue,
     reset,
+    trigger,
     formState: { errors, isValid, isSubmitted },
   } = useForm<ExhibitionRegisterFormValues>({
     resolver: zodResolver(exhibitionRegisterSchema),
@@ -130,11 +133,12 @@ export function ExhibitionRegister() {
       const restoredTitle = (restored.title as string) ?? fetchedDetail.title ?? '';
       const restoredSubtitle = (restored.subtitle as string) ?? fetchedDetail.subtitle ?? '';
       const restoredIntro = (restored.intro as string) ?? fetchedDetail.content ?? '';
-      const restoredType = (restored.type as string) ?? fetchedDetail.displayType ?? '';
-      const restoredField =
-        (restored.field as ExhibitionRegisterFormValues['field']) ??
-        (fetchedDetail.displayFields as ExhibitionRegisterFormValues['field']) ??
-        [];
+      const rawRestoredType = (restored.type as string) ?? fetchedDetail.displayType ?? '';
+      const restoredType = DISPLAY_TYPE_REVERSE_MAP[rawRestoredType] ?? rawRestoredType;
+      const rawRestoredFields = (restored.field as string[]) ?? fetchedDetail.displayFields ?? [];
+      const restoredField = rawRestoredFields.map(
+        (f) => DISPLAY_FIELD_REVERSE_MAP[f] ?? f,
+      ) as ExhibitionRegisterFormValues['field'];
       const restoredSchool =
         (restored.school as string) ??
         fetchedDetail.organization ??
@@ -159,6 +163,7 @@ export function ExhibitionRegister() {
         department: restoredDepartment,
         organizer: restoredOrganizer,
       });
+      trigger();
     }
   }, [displayId, state, fetchedDetail, restored, artistProfile, reset, shouldUseDraft]);
 


### PR DESCRIPTION
## 📝 작업 내용

- 전시 수정 페이지 진입 시 상세 응답의 전시 유형/분야 enum 값을 프론트 칩 선택값으로 정규화했습니다.
- 전시 기본 정보 수정 화면에서 주소 초기값으로 `location.roadAddress`를 사용하도록 보정했습니다.
- 전시 수정 요청 payload의 `type`, `fields` 매핑을 API 스키마에 맞게 보정했습니다.
- 전시 콘텐츠 사진 관리 화면에서 카운터, 사진 추가 버튼, 사진 그리드 간격을 조정했습니다.
- Vercel build에서 발생한 location state 타입 추론 오류를 해결했습니다.

## 🔍 관련 이슈

- #313

## 🖼️ 스크린샷

- 전시 수정 페이지에서 기존 전시 유형/분야/주소가 초기값으로 표시되는지 확인이 필요합니다.

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [x] `pnpm run build` 통과
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- Swagger 기준으로 전시 생성/수정 API와 검색 API의 enum 값이 달라, 상세 응답값을 화면 선택값으로 변환하는 reverse map을 추가했습니다.