### PR TITLE
fix: 소모임·동아리 전시 및 연합 전시의 스키마 그룹 불일치 해결

### DIFF
--- a/src/pages/exhibition-register/exhibitionRegister.schema.ts
+++ b/src/pages/exhibition-register/exhibitionRegister.schema.ts
@@ -49,7 +49,7 @@ export const exhibitionRegisterSchema = z
       data.type === '졸업 전시' ||
       data.type === '과제 전시' ||
       data.type === '학과·학회 전시' ||
-      data.type === '연합 전시';
+      data.type === '소모임·동아리 전시';
 
     if (isInstitution && !data.department) {
       ctx.addIssue({
@@ -59,7 +59,7 @@ export const exhibitionRegisterSchema = z
       });
     }
 
-    const isOrganization = data.type === '소모임·동아리 전시' || data.type === '기타 단체 전시';
+    const isOrganization = data.type === '연합 전시' || data.type === '기타 단체 전시';
 
     if (isOrganization && !data.organizer) {
       ctx.addIssue({


### PR DESCRIPTION
## 📝 작업 내용

- `'소모임·동아리 전시'`와 `'연합 전시'`의 Zod 유효성 검사 그룹 불일치 버그를 수정하였습니다.
- `constants/exhibition.ts`에서 `'소모임·동아리 전시'`는 `institution` 그룹, `'연합 전시'`는 `organization` 그룹으로 매핑되어 있으나, `exhibitionRegister.schema.ts`의 스키마 파일에서는 두 타입이 서로 뒤바뀌어 검사 로직이 작동하는 오류를 수정하였습니다.

## 🔍 관련 이슈

- #334

## 🖼️ 스크린샷

- '소모임·동아리 전시'를 선택했을 때 대학/학과 입력 폼만 나타나고, 입력 완료 시 '다음' 버튼이 정상 활성화되는 것을 검증하였습니다.

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 스키마 파일의 `isInstitution`과 `isOrganization` 조건 분기 목록의 정합성이 상수의 `group` 정보와 정확히 일치하게 되었습니다.
