### PR TITLE
fix: 개인 전시작 관리 기능 개선

### DIFF
--- a/src/api/dto/displayArtwork.dto.ts
+++ b/src/api/dto/displayArtwork.dto.ts
@@ -435,6 +435,7 @@ export type GetArtworkPreviewResponseDto = ApiResponseDto<GetArtworkPreviewRespo
 
 export interface DisplayArtworkDto {
   artworkId: number;
+  displayId?: number;
   artworkName: string;
   artistName: string;
   artistUserId?: number;

--- a/src/api/dto/personalArtwork.dto.ts
+++ b/src/api/dto/personalArtwork.dto.ts
@@ -4,6 +4,7 @@ export interface PersonalArtworkRequestDto {
   artworkName: string;
   content?: string;
   type: string;
+  types?: string[];
   productionYear: number;
   materialMedia: string;
   size?: string;
@@ -18,6 +19,7 @@ export interface PersonalArtworkResponseDataDto {
   artworkName: string;
   content?: string;
   type: string;
+  types?: string[];
   productionYear: number;
   materialMedia: string;
   size?: string;

--- a/src/components/mypage/ArtworkCard.tsx
+++ b/src/components/mypage/ArtworkCard.tsx
@@ -1,8 +1,14 @@
+import { useState } from 'react';
+
 import { Bookmark } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 
 import { OptimizedImage } from '@/components/common/OptimizedImage';
+import { useDeletePersonalArtwork } from '@/hooks/queries/usePersonalArtwork';
 import type { SavedArtworkItem } from '@/types/mypage';
 
+import { ArtworkDeleteConfirmModal } from './ArtworkDeleteConfirmModal';
+import { ExhibitionMenuButton } from './ExhibitionMenuButton';
 import { MemoFooter } from './MemoFooter';
 
 interface ArtworkCardProps {
@@ -12,6 +18,7 @@ interface ArtworkCardProps {
   onSaveMemo?: (item: SavedArtworkItem, memo: string) => void;
   onDeleteMemo?: (item: SavedArtworkItem) => void;
   onOpen?: (item: SavedArtworkItem) => void;
+  showMenu?: boolean;
 }
 
 export function ArtworkCard({
@@ -21,7 +28,13 @@ export function ArtworkCard({
   onSaveMemo,
   onDeleteMemo,
   onOpen,
+  showMenu = false,
 }: ArtworkCardProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const navigate = useNavigate();
+  const deletePersonalArtwork = useDeletePersonalArtwork();
+
   /* 카드 영역은 div라서 키보드로도 열 수 있도록 역할과 키 처리를 함께 부여합니다. */
   const openHandlers = onOpen
     ? {
@@ -37,20 +50,90 @@ export function ArtworkCard({
         },
       }
     : {};
+
+  const handleEdit = () => {
+    if (item.personalArtworkId) {
+      navigate(`/personal-artworks/register?id=${item.personalArtworkId}`);
+    } else if (item.artworkId) {
+      // 일반 전시 작품 수정 페이지로 이동
+      navigate(`/artwork/${item.artworkId}/edit`);
+    }
+  };
+
+  const handleDelete = () => {
+    if (item.personalArtworkId) {
+      deletePersonalArtwork.mutate(item.personalArtworkId);
+    }
+  };
+
   return (
     <article className="bg-card rounded-2xl shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)] flex flex-col relative">
       <div {...openHandlers} className={onOpen ? 'cursor-pointer px-1.5 py-2.5' : 'px-1.5 py-2.5'}>
-        <div className="relative rounded-xl overflow-hidden">
-          <div className="w-full h-44 bg-box200">
-            {item.thumbnail && (
-              <OptimizedImage
-                className="block w-full h-full object-cover"
-                src={item.thumbnail}
-                displayWidth={170}
-                alt={item.title}
-              />
-            )}
+        <div className="relative rounded-xl">
+          <div className="rounded-xl overflow-hidden">
+            <div className="w-full h-44 bg-box200">
+              {item.thumbnail && (
+                <OptimizedImage
+                  className="block w-full h-full object-cover"
+                  src={item.thumbnail}
+                  displayWidth={170}
+                  alt={item.title}
+                />
+              )}
+            </div>
           </div>
+
+          {showMenu && !!item.personalArtworkId && (
+            <>
+              <ExhibitionMenuButton
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setIsMenuOpen((prev) => !prev);
+                }}
+              />
+              {isMenuOpen && (
+                <>
+                  <div
+                    className="fixed inset-0 z-40"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setIsMenuOpen(false);
+                    }}
+                  />
+                  <div
+                    onClick={(event) => event.stopPropagation()}
+                    className="absolute right-2 top-12 z-50 w-25 rounded-[14px] border border-[#C4C4C4] bg-[#FCFCFC] shadow-[2px_4px_18px_0px_rgba(67,0,209,0.05)]"
+                    style={{ fontFamily: 'Pretendard' }}
+                  >
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setIsMenuOpen(false);
+                        handleEdit();
+                      }}
+                      className="flex h-10 w-full items-center pl-[14px] text-left text-[12px] leading-[140%] tracking-[-0.36px] text-[#111]"
+                    >
+                      수정
+                    </button>
+                    <div className="border-t border-[#E9E9E9]" />
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setIsMenuOpen(false);
+                        setIsDeleteModalOpen(true);
+                      }}
+                      className="flex h-10 w-full items-center pl-[14px] text-left text-[12px] leading-[140%] tracking-[-0.36px] text-[#C32427]"
+                    >
+                      삭제
+                    </button>
+                  </div>
+                </>
+              )}
+            </>
+          )}
+
           {!isArtistView && (
             <button
               type="button"
@@ -86,6 +169,16 @@ export function ArtworkCard({
           userId={item.userId}
           onSave={(memo) => onSaveMemo?.(item, memo)}
           onDelete={() => onDeleteMemo?.(item)}
+        />
+      )}
+
+      {isDeleteModalOpen && (
+        <ArtworkDeleteConfirmModal
+          onConfirm={() => {
+            setIsDeleteModalOpen(false);
+            handleDelete();
+          }}
+          onCancel={() => setIsDeleteModalOpen(false)}
         />
       )}
     </article>

--- a/src/components/mypage/ArtworkCard.tsx
+++ b/src/components/mypage/ArtworkCard.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { Bookmark } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
+import { getArtworkDetail } from '@/api/endpoints';
+import { queryKeys } from '@/api/queryKeys';
 import { OptimizedImage } from '@/components/common/OptimizedImage';
 import { useDeletePersonalArtwork } from '@/hooks/queries/usePersonalArtwork';
 import type { SavedArtworkItem } from '@/types/mypage';
@@ -33,6 +36,7 @@ export function ArtworkCard({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const deletePersonalArtwork = useDeletePersonalArtwork();
 
   /* 카드 영역은 div라서 키보드로도 열 수 있도록 역할과 키 처리를 함께 부여합니다. */
@@ -54,9 +58,6 @@ export function ArtworkCard({
   const handleEdit = () => {
     if (item.personalArtworkId) {
       navigate(`/personal-artworks/register?id=${item.personalArtworkId}`);
-    } else if (item.artworkId) {
-      // 일반 전시 작품 수정 페이지로 이동
-      navigate(`/artwork/${item.artworkId}/edit`);
     }
   };
 
@@ -65,6 +66,27 @@ export function ArtworkCard({
       deletePersonalArtwork.mutate(item.personalArtworkId);
     }
   };
+
+  const handleGoWorkPage = async () => {
+    if (item.displayId) {
+      navigate(`/exhibition/${item.displayId}/work`);
+      return;
+    }
+
+    if (item.artworkId) {
+      const artwork = await queryClient.fetchQuery({
+        queryKey: queryKeys.displayArtworks.detail(item.artworkId),
+        queryFn: () => getArtworkDetail(item.artworkId as number),
+      });
+      const displayId = artwork.exhibitionInfo?.displayId;
+
+      if (displayId) {
+        navigate(`/exhibition/${displayId}/work`);
+      }
+    }
+  };
+
+  const isPersonalArtwork = Boolean(item.personalArtworkId);
 
   return (
     <article className="bg-card rounded-2xl shadow-[8px_8px_18px_0px_rgba(67,0,209,0.04)] flex flex-col relative">
@@ -83,7 +105,7 @@ export function ArtworkCard({
             </div>
           </div>
 
-          {showMenu && !!item.personalArtworkId && (
+          {showMenu && (isPersonalArtwork || !!item.artworkId) && (
             <>
               <ExhibitionMenuButton
                 onClick={(event) => {
@@ -102,32 +124,48 @@ export function ArtworkCard({
                   />
                   <div
                     onClick={(event) => event.stopPropagation()}
-                    className="absolute right-2 top-12 z-50 w-25 rounded-[14px] border border-[#C4C4C4] bg-[#FCFCFC] shadow-[2px_4px_18px_0px_rgba(67,0,209,0.05)]"
+                    className="absolute right-2 top-12 z-50 w-36 rounded-[14px] border border-[#C4C4C4] bg-[#FCFCFC] shadow-[2px_4px_18px_0px_rgba(67,0,209,0.05)]"
                     style={{ fontFamily: 'Pretendard' }}
                   >
-                    <button
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        setIsMenuOpen(false);
-                        handleEdit();
-                      }}
-                      className="flex h-10 w-full items-center pl-[14px] text-left text-[12px] leading-[140%] tracking-[-0.36px] text-[#111]"
-                    >
-                      수정
-                    </button>
-                    <div className="border-t border-[#E9E9E9]" />
-                    <button
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        setIsMenuOpen(false);
-                        setIsDeleteModalOpen(true);
-                      }}
-                      className="flex h-10 w-full items-center pl-[14px] text-left text-[12px] leading-[140%] tracking-[-0.36px] text-[#C32427]"
-                    >
-                      삭제
-                    </button>
+                    {isPersonalArtwork ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setIsMenuOpen(false);
+                            handleEdit();
+                          }}
+                          className="flex h-10 w-full items-center pl-[14px] text-left text-[12px] leading-[140%] tracking-[-0.36px] text-[#111]"
+                        >
+                          수정
+                        </button>
+                        <div className="border-t border-[#E9E9E9]" />
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setIsMenuOpen(false);
+                            setIsDeleteModalOpen(true);
+                          }}
+                          className="flex h-10 w-full items-center pl-[14px] text-left text-[12px] leading-[140%] tracking-[-0.36px] text-[#C32427]"
+                        >
+                          삭제
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          setIsMenuOpen(false);
+                          handleGoWorkPage();
+                        }}
+                        className="flex h-10 w-full items-center pl-[14px] text-left text-[12px] leading-[140%] tracking-[-0.36px] text-[#111]"
+                      >
+                        작업 페이지 바로가기
+                      </button>
+                    )}
                   </div>
                 </>
               )}

--- a/src/components/mypage/ArtworkDeleteConfirmModal.tsx
+++ b/src/components/mypage/ArtworkDeleteConfirmModal.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useId, useRef } from 'react';
+
+type Props = {
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function ArtworkDeleteConfirmModal({ onConfirm, onCancel }: Props) {
+  const descriptionId = useId();
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    cancelButtonRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label="작품 삭제"
+      aria-describedby={descriptionId}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-neutral-900/40 px-10"
+    >
+      <div className="relative h-48 w-80 overflow-hidden rounded-[20px] bg-neutral-50/20 shadow-[2px_8px_18px_0px_rgba(4,0,250,0.04),inset_-3px_-3px_3px_-2px_rgba(241,241,241,0.60),inset_4px_4px_3px_-2px_rgba(255,255,255,1.00)] backdrop-blur-[10px]">
+        <div className="absolute left-1/2 top-6 flex w-72 -translate-x-1/2 flex-col items-center justify-center gap-2">
+          <h3 className="w-72 text-center typo-body-xl-bold text-modal-title">
+            작품을 삭제할까요?
+          </h3>
+          <p id={descriptionId} className="w-72 text-center typo-body-md-regular text-modal-desc">
+            삭제한 작품은 복구할 수 없어요.
+            <br />
+            정말 삭제하시겠어요?
+          </p>
+        </div>
+
+        <div className="absolute left-5 top-[126px] flex items-center justify-start gap-2.5">
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="flex h-11 w-32 items-center justify-center gap-2.5 rounded-full bg-modal-btn-hover-bg"
+          >
+            <span className="typo-body-lg-regular text-modal-btn-hover-fg">삭제하기</span>
+          </button>
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            onClick={onCancel}
+            className="flex h-11 w-32 items-center justify-center gap-2.5 rounded-full bg-modal-btn-bg"
+          >
+            <span className="typo-body-lg-regular text-modal-btn-fg">취소</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/mypage/ExhibitionMenuButton.tsx
+++ b/src/components/mypage/ExhibitionMenuButton.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+import { cn } from '@/utils/cn';
+
+type Props = {
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
+  id?: string;
+};
+
+export function ExhibitionMenuButton({ onClick, className = '', id }: Props) {
+  const [pressed, setPressed] = useState(false);
+
+  return (
+    <button
+      type="button"
+      id={id}
+      aria-label="메뉴"
+      onMouseDown={() => setPressed(true)}
+      onMouseUp={() => setPressed(false)}
+      onMouseLeave={() => setPressed(false)}
+      onClick={(event) => {
+        onClick?.(event);
+      }}
+      className={cn(
+        'absolute right-2 top-2',
+        'flex size-[22px] items-center justify-center rounded-full border-0 bg-transparent p-0 outline-none',
+        'cursor-pointer transition-transform duration-100 ease-out',
+        pressed ? 'scale-[0.92]' : '',
+        className,
+      )}
+    >
+      <span
+        className="flex size-[22px] items-center justify-center rounded-full backdrop-blur-[4.5px]"
+        style={{
+          backgroundImage:
+            'linear-gradient(90deg, rgba(254,254,254,0.05), rgba(254,254,254,0.05)), linear-gradient(90deg, rgba(254,254,254,0.24), rgba(254,254,254,0.24))',
+          boxShadow:
+            '2px 4px 18px 0px rgba(67,0,209,0.08), inset 1px 1px 2px 0px white, inset -1px -1px 2px 0px rgba(241,241,241,0.6)',
+        }}
+        aria-hidden="true"
+      >
+        <span className="flex items-center gap-[2px]">
+          <span className="size-[2.5px] rounded-full bg-[#262626]" />
+          <span className="size-[2.5px] rounded-full bg-[#262626]" />
+          <span className="size-[2.5px] rounded-full bg-[#262626]" />
+        </span>
+      </span>
+    </button>
+  );
+}

--- a/src/components/mypage/index.ts
+++ b/src/components/mypage/index.ts
@@ -1,7 +1,9 @@
 export { ArtistCard } from './ArtistCard';
 export { ArtworkCard } from './ArtworkCard';
+export { ArtworkDeleteConfirmModal } from './ArtworkDeleteConfirmModal';
 export { AuthPageHeader } from './AuthPageHeader';
 export { ExhibitionCard } from './ExhibitionCard';
+export { ExhibitionMenuButton } from './ExhibitionMenuButton';
 export { MemoFooter } from './MemoFooter';
 export { MyPageHeader } from './MyPageHeader';
 export { SettingsSheet } from './SettingsSheet';

--- a/src/hooks/queries/useArchive.ts
+++ b/src/hooks/queries/useArchive.ts
@@ -32,17 +32,18 @@ import {
 import { queryKeys } from '@/api/queryKeys';
 import { useAuthStore } from '@/stores/authStore';
 
-export const useArchivedExhibitions = () => {
+export const useArchivedExhibitions = ({ enabled = true }: { enabled?: boolean } = {}) => {
   const accessToken = useAuthStore((state) => state.accessToken);
   return useQuery({
     queryKey: queryKeys.archives.displays.list(),
     queryFn: getArchivedExhibitions,
-    enabled: !!accessToken,
+    enabled: enabled && !!accessToken,
   });
 };
 
 export const useInfiniteArchivedArtworks = (
   params: Omit<GetArchivedArtworksRequestDto, 'cursorId'> & { size: number },
+  { enabled = true }: { enabled?: boolean } = {},
 ) => {
   const accessToken = useAuthStore((state) => state.accessToken);
 
@@ -56,18 +57,18 @@ export const useInfiniteArchivedArtworks = (
     initialPageParam: null as ArchiveArtworkCursorDto | null,
     getNextPageParam: (lastPage) =>
       lastPage.hasNext ? (lastPage.nextCursorId ?? lastPage.nextCursor ?? null) : null,
-    enabled: !!accessToken,
+    enabled: enabled && !!accessToken,
   });
 };
 
-export const useArchivedArtists = () => {
+export const useArchivedArtists = ({ enabled = true }: { enabled?: boolean } = {}) => {
   const accessToken = useAuthStore((state) => state.accessToken);
   return useInfiniteQuery({
     queryKey: queryKeys.archives.artists.list(),
     queryFn: ({ pageParam }) => getArchivedArtists({ cursorId: pageParam ?? undefined }),
     initialPageParam: null as number | null,
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursorId : null),
-    enabled: !!accessToken,
+    enabled: enabled && !!accessToken,
   });
 };
 

--- a/src/hooks/queries/usePersonalArtwork.ts
+++ b/src/hooks/queries/usePersonalArtwork.ts
@@ -49,16 +49,21 @@ export const usePersonalArtwork = (personalArtworkId: number) =>
   useQuery({
     queryKey: queryKeys.personalArtworks.detail(personalArtworkId),
     queryFn: () => getPersonalArtwork(personalArtworkId),
-    enabled: Number.isFinite(personalArtworkId),
+    enabled: Number.isFinite(personalArtworkId) && personalArtworkId > 0,
   });
+
+const invalidatePersonalArtworkLists = (queryClient: ReturnType<typeof useQueryClient>) => {
+  queryClient.invalidateQueries({ queryKey: queryKeys.personalArtworks.lists() });
+  queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.me() });
+  queryClient.invalidateQueries({ queryKey: queryKeys.displayArtworks.lists() });
+};
 
 export const useCreatePersonalArtwork = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (body: PersonalArtworkRequestDto) => createPersonalArtwork(body),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: queryKeys.personalArtworks.lists() }),
+    onSuccess: () => invalidatePersonalArtworkLists(queryClient),
   });
 };
 
