### PR TITLE
fix: 대표자가 아닌 일반 팀원의 전시 콘텐츠 삭제(X) 버튼 비활성화

### DIFF
--- a/src/api/dto/display.dto.ts
+++ b/src/api/dto/display.dto.ts
@@ -186,6 +186,7 @@ export interface DisplayContentDto {
   width: number;
   height: number;
   sortOrder: number;
+  userId: number;
 }
 
 export interface DisplayContentCategoryDto {

--- a/src/hooks/usePolicy.ts
+++ b/src/hooks/usePolicy.ts
@@ -104,6 +104,7 @@ export function useDisplayCreatePolicy(): PermissionMap<'create'> {
 
 export function useDisplayContentPolicy(
   display?: DisplayPolicyResource,
+  content?: UserOwnedResource,
 ): PolicyPermissionMap<'displayContent'> {
   const user = useCurrentPolicyUser();
 
@@ -116,10 +117,11 @@ export function useDisplayContentPolicy(
         display ? policies.displayContent.deleteCategory(user, display) : false,
       createContent: () => (display ? policies.displayContent.createContent(user, display) : false),
       editContent: () => (display ? policies.displayContent.editContent(user, display) : false),
-      deleteContent: () => (display ? policies.displayContent.deleteContent(user, display) : false),
+      deleteContent: () =>
+        display ? policies.displayContent.deleteContent(user, display, content) : false,
       reorder: () => (display ? policies.displayContent.reorder(user, display) : false),
     }),
-    [user, display],
+    [user, display, content],
   );
 }
 

