### PR TITLE
feat: [iOS/Safari] <input />의 focus 확대 방지하기

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -46,3 +46,11 @@
       100% 0%;
   }
 }
+
+/* iOS Safari input focus auto-zoom prevention */
+input,
+select,
+textarea {
+  font-size: 16px !important;
+}
+


### PR DESCRIPTION
## 📝 작업 내용

- iOS/Safari 브라우저에서 `input`, `select`, `textarea` 포커스 시 화면이 자동으로 확대(Focus Zoom)되는 현상을 방지하는 전역 스타일을 추가하였습니다.
- 폰트 크기가 16px 미만일 때 발생하는 브라우저의 기본 동작을 해결하기 위해, 전역 스타일에서 해당 요소들의 최소 `font-size`를 `16px`로 지정하였습니다.

## 🔍 관련 이슈

- #332

## 🖼️ 스크린샷

- 모바일 기기(iOS Safari)에서 input 포커스 시 화면 전체가 확대되지 않고 폼 입력창만 정상적으로 포커스 인 되는 것을 테스트 완료하였습니다.

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 평상시와 활성화 시점 모두 폰트 크기를 `16px`로 고정함으로써 포커스 시 글자가 튀는 현상(레이아웃 시프트)과 Safari 크로스 브라우징 오작동을 원천 방지하였습니다.
