### PR TITLE
fix: 마이페이지 작품 카드 메모 영역 정렬

### DIFF
--- a/src/components/mypage/ArtworkCard.tsx
+++ b/src/components/mypage/ArtworkCard.tsx
@@ -81,7 +81,7 @@ export function ArtworkCard({
 
       {!isArtistView && (
         <MemoFooter
-          className="px-2.5 py-2"
+          className="mt-auto px-2.5 py-2"
           memo={item.memo}
           userId={item.userId}
           onSave={(memo) => onSaveMemo?.(item, memo)}

--- a/src/components/mypage/ExhibitionCard.tsx
+++ b/src/components/mypage/ExhibitionCard.tsx
@@ -98,7 +98,7 @@ export function ExhibitionCard({
 
       {!isArtistView && (
         <MemoFooter
-          className="px-4 py-2"
+          className="mt-auto px-4 py-2"
           memo={item.memo}
           userId={item.userId}
           onSave={(memo) => onSaveMemo?.(item, memo)}

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -213,7 +213,7 @@ export function MyPage() {
       artworkId: item.artworkId,
       personalArtworkId: item.personalArtworkId,
       userId: item.userId ?? userData?.id,
-      title: item.artworkName ?? item.title ?? item.artworkTitle ?? '작품',
+      title: item.artworkName ?? item.title ?? item.artworkTitle ?? '',
       artist: item.artist ?? item.artistName ?? '',
       thumbnail: getImageUrl(item),
       memo: item.memo ?? undefined,


### PR DESCRIPTION
## 📝 작업 내용

- 마이페이지 작품/전시 카드의 `MemoFooter`가 카드 하단에 붙도록 스타일을 수정했습니다.
- 저장한 작품 목록에서 작품명이 없는 경우 기본 문구 대신 빈 문자열로 표시되도록 수정했습니다.

## 🔍 관련 이슈

- close #318

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

`pnpm -s tsc -b --pretty false`

## 💬 기타 참고 사항

- 없음