--- a/src/mocks/data/repository.ts
+++ b/src/mocks/data/repository.ts
@@ -118,6 +118,7 @@ const displayToDetail = (display: (typeof MOCK_DISPLAY_DETAILS)[number]) => ({
       width: 1600,
       height: 1600,
       sortOrder: imageIndex + 1,
+      userId: 1,
     })),
   })),
   artworks: display.artworkSection.artworks.map((artwork, index) => ({

--- a/src/mocks/handlers/displayContent.ts
+++ b/src/mocks/handlers/displayContent.ts
@@ -61,6 +61,7 @@ export const displayContentHandlers = [
         width: body.width ?? 1600,
         height: body.height ?? 1600,
         sortOrder: (category?.contents.length ?? 0) + 1,
+        userId: mockDb.me.userId,
       };
       category?.contents.push(content);
 

--- a/src/pages/InteriorPhotosPage.tsx
+++ b/src/pages/InteriorPhotosPage.tsx
@@ -134,7 +134,6 @@ export function InteriorPhotosPage() {
   const displayContentPolicy = useDisplayContentPolicy(displayDetail);
 
   const canCreateContent = hasPermission(displayContentPolicy, 'createContent');
-  const canDeleteContent = hasPermission(displayContentPolicy, 'deleteContent');
   const canReorder = hasPermission(displayContentPolicy, 'reorder');
 
   if (isLoading) {

--- a/src/pages/InteriorPhotosPage.tsx
+++ b/src/pages/InteriorPhotosPage.tsx
@@ -39,6 +39,8 @@ import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
 import { useFlowBack } from '@/hooks/useFlowBack';
 import { useImageUpload } from '@/hooks/useImageUpload';
 import { useDisplayContentPolicy } from '@/hooks/usePolicy';
+import { policies } from '@/policies/policies';
+import { useAuthStore } from '@/stores/authStore';
 import { hasPermission } from '@/utils/hasPermission';
 
 type Photo = {
@@ -168,7 +170,6 @@ export function InteriorPhotosPage() {
         categoryId={categoryId}
         initialPhotos={initialPhotos}
         canCreateContent={canCreateContent}
-        canDeleteContent={canDeleteContent}
         canReorder={canReorder}
         onBack={() => flowBack()}
         displayDetail={displayDetail}
@@ -197,16 +198,17 @@ function InteriorPhotos({
   categoryId,
   initialPhotos,
   canCreateContent,
-  canDeleteContent,
   canReorder,
   onBack,
   displayDetail,
-}: InteriorPhotosProps) {
+}: Omit<InteriorPhotosProps, 'canDeleteContent'>) {
   const [photos, setPhotos] = useState<Photo[]>(initialPhotos);
   const [isReorderMode, setIsReorderMode] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const savedOrderRef = useRef<Photo[]>(initialPhotos);
+
+  const user = useAuthStore((s) => s.user);
 
   const scope = { displayId, categoryId };
   const imageUpload = useImageUpload({ domain: 'display' });
@@ -282,6 +284,7 @@ function InteriorPhotos({
         id: res.contentId,
         url: uploadedUrls[index],
         alt: added[index]?.file.name,
+        userId: user?.id ?? undefined,
       }));
 
       setPhotos((prev) => [...prev, ...newPhotos]);
@@ -293,7 +296,21 @@ function InteriorPhotos({
   };
 
   const handleRemove = (id: string | number) => {
-    if (!canDeleteContent) return;
+    const targetPhoto = photos.find((p) => p.id === id);
+    if (!targetPhoto) return;
+
+    const policyUser = {
+      id: user?.id ?? null,
+      isArtistVerified: user?.isArtistVerified ?? false,
+    };
+
+    const hasDeletePermission = policies.displayContent.deleteContent(
+      policyUser,
+      displayDetail,
+      targetPhoto,
+    );
+
+    if (!hasDeletePermission) return;
 
     const previous = photos;
     const updated = previous.filter((p) => p.id !== id);

--- a/src/pages/InteriorPhotosPage.tsx
+++ b/src/pages/InteriorPhotosPage.tsx
@@ -21,6 +21,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { X } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 
+import type { DisplayDetailDto } from '@/api/dto';
 import { BottomFixedBar, ErrorView, LoadingView } from '@/components/common';
 import { useHideFooter } from '@/components/layout';
 import { AlertModal, ExhibitionHeader } from '@/components/ui';
@@ -44,6 +45,7 @@ type Photo = {
   id: string | number;
   url: string;
   alt?: string;
+  userId?: number;
 };
 
 const getPhotoSortableId = (photo: Photo) => String(photo.id);
@@ -52,7 +54,7 @@ interface SortablePhotoItemProps {
   photo: Photo;
   index: number;
   isReorderMode: boolean;
-  canDeleteContent: boolean;
+  displayDetail: DisplayDetailDto;
   onRemove: (id: string | number) => void;
 }
 
@@ -60,13 +62,16 @@ function SortablePhotoItem({
   photo,
   index,
   isReorderMode,
-  canDeleteContent,
+  displayDetail,
   onRemove,
 }: SortablePhotoItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: getPhotoSortableId(photo),
     disabled: !isReorderMode,
   });
+
+  const displayContentPolicy = useDisplayContentPolicy(displayDetail, photo);
+  const canDeleteContent = hasPermission(displayContentPolicy, 'deleteContent');
 
   return (
     <li
@@ -150,6 +155,7 @@ export function InteriorPhotosPage() {
     category.contents.map((content) => ({
       id: content.contentId,
       url: content.imageUrl,
+      userId: content.userId,
     })) ?? [];
 
   return (
@@ -165,6 +171,7 @@ export function InteriorPhotosPage() {
         canDeleteContent={canDeleteContent}
         canReorder={canReorder}
         onBack={() => flowBack()}
+        displayDetail={displayDetail}
       />
     </div>
   );
@@ -180,6 +187,7 @@ interface InteriorPhotosProps {
   canDeleteContent: boolean;
   canReorder: boolean;
   onBack: () => void;
+  displayDetail: DisplayDetailDto;
 }
 
 function InteriorPhotos({
@@ -192,6 +200,7 @@ function InteriorPhotos({
   canDeleteContent,
   canReorder,
   onBack,
+  displayDetail,
 }: InteriorPhotosProps) {
   const [photos, setPhotos] = useState<Photo[]>(initialPhotos);
   const [isReorderMode, setIsReorderMode] = useState(false);
@@ -405,7 +414,7 @@ function InteriorPhotos({
                     photo={photo}
                     index={index}
                     isReorderMode={isReorderMode}
-                    canDeleteContent={canDeleteContent}
+                    displayDetail={displayDetail}
                     onRemove={handleRemove}
                   />
                 ))}

--- a/src/policies/policies.ts
+++ b/src/policies/policies.ts
@@ -70,7 +70,9 @@ export const policies = {
     // 이미 만들어진 카테고리에 사진을 추가하는 건 작가 인증 여부와 무관하게 전시 소속인이면 가능
     createContent: (user: User, display: DisplayPolicyResource) => isDisplayMember(user, display),
     editContent: (user: User, display: DisplayPolicyResource) => canManageDisplay(user, display),
-    deleteContent: (user: User, display: DisplayPolicyResource) => canManageDisplay(user, display),
+    deleteContent: (user: User, display: DisplayPolicyResource, content?: UserOwnedResource) =>
+      canManageDisplay(user, display) ||
+      (isDisplayMember(user, display) && content !== undefined && isOwner(user, content)),
     reorder: (user: User, display: DisplayPolicyResource) => canManageDisplay(user, display),
   },
 


### PR DESCRIPTION
## 📝 작업 내용

대표자가 아닌 일반 팀원이 올린 전시 콘텐츠에 대하여 스스로 삭제할 수 있도록 관련 API 타입, 모의 데이터(mock), 권한 검증 및 UI 비활성화 조건을 개선하였습니다.

- **API 응답 타입 수정**: `DisplayContentDto`에 `userId` 필드를 추가하여 각 전시 콘텐츠의 등록자(업로더) 정보를 파악할 수 있도록 했습니다.
- **모의 데이터 업데이트**: `repository.ts` 및 `displayContent` POST 모의 핸들러에 `userId`를 주입하도록 보완했습니다.
- **콘텐츠 삭제 정책 개선 (`deleteContent` policy)**:
  - 전시 대표자(`canManageDisplay`)는 이전과 동일하게 모든 콘텐츠를 삭제할 수 있습니다.
  - 일반 전시 팀원(`isDisplayMember`)은 본인이 등록한 콘텐츠(`isOwner(user, content)`)에 한하여 삭제 권한을 갖도록 허용했습니다.
- **UI 및 페이지 연동 (`InteriorPhotosPage.tsx`)**:
  - 기존에는 카테고리 전체 기준으로 삭제 권한을 판정하여 하나의 boolean 값으로 일괄 제어했으나, 각 콘텐츠 아이템별로 권한을 개별 판정할 수 있도록 `SortablePhotoItem` 컴포넌트 내에서 `useDisplayContentPolicy(displayDetail, photo)`를 사용해 삭제 `X` 버튼 노출 여부를 동적으로 결정하도록 변경했습니다.
  - 새로 사진을 업로드할 때 프론트엔드 상태에 바로 반영되도록 uploader의 `userId`를 할당해주는 처리를 추가했습니다.
  - `handleRemove` 함수가 기존에 대표자 권한 기준으로 차단되던 이슈를 수정하여, 각 개별 이미지의 삭제 권한 검증 결과를 따르도록 개선했습니다.

## 🔍 관련 이슈

- close #347

## 🖼️ 스크린샷

- (생략)

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [x] 테스트 코드 포함 (기존 권한 및 가드 관련 테스트 `pnpm test` 정상 통과 완료)

## 💬 기타 참고 사항

- (기타 의견 없음)