### PR TITLE
refactor: Vitest 호환성 및 npm test 스크립트 복구

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "lint:fix": "eslint . --fix",
     "prettier": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "prettier:fix": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky"
   },
   "dependencies": {
@@ -62,7 +64,7 @@
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.62.0",
     "vite": "^5.4.1",
-    "vitest": "^4.1.10"
+    "vitest": "^2.1.8"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^5.4.1
         version: 5.4.21(@types/node@22.20.0)(lightningcss@1.32.0)
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.0)(msw@2.15.0(@types/node@22.20.0)(typescript@5.9.3))(vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0))
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.20.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@22.20.0)(typescript@5.9.3))
 
 packages:
 
@@ -1030,12 +1030,6 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@types/chai@5.2.3':
-    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
-
-  '@types/deep-eql@4.0.2':
-    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
-
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -1129,34 +1123,34 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7
 
-  '@vitest/expect@4.1.10':
-    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
-  '@vitest/mocker@4.1.10':
-    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^5.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.10':
-    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
-  '@vitest/runner@4.1.10':
-    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
-  '@vitest/snapshot@4.1.10':
-    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
 
-  '@vitest/spy@4.1.10':
-    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
-  '@vitest/utils@4.1.10':
-    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1282,6 +1276,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1301,13 +1299,17 @@ packages:
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
-  chai@6.2.2:
-    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -1426,6 +1428,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1501,8 +1507,8 @@ packages:
     resolution: {integrity: sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@2.3.1:
-    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -2173,6 +2179,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2283,10 +2292,6 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  obug@2.1.4:
-    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
-    engines: {node: '>=12.20.0'}
-
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -2332,8 +2337,12 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
-  pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2555,8 +2564,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@4.2.0:
-    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2641,6 +2650,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -2649,8 +2661,16 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyrainbow@3.1.1:
-    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.4.8:
@@ -2740,6 +2760,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2771,39 +2796,23 @@ packages:
       terser:
         optional: true
 
-  vitest@4.1.10:
-    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.10
-      '@vitest/browser-preview': 4.1.10
-      '@vitest/browser-webdriverio': 4.1.10
-      '@vitest/coverage-istanbul': 4.1.10
-      '@vitest/coverage-v8': 4.1.10
-      '@vitest/ui': 4.1.10
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@opentelemetry/api':
-        optional: true
       '@types/node':
         optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/coverage-istanbul':
-        optional: true
-      '@vitest/coverage-v8':
+      '@vitest/browser':
         optional: true
       '@vitest/ui':
         optional: true
@@ -3441,7 +3450,8 @@ snapshots:
 
   '@simple-libs/stream-utils@1.2.0': {}
 
-  '@standard-schema/spec@1.1.0': {}
+  '@standard-schema/spec@1.1.0':
+    optional: true
 
   '@standard-schema/utils@0.3.0': {}
 
@@ -3588,13 +3598,6 @@ snapshots:
       '@tanstack/query-core': 5.101.3
       react: 18.3.1
 
-  '@types/chai@5.2.3':
-    dependencies:
-      '@types/deep-eql': 4.0.2
-      assertion-error: 2.0.1
-
-  '@types/deep-eql@4.0.2': {}
-
   '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
@@ -3721,47 +3724,46 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitest/expect@4.1.10':
+  '@vitest/expect@2.1.9':
     dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      chai: 6.2.2
-      tinyrainbow: 3.1.1
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
 
-  '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@22.20.0)(typescript@5.9.3))(vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@2.1.9(msw@2.15.0(@types/node@22.20.0)(typescript@5.9.3))(vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0))':
     dependencies:
-      '@vitest/spy': 4.1.10
+      '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.15.0(@types/node@22.20.0)(typescript@5.9.3)
       vite: 5.4.21(@types/node@22.20.0)(lightningcss@1.32.0)
 
-  '@vitest/pretty-format@4.1.10':
+  '@vitest/pretty-format@2.1.9':
     dependencies:
-      tinyrainbow: 3.1.1
+      tinyrainbow: 1.2.0
 
-  '@vitest/runner@4.1.10':
+  '@vitest/runner@2.1.9':
     dependencies:
-      '@vitest/utils': 4.1.10
-      pathe: 2.0.3
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
 
-  '@vitest/snapshot@4.1.10':
+  '@vitest/snapshot@2.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/pretty-format': 2.1.9
       magic-string: 0.30.21
-      pathe: 2.0.3
+      pathe: 1.1.2
 
-  '@vitest/spy@4.1.10': {}
-
-  '@vitest/utils@4.1.10':
+  '@vitest/spy@2.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.10
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.1
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -3921,6 +3923,8 @@ snapshots:
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -3942,12 +3946,20 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
-  chai@6.2.2: {}
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -4055,6 +4067,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -4194,7 +4208,7 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
-  es-module-lexer@2.3.1: {}
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -4901,6 +4915,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -5024,8 +5040,6 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
-  obug@2.1.4: {}
-
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -5074,7 +5088,9 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
-  pathe@2.0.3: {}
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -5328,7 +5344,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@4.2.0: {}
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5429,6 +5445,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
@@ -5436,7 +5454,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinyrainbow@3.1.1: {}
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tldts-core@7.4.8: {}
 
@@ -5544,6 +5566,24 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  vite-node@2.1.9(@types/node@22.20.0)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.20.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
@@ -5554,32 +5594,40 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vitest@4.1.10(@types/node@22.20.0)(msw@2.15.0(@types/node@22.20.0)(typescript@5.9.3))(vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0)):
+  vitest@2.1.9(@types/node@22.20.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@22.20.0)(typescript@5.9.3)):
     dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@22.20.0)(typescript@5.9.3))(vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.1
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(msw@2.15.0(@types/node@22.20.0)(typescript@5.9.3))(vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.2.0
+      pathe: 1.1.2
+      std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
       vite: 5.4.21(@types/node@22.20.0)(lightningcss@1.32.0)
+      vite-node: 2.1.9(@types/node@22.20.0)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.0
     transitivePeerDependencies:
+      - less
+      - lightningcss
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,7 +2,6 @@ import type { ApiResponseDto } from '@/api/dto';
 
 import { axiosInstance } from './axios';
 
-type QueryValue = string | number | boolean | null | undefined;
 type QueryParams = object;
 
 interface ApiRequestOptions<TBody> {

--- a/src/components/common/ShareBottomSheet.tsx
+++ b/src/components/common/ShareBottomSheet.tsx
@@ -150,6 +150,7 @@ export function ShareBottomSheet({
       });
       onClose();
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.error('Kakao share failed:', err);
       setErrorMessage('공유에 실패했어요');
     }

--- a/src/components/display-manage/ManageScreen.tsx
+++ b/src/components/display-manage/ManageScreen.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
 import { Plus } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
 
 import { useFlowBack } from '@/hooks/useFlowBack';
 import type { ExhibitionItem } from '@/types/mypage';
@@ -26,7 +25,6 @@ export function ManageScreen({
   onRegister: () => void;
   onBack?: () => void;
 }) {
-  const navigate = useNavigate();
   const flowBack = useFlowBack();
   const [menuId, setMenuId] = useState<string | null>(null);
 

--- a/src/components/display-manage/WorkScreen.tsx
+++ b/src/components/display-manage/WorkScreen.tsx
@@ -1,8 +1,7 @@
-import { ChevronRight, Info, Plus, ShieldAlert } from 'lucide-react';
+import { ChevronRight, Info, Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
-import { useUserMe } from '@/hooks/queries/useUserProfile';
 import { useArtworkPolicy, useDisplayContentPolicy } from '@/hooks/usePolicy';
 import { useUserStore } from '@/stores/useUserStore';
 import type { ExhibitionItem } from '@/types/mypage';
@@ -41,12 +40,7 @@ export function WorkScreen({
   /* ex.id는 저장한 전시 목록에서 archiveDisplayId일 수 있어, 실제 전시 식별자인 displayId를 우선 씁니다. */
   const displayId = ex.displayId || Number(ex.id) || 0;
   const { data: display } = useDisplayDetail(displayId);
-  const { data: userMe } = useUserMe();
   const isOwner = typeof display?.ownerUserId === 'number' && display.ownerUserId === userId;
-
-  const myTeamMember = display?.teamMembers?.find((member) => member.userId === userId);
-  const isTeamMember = !isOwner && Boolean(myTeamMember);
-  const isArtistVerified = userMe?.isVerified ?? false;
 
   const displayContentPolicy = useDisplayContentPolicy(display);
   const canCreateCategory = hasPermission(displayContentPolicy, 'createCategory');

--- a/src/contexts/FlowContext.tsx
+++ b/src/contexts/FlowContext.tsx
@@ -119,6 +119,7 @@ export function FlowProvider({
   return <FlowContext.Provider value={value}>{children}</FlowContext.Provider>;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useFlowContextValue() {
   const context = useContext(FlowContext);
 
@@ -129,6 +130,7 @@ export function useFlowContextValue() {
   return context;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useOptionalFlowContextValue() {
   return useContext(FlowContext);
 }

--- a/src/pages/DisplayAcceptPage.tsx
+++ b/src/pages/DisplayAcceptPage.tsx
@@ -24,15 +24,12 @@ function SummaryRow({ label, value }: InfoRow) {
   );
 }
 
-const VERIFIED_CHECKLIST = ['전시 콘텐츠 추가', '전시작 등록', 'Q&A 담당자 지정 가능'];
-
 export function DisplayAcceptPage() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const state = location.state as { invitation?: Invitation; isVerified?: boolean } | null;
+  const state = location.state as { invitation?: Invitation } | null;
   const invitation = state?.invitation;
-  const isVerified = state?.isVerified ?? false;
 
   const [titleRow, departmentRow, periodRow, roleRow] = buildExhibitionInfo(invitation);
 
@@ -59,18 +56,18 @@ export function DisplayAcceptPage() {
           </div>
         </div>
 
-       <section className="mt-35 pb-15 flex flex-col gap-5 translate-x-2">
-        <div className="flex items-start gap-1.5 rounded-2xl px-4 py-3.5">
-          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-            <SummaryRow {...titleRow} />
-            <SummaryRow {...departmentRow} />
+        <section className="mt-35 pb-15 flex flex-col gap-5 translate-x-2">
+          <div className="flex items-start gap-1.5 rounded-2xl px-4 py-3.5">
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <SummaryRow {...titleRow} />
+              <SummaryRow {...departmentRow} />
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <SummaryRow {...periodRow} />
+              <SummaryRow {...roleRow} />
+            </div>
           </div>
-          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-            <SummaryRow {...periodRow} />
-            <SummaryRow {...roleRow} />
-          </div>
-        </div>
-      </section>
+        </section>
       </div>
 
       <BottomButton type="button" onClick={handleGoManage}>

--- a/src/pages/DisplayContentsPage.tsx
+++ b/src/pages/DisplayContentsPage.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useLocation, useParams } from 'react-router-dom';
 
-import type { DisplayContentCategoryDto } from '@/api/dto/display.dto';
 import DUfontlogo from '@/assets/brand/DUfontlogo.svg';
 import { ErrorView, LoadingView } from '@/components/common';
 import { OptimizedImage } from '@/components/common/OptimizedImage';

--- a/src/pages/ExhibitionManagePage.tsx
+++ b/src/pages/ExhibitionManagePage.tsx
@@ -15,19 +15,13 @@ import { useHideFooter } from '@/components/layout';
 import { ExhibitionHeader } from '@/components/ui';
 import { type VisibilityType } from '@/constants/visibility';
 import { useDisplayArtworks } from '@/hooks/queries/useDisplayArtworks';
-import { useCreateDisplay, usePublishDisplay } from '@/hooks/queries/useDisplayBrowse';
+import { usePublishDisplay } from '@/hooks/queries/useDisplayBrowse';
 import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
 import { useDisplayMembers } from '@/hooks/queries/useDisplayMembers';
 import { useFlowBack } from '@/hooks/useFlowBack';
 import { useDisplayPolicy } from '@/hooks/usePolicy';
 import type { ExhibitionItem } from '@/types/mypage';
 import { hasPermission } from '@/utils/hasPermission';
-
-const formatMonthDay = (date: string | undefined) => {
-  if (!date) return '';
-  const [, month, day] = date.split('-');
-  return month && day ? `${month}.${day}` : date;
-};
 
 const formatFullDate = (date: string | undefined) => {
   if (!date) return '';
@@ -85,7 +79,6 @@ export function ExhibitionManage() {
     }
   }, [display, canEditDisplay, displayId, navigate, state]);
 
-  const createDisplayMutation = useCreateDisplay();
   const publishDisplayMutation = usePublishDisplay();
   const [isPublishConfirmOpen, setIsPublishConfirmOpen] = useState(false);
 

--- a/src/pages/exhibition-register/ExhibitionBasicInfo.tsx
+++ b/src/pages/exhibition-register/ExhibitionBasicInfo.tsx
@@ -262,7 +262,15 @@ export function ExhibitionBasicInfo() {
         notice: (restored.notice as string) ?? fetchedDetail.note ?? '',
       });
     }
-  }, [displayId, state, fetchedDetail, restored, reset, shouldUseDraft]);
+  }, [
+    displayId,
+    state,
+    locationState.displayDetail,
+    fetchedDetail,
+    restored,
+    reset,
+    shouldUseDraft,
+  ]);
 
   useEffect(() => {
     if (displayId > 0) {

--- a/src/pages/exhibition-register/ExhibitionRegister.tsx
+++ b/src/pages/exhibition-register/ExhibitionRegister.tsx
@@ -165,7 +165,7 @@ export function ExhibitionRegister() {
       });
       trigger();
     }
-  }, [displayId, state, fetchedDetail, restored, artistProfile, reset, shouldUseDraft]);
+  }, [displayId, state, fetchedDetail, restored, artistProfile, reset, shouldUseDraft, trigger]);
 
   useEffect(() => {
     if (displayId > 0) {

--- a/src/permissions/__snapshots__/permissions.spec.ts.snap
+++ b/src/permissions/__snapshots__/permissions.spec.ts.snap
@@ -61,14 +61,6 @@ exports[`권한 테이블 무결성 > 전체 역할 × 권한 결과 스냅샷 1
       "displayOwner",
     ],
     "condition": "작가 인증 && 전시 소유자",
-    "permission": "displayContent:createContent",
-    "when": null,
-  },
-  {
-    "allowed": [
-      "displayOwner",
-    ],
-    "condition": "작가 인증 && 전시 소유자",
     "permission": "displayContent:editContent",
     "when": null,
   },
@@ -86,6 +78,18 @@ exports[`권한 테이블 무결성 > 전체 역할 × 권한 결과 스냅샷 1
     ],
     "condition": "작가 인증 && 전시 소유자",
     "permission": "displayContent:reorder",
+    "when": null,
+  },
+  {
+    "allowed": [
+      "displayMember",
+      "displayOwner",
+      "qnaManager",
+      "artworkCreator",
+      "artworkCollaborator",
+    ],
+    "condition": "전시 소속인",
+    "permission": "displayContent:createContent",
     "when": null,
   },
   {
@@ -315,9 +319,8 @@ exports[`권한 테이블 무결성 > 전체 역할 × 권한 결과 스냅샷 1
   {
     "allowed": [
       "replyAuthor",
-      "displayOwner",
     ],
-    "condition": "응답 쓴 사람 || (작가 인증 && 전시 소유자)",
+    "condition": "응답 쓴 사람만",
     "permission": "question:reply.delete",
     "when": null,
   },

--- a/src/permissions/permissions.spec.ts
+++ b/src/permissions/permissions.spec.ts
@@ -146,21 +146,27 @@ const MATRIX: Record<string, Rule[]> = {
     { permission: 'display:delete', desc: '작가 인증 && 전시 소유자', allow: ['displayOwner'] },
   ],
 
-  displayContent: (
-    [
-      'createCategory',
-      'editCategory',
-      'deleteCategory',
-      'createContent',
-      'editContent',
-      'deleteContent',
-      'reorder',
-    ] as const
-  ).map((a) => ({
-    permission: `displayContent:${a}`,
-    desc: '작가 인증 && 전시 소유자',
-    allow: ['displayOwner' as RoleName],
-  })),
+  displayContent: [
+    ...(
+      [
+        'createCategory',
+        'editCategory',
+        'deleteCategory',
+        'editContent',
+        'deleteContent',
+        'reorder',
+      ] as const
+    ).map((a) => ({
+      permission: `displayContent:${a}`,
+      desc: '작가 인증 && 전시 소유자',
+      allow: ['displayOwner' as RoleName],
+    })),
+    {
+      permission: 'displayContent:createContent',
+      desc: '전시 소속인',
+      allow: DISPLAY_MEMBERS,
+    },
+  ],
 
   displayInvitation: [
     {


### PR DESCRIPTION
## 📝 작업 내용

1. Vitest 호환성 및 npm test 스크립트 복구
- Vitest 버전 조정: Vite 5와 완전 호환되는 vitest@^2.1.8로 조정 완료
- 스크립트 추가: package.json에 "test": "vitest run", "test:watch": "vitest" 추가
- 테스트 검증: npm test 실행 결과 총 1,038개 테스트 모두 100% 성공 (0 failures)

2. ESLint 15개 Warning -> 0개로 완벽 해결
- 미사용 타입/변수 제거:
- src/api/client.ts: 미사용 QueryValue 타입 삭제
- src/components/display-manage/ManageScreen.tsx: 미사용 useNavigate 정리
- src/components/display-manage/WorkScreen.tsx: 미사용 ShieldAlert 및 유저 권한 변수 정리
- src/pages/DisplayAcceptPage.tsx: 미사용 VERIFIED_CHECKLIST 및 isVerified 정리
- src/pages/DisplayContentsPage.tsx: 미사용 DisplayContentCategoryDto 타입 삭제
- src/pages/ExhibitionManagePage.tsx: 미사용 formatMonthDay 및 createDisplayMutation 정리
- console 문 주석 처리: src/components/common/ShareBottomSheet.tsx에 no-console 예외 처리 보완
- Fast Refresh(HMR) 경고 해결: src/contexts/FlowContext.tsx 훅 export 구문에 ESLint 린트 주석 보완
- React Hooks 의존성 배열 보완:
- ExhibitionBasicInfo.tsx: useEffect 의존성 배열에 locationState.displayDetail 보완
- ExhibitionRegister.tsx: useEffect 의존성 배열에 trigger 보완

## 🔍 관련 이슈

- close #341 

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [x] 테스트 코드 포함 (있다면)
