### PR TITLE
fix: 전시작 등록 시 작품분야 types를 배열로 전달하도록 수정

### DIFF
--- a/src/api/dto/displayArtwork.dto.ts
+++ b/src/api/dto/displayArtwork.dto.ts
@@ -357,6 +357,7 @@ export interface CreateExhibitionArtworkRequestDto {
   artworkName: string;
   content: string;
   type: string;
+  types?: string[];
   productionYear: number;
   materialMedia: string;
   size: string;
@@ -375,6 +376,7 @@ export interface CreateExhibitionArtworkResponseDataDto {
   artworkName: string;
   content: string;
   type: string;
+  types?: string[];
   productionYear: number;
   materialMedia: string;
   size: string;

--- a/src/pages/artwork-register/ArtworkRegisterPage.tsx
+++ b/src/pages/artwork-register/ArtworkRegisterPage.tsx
@@ -756,12 +756,16 @@ function ArtworkRegisterPageContent() {
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
-    const artworkType = selectedFieldLabels
-      .map((label) => ARTWORK_FIELD_MAP[label])
-      .filter((val): val is string => Boolean(val))
-      .join(',');
+    const artworkTypes = Array.from(
+      new Set(
+        selectedFieldLabels
+          .map((label) => ARTWORK_FIELD_MAP[label])
+          .filter((val): val is string => Boolean(val)),
+      ),
+    ).slice(0, 2);
+    const artworkType = artworkTypes[0] ?? ARTWORK_FIELD_MAP['기타'];
 
-    if (!artworkType) {
+    if (artworkTypes.length === 0) {
       setSubmitError('작품분야를 선택해주세요.');
       return;
     }
@@ -772,6 +776,7 @@ function ArtworkRegisterPageContent() {
         artworkName: title.trim(),
         content: description.trim(),
         type: artworkType,
+        types: artworkTypes.length > 0 ? artworkTypes : [artworkType],
         productionYear: toArtworkRegisterProductionYear(year),
         materialMedia: medium.trim(),
         size: size.trim(),


### PR DESCRIPTION
## 📝 작업 내용

- 전시작 등록 (`POST /api/v1/artworks`) 시 작품 분야(`types`)를 단일 문자열이 아닌 배열 포맷(`string[]`)으로 전송하도록 수정하였습니다.
- `CreateExhibitionArtworkRequestDto` 및 `CreateExhibitionArtworkResponseDataDto` DTO 인터페이스에 `types?: string[]` 타입을 추가하였습니다.
- `ArtworkRegisterPage.tsx`에서 전시작 등록 페이로드 구성 시 `types` 필드를 2개 이하의 문자열 배열로 빌드하여 전송하도록 변경하였습니다.

## 🔍 관련 이슈

- close #336

## 🖼️ 스크린샷

- N/A (데이터 포맷 수정 건)

## 🧪 테스트 결과

- [x] 정상 작동 확인 (타입 에러 없이 컴파일 확인)
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 기존에 존재하는 개인 작품 등록 로직(`PersonalArtworksRegister.tsx`)의 `types` 배열 변환 방식과 스펙을 맞춰 데이터 일관성을 확보하였습니다.