@@ -74,7 +79,7 @@ export const useUpdatePersonalArtwork = () => {
       body: Partial<PersonalArtworkRequestDto>;
     }) => updatePersonalArtwork(personalArtworkId, body),
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.personalArtworks.lists() });
+      invalidatePersonalArtworkLists(queryClient);
       queryClient.invalidateQueries({
         queryKey: queryKeys.personalArtworks.detail(variables.personalArtworkId),
       });
@@ -88,7 +93,7 @@ export const useDeletePersonalArtwork = () => {
   return useMutation({
     mutationFn: (personalArtworkId: number) => deletePersonalArtwork(personalArtworkId),
     onSuccess: (_, personalArtworkId) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.personalArtworks.lists() });
+      invalidatePersonalArtworkLists(queryClient);
       queryClient.removeQueries({
         queryKey: queryKeys.personalArtworks.detail(personalArtworkId),
       });

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -397,6 +397,7 @@ export function MyPage() {
                 key={item.id}
                 item={item}
                 isArtistView={isArtistView}
+                showMenu={isArtistView}
                 onUnarchive={(artwork) => {
                   if (window.confirm('저장한 작품에서 삭제할까요?')) {
                     if (artwork.personalArtworkId) {

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -123,9 +123,12 @@ export function MyPage() {
       syncArtistViewWithVerification(isVerified);
     }
   }, [isVerified, syncArtistViewWithVerification]);
-  const archivedExhibitionsQuery = useArchivedExhibitions();
-  const archivedArtworksQuery = useInfiniteArchivedArtworks({ size: 20 });
-  const archivedArtistsQuery = useArchivedArtists();
+  const archivedExhibitionsQuery = useArchivedExhibitions({ enabled: !isArtistView });
+  const archivedArtworksQuery = useInfiniteArchivedArtworks(
+    { size: 20 },
+    { enabled: !isArtistView },
+  );
+  const archivedArtistsQuery = useArchivedArtists({ enabled: !isArtistView });
   const myArtistProfileQuery = useMyArtistProfile({
     enabled: isArtistView,
   });

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -238,6 +238,7 @@ export function MyPage() {
     ).map((item) => ({
       id: `exhibit-${item.artworkId}`,
       artworkId: item.artworkId,
+      displayId: item.displayId,
       title: item.artworkName,
       artist: item.artistName || artistName,
       thumbnail: item.artworkImageUrl ?? '',

--- a/src/pages/personal-artworks-register/PersonalArtworksRegister.tsx
+++ b/src/pages/personal-artworks-register/PersonalArtworksRegister.tsx
@@ -239,7 +239,7 @@ export function PersonalArtworksRegister() {
       updatePersonalArtwork.mutate(
         { personalArtworkId, body },
         {
-          onSuccess: () => navigate(`/personal-artworks/${personalArtworkId}`),
+          onSuccess: () => navigate(`/personal-artworks/${personalArtworkId}`, { replace: true }),
           onError: () => setSubmitError('작품 수정에 실패했어요. 잠시 후 다시 시도해주세요.'),
         },
       );

--- a/src/pages/personal-artworks-register/PersonalArtworksRegister.tsx
+++ b/src/pages/personal-artworks-register/PersonalArtworksRegister.tsx
@@ -2,17 +2,22 @@ import { useEffect, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { BottomFixedBar, ImageUploader } from '@/components/common';
 import { ChipGroup, ExhibitionHeader, RequiredLabel } from '@/components/ui';
 import {
   ARTWORK_FIELD_MAP,
+  ARTWORK_TYPE_LABEL_MAP,
   DEFAULT_ARTWORK_IMAGE_HEIGHT,
   DEFAULT_ARTWORK_IMAGE_WIDTH,
   MAX_PERSONAL_ARTWORK_IMAGES,
 } from '@/constants';
-import { useCreatePersonalArtwork } from '@/hooks/queries/usePersonalArtwork';
+import {
+  useCreatePersonalArtwork,
+  usePersonalArtwork,
+  useUpdatePersonalArtwork,
+} from '@/hooks/queries/usePersonalArtwork';
 import { useImageUpload } from '@/hooks/useImageUpload';
 import { usePersonalArtworkPolicy } from '@/hooks/usePolicy';
 import { hasPermission } from '@/utils/hasPermission';
@@ -29,8 +34,14 @@ const INPUT_CLASS =
 
 export function PersonalArtworksRegister() {
   const navigate = useNavigate();
-  const personalArtworkPolicy = usePersonalArtworkPolicy();
-  const canCreatePersonalArtwork = hasPermission(personalArtworkPolicy, 'create');
+  const [searchParams] = useSearchParams();
+  const personalArtworkId = Number(searchParams.get('id') ?? 0);
+  const isEditMode = Number.isFinite(personalArtworkId) && personalArtworkId > 0;
+  const { data: personalArtwork } = usePersonalArtwork(personalArtworkId);
+  const personalArtworkPolicy = usePersonalArtworkPolicy(personalArtwork);
+  const canSubmitPersonalArtwork = isEditMode
+    ? Boolean(personalArtwork) && hasPermission(personalArtworkPolicy, 'edit')
+    : hasPermission(personalArtworkPolicy, 'create');
 
   const artworkUpload = useImageUpload({
     domain: 'artwork',
@@ -56,6 +67,8 @@ export function PersonalArtworksRegister() {
   const [isMaterialTouched, setIsMaterialTouched] = useState(false);
   const [size, setSize] = useState('');
   const [thoughts, setThoughts] = useState('');
+  const [initialArtworkImages, setInitialArtworkImages] = useState<string[]>([]);
+  const [initialProcessImages, setInitialProcessImages] = useState<string[]>([]);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const {
     formState: { errors },
@@ -78,12 +91,15 @@ export function PersonalArtworksRegister() {
   });
 
   const createPersonalArtwork = useCreatePersonalArtwork();
+  const updatePersonalArtwork = useUpdatePersonalArtwork();
   /* 이미지 업로드는 mutation 시작 전에 실행되므로 제출 전 구간까지 함께 잠급니다. */
   const [isUploading, setIsUploading] = useState(false);
-  const isSubmitting = isUploading || createPersonalArtwork.isPending;
+  const isSubmitting =
+    isUploading || createPersonalArtwork.isPending || updatePersonalArtwork.isPending;
+  const artworkImageCount = initialArtworkImages.length + images.length;
 
   const formValue = {
-    artworkImageCount: images.length,
+    artworkImageCount,
     title,
     intro,
     field,
@@ -93,7 +109,7 @@ export function PersonalArtworksRegister() {
     thoughts,
   };
   const isFormValid =
-    canCreatePersonalArtwork && personalArtworkRegisterSchema.safeParse(formValue).success;
+    canSubmitPersonalArtwork && personalArtworkRegisterSchema.safeParse(formValue).success;
   const formError = personalArtworkRegisterSchema.safeParse(formValue).error;
   const getFormError = (fieldName: keyof PersonalArtworkRegisterFormValues) =>
     formError?.issues.find((issue) => issue.path[0] === fieldName)?.message;
@@ -105,10 +121,53 @@ export function PersonalArtworksRegister() {
     register('year');
   }, [register]);
 
+  useEffect(() => {
+    if (!isEditMode || !personalArtwork) return;
+
+    const artworkImages = personalArtwork.images
+      .filter((image) => image.imageType !== 'WORK_PROCESS')
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((image) => image.imageUrl);
+    const processImages = personalArtwork.images
+      .filter((image) => image.imageType === 'WORK_PROCESS')
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((image) => image.imageUrl);
+    const artworkTypeValues =
+      personalArtwork.types && personalArtwork.types.length > 0
+        ? personalArtwork.types
+        : personalArtwork.type.split(',');
+    const fieldLabels = artworkTypeValues
+      .map((type) => ARTWORK_TYPE_LABEL_MAP[type.trim()])
+      .filter((label): label is string => Boolean(label));
+    const nextField = fieldLabels.length > 0 ? fieldLabels.join(', ') : '기타';
+    const nextYear = String(personalArtwork.productionYear || '');
+
+    // 수정 모드에서는 서버 응답을 등록 폼 상태로 한 번 옮겨 담습니다.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setInitialArtworkImages(artworkImages);
+    setInitialProcessImages(processImages);
+    setTitle(personalArtwork.artworkName ?? '');
+    setIntro(personalArtwork.content ?? '');
+    setField(nextField);
+    setYear(nextYear);
+    setMaterial(personalArtwork.materialMedia ?? '');
+    setSize(personalArtwork.size ?? '');
+    setThoughts(personalArtwork.point ?? '');
+
+    setValue('artworkImageCount', artworkImages.length, { shouldValidate: true });
+    setValue('title', personalArtwork.artworkName ?? '', { shouldValidate: true });
+    setValue('intro', personalArtwork.content ?? '', { shouldValidate: true });
+    setValue('field', nextField, { shouldValidate: true });
+    setValue('year', nextYear, { shouldValidate: true });
+    setValue('material', personalArtwork.materialMedia ?? '', { shouldValidate: true });
+    setValue('size', personalArtwork.size ?? '', { shouldValidate: true });
+    setValue('thoughts', personalArtwork.point ?? '', { shouldValidate: true });
+  }, [isEditMode, personalArtwork, setValue]);
+
   /* 이미지를 업로드한 뒤 작품을 등록합니다. */
   const handleSubmit = async () => {
     const parsed = personalArtworkRegisterSchema.safeParse(formValue);
-    if (!canCreatePersonalArtwork || !parsed.success || isSubmitting) return;
+    if (!canSubmitPersonalArtwork || !parsed.success || isSubmitting) return;
 
     setSubmitError(null);
 
@@ -146,50 +205,74 @@ export function PersonalArtworksRegister() {
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
-    const artworkType =
-      selectedFieldLabels
-        .map((label) => ARTWORK_FIELD_MAP[label])
-        .filter((val): val is string => Boolean(val))
-        .join(',') || ARTWORK_FIELD_MAP['기타'];
+    const artworkTypes = Array.from(
+      new Set(
+        selectedFieldLabels
+          .map((label) => ARTWORK_FIELD_MAP[label])
+          .filter((val): val is string => Boolean(val)),
+      ),
+    ).slice(0, 2);
+    const artworkType = artworkTypes[0] ?? ARTWORK_FIELD_MAP['기타'];
 
-    createPersonalArtwork.mutate(
-      {
-        artworkName: title.trim(),
-        content: intro.trim(),
-        type: artworkType,
-        productionYear: toPersonalArtworkProductionYear(year),
-        materialMedia: material.trim(),
-        size: size.trim(),
-        point: thoughts.trim(),
-        images: [
-          ...artworkImageUrls.map((url, index) => toImage(url, index, 'ARTWORK')),
-          ...processImageUrls.map((url, index) => toImage(url, index, 'WORK_PROCESS')),
-        ],
-      },
-      {
-        onSuccess: () =>
-          navigate('/personal-artworks/complete', {
-            state: { type: 'personalArtwork' },
-          }),
-        onError: () => setSubmitError('작품 등록에 실패했어요. 잠시 후 다시 시도해주세요.'),
-      },
-    );
+    const body = {
+      artworkName: title.trim(),
+      content: intro.trim(),
+      type: artworkType,
+      types: artworkTypes.length > 0 ? artworkTypes : [artworkType],
+      productionYear: toPersonalArtworkProductionYear(year),
+      materialMedia: material.trim(),
+      size: size.trim(),
+      point: thoughts.trim(),
+      images: [
+        ...initialArtworkImages.map((url, index) => toImage(url, index, 'ARTWORK')),
+        ...artworkImageUrls.map((url, index) =>
+          toImage(url, initialArtworkImages.length + index, 'ARTWORK'),
+        ),
+        ...initialProcessImages.map((url, index) => toImage(url, index, 'WORK_PROCESS')),
+        ...processImageUrls.map((url, index) =>
+          toImage(url, initialProcessImages.length + index, 'WORK_PROCESS'),
+        ),
+      ],
+    };
+
+    if (isEditMode) {
+      updatePersonalArtwork.mutate(
+        { personalArtworkId, body },
+        {
+          onSuccess: () => navigate(`/personal-artworks/${personalArtworkId}`),
+          onError: () => setSubmitError('작품 수정에 실패했어요. 잠시 후 다시 시도해주세요.'),
+        },
+      );
+      return;
+    }
+
+    createPersonalArtwork.mutate(body, {
+      onSuccess: () =>
+        navigate('/personal-artworks/complete', {
+          state: { type: 'personalArtwork' },
+        }),
+      onError: () => setSubmitError('작품 등록에 실패했어요. 잠시 후 다시 시도해주세요.'),
+    });
   };
 
   return (
     <div className="mx-auto min-h-dvh w-96 bg-page">
-      <ExhibitionHeader title="작품 등록" />
+      <ExhibitionHeader title={isEditMode ? '작품 수정' : '작품 등록'} />
 
       <main>
         <div className="flex flex-col gap-6 px-5 pb-bottom-bar-offset">
           <div className="self-stretch flex justify-center">
             <ImageUploader
               images={images}
+              initialImages={initialArtworkImages}
               maxImages={MAX_PERSONAL_ARTWORK_IMAGES}
               padded
               className="[justify-content:safe_center]"
               onAddImages={addImages}
               onRemoveImage={removeImage}
+              onRemoveInitialImage={(url) =>
+                setInitialArtworkImages((prev) => prev.filter((imageUrl) => imageUrl !== url))
+              }
               emptyLabel="이미지 업로드"
             />
           </div>
@@ -342,9 +425,13 @@ export function PersonalArtworksRegister() {
             <RequiredLabel>작품과정</RequiredLabel>
             <ImageUploader
               images={processImages}
+              initialImages={initialProcessImages}
               maxImages={MAX_PERSONAL_ARTWORK_IMAGES}
               onAddImages={addProcessImages}
               onRemoveImage={removeProcessImage}
+              onRemoveInitialImage={(url) =>
+                setInitialProcessImages((prev) => prev.filter((imageUrl) => imageUrl !== url))
+              }
               emptyLabel="작업과정 업로드"
             />
           </div>
@@ -378,7 +465,7 @@ export function PersonalArtworksRegister() {
           onClick={handleSubmit}
           className="w-full h-11 py-3 bg-dark rounded-xl typo-body-sm-bold text-card inline-flex justify-center items-center gap-1.5 disabled:opacity-40"
         >
-          {isSubmitting ? '등록 중' : '완료'}
+          {isSubmitting ? (isEditMode ? '수정 중' : '등록 중') : '완료'}
         </button>
       </BottomFixedBar>
     </div>

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -24,6 +24,7 @@ export interface SavedArtworkItem {
   archiveWorkId?: number;
   artworkId?: number | null;
   personalArtworkId?: number | null;
+  displayId?: number | null;
   userId?: number;
   title: string;
   artist: string;


### PR DESCRIPTION
## 📝 작업 내용

- 개인 전시작 카드 우상단 메뉴 버튼을 추가했습니다.
- 개인 전시작 삭제 확인을 기본 confirm 대신 서비스 공통 톤의 모달로 교체했습니다.
- 개인 전시작 삭제 API를 모달 확인 액션에 연결했습니다.
- 개인 전시작 수정 진입 시 작품 등록 페이지를 수정 모드로 재사용하도록 했습니다.
- 수정 페이지에서 기존 작품 정보와 이미지 초기값을 표시하도록 보정했습니다.
- 수정 완료 시 PATCH `/v1/personal-artworks/{personalArtworkId}`를 호출하도록 연결했습니다.
- `type`은 단일 enum, `types`는 enum 배열로 전송하도록 payload를 정리했습니다.
- 상세 응답의 `types` 배열을 작품 분야 초기값에 반영했습니다.
- 개인 작품 등록/수정/삭제 성공 후 내 작품 목록 query key까지 invalidate하도록 보강했습니다.
- 전시 등록 작품 카드에는 `작업 페이지 바로가기` 메뉴를 표시하고 `/exhibition/{displayId}/work`로 이동하도록 했습니다.
- 개인 전시작 수정 완료 후 작품 상세로 이동할 때 history를 replace하여 상세 화면의 뒤로가기 버튼이 수정 페이지로 되돌아가지 않도록 했습니다.
- 작가 뷰에서는 저장 아카이브 목록 API를 불필요하게 호출하지 않도록 query enabled 조건을 분리했습니다.

## 🔍 관련 이슈

-close #312

## 🖼️ 스크린샷

- 개인 전시작 카드 우상단 메뉴 버튼
- 수정/삭제 메뉴
- 작품 삭제 확인 모달
- 전시 등록 작품의 작업 페이지 바로가기 메뉴

## 🧪 테스트 결과

- [x] `pnpm -s tsc -b --pretty false`
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- `/api/v1/archives/artworks` 500은 스웨거 기준 프론트 요청 파라미터(`size`, `cursorId`) 문제는 아닌 것으로 확인했습니다.
- 작가 뷰에서 해당 아카이브 API가 불필요하게 호출되지 않도록 프론트 호출 조건을 먼저 제한했습니다.
- 개인 전시작 수정 API의 enum 값은 스웨거와 일치하도록 `type`/`types`를 분리해 전송합니다.
