### PR TITLE
fix: [iOS/Safari] <input />의 focus 확대 방지 삭제

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -46,15 +46,3 @@
       100% 0%;
   }
 }
-
-/* iOS Safari input focus auto-zoom prevention (16px + scale + layout compensation) */
-input,
-select,
-textarea {
-  font-size: 16px !important;
-  width: 114.3% !important;
-  transform: scale(0.875);
-  transform-origin: left top;
-  margin-right: -14.3% !important;
-}
-


### PR DESCRIPTION
## 📝 작업 내용

- iOS/Safari에서 input focus 시 확대를 방지하기 위해 전역으로 적용하던 스타일을 삭제했습니다.
- `input`, `select`, `textarea`에 강제 적용되던 `font-size: 16px !important` 처리를 제거했습니다.
- 현재 코드 기준으로 `scale(0.875)`, `width: 114.3%`, `margin-right: -14.3%` 보정 스타일은 남아있지 않음을 확인했습니다.

## 🔍 관련 이슈

- close #351

## 🖼️ 스크린샷

- N/A (전역 CSS 삭제 건)

## 🧪 테스트 결과

- [x] 정상 작동 확인 (`pnpm build`)
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- 디자이너 요청에 따라 Safari 기본 focus 확대 동작을 따르도록 기존 우회 스타일을 제거했습니다.