### PR TITLE
fix: 작품 수정 이미지 누락 수정

### DIFF
--- a/src/api/dto/displayArtwork.dto.ts
+++ b/src/api/dto/displayArtwork.dto.ts
@@ -370,6 +370,8 @@ export interface CreateExhibitionArtworkRequestDto {
   qaHandlerUserIds: number[];
 }
 
+export type UpdateExhibitionArtworkRequestDto = Partial<CreateExhibitionArtworkRequestDto>;
+
 export interface CreateExhibitionArtworkResponseDataDto {
   artworkId: number;
   displayId: number;

--- a/src/api/endpoints/displayArtwork.ts
+++ b/src/api/endpoints/displayArtwork.ts
@@ -30,6 +30,7 @@ import type {
   UpdateArtworkFeelingResponseDataDto,
   UpdateArtworkOrderRequestDto,
   UpdateArtworkOrderResponseDataDto,
+  UpdateExhibitionArtworkRequestDto,
 } from '@/api/dto';
 
 import { apiRequest } from '../client';
@@ -170,6 +171,13 @@ export const createExhibitionArtwork = async (
   body: CreateExhibitionArtworkRequestDto,
 ): Promise<CreateExhibitionArtworkResponseDataDto> =>
   apiRequest('/v1/artworks', { method: 'POST', body });
+
+// PATCH /v1/artworks/:artworkId
+export const updateExhibitionArtwork = async (
+  artworkId: number,
+  body: UpdateExhibitionArtworkRequestDto,
+): Promise<CreateExhibitionArtworkResponseDataDto> =>
+  apiRequest(`/v1/artworks/${artworkId}`, { method: 'PATCH', body });
 
 // DELETE /v1/artworks/:artworkId
 export const deleteArtwork = async (artworkId: number): Promise<DeleteArtworkResponseDataDto> =>

--- a/src/components/artwork-register/RegisterArtworkPage.tsx
+++ b/src/components/artwork-register/RegisterArtworkPage.tsx
@@ -198,7 +198,7 @@ function RegisterArtworkPage({
         </section>
 
         <section className="flex flex-col gap-3">
-          <RequiredLabel>작품과정</RequiredLabel>
+          <RequiredLabel>작업과정</RequiredLabel>
           <ImageUploader
             images={processImages}
             maxImages={MAX_ARTWORK_PROGRESS_IMAGES}

--- a/src/hooks/queries/useDisplayArtworks.ts
+++ b/src/hooks/queries/useDisplayArtworks.ts
@@ -1,12 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { CreateExhibitionArtworkRequestDto } from '@/api/dto';
+import type {
+  CreateExhibitionArtworkRequestDto,
+  UpdateExhibitionArtworkRequestDto,
+} from '@/api/dto';
 import {
   createExhibitionArtwork,
   deleteArtwork,
   getArtistArtworks,
   getDisplayArtworks,
   updateArtworkOrder,
+  updateExhibitionArtwork,
 } from '@/api/endpoints';
 import { getPersonalArtworks } from '@/api/endpoints/personalArtwork';
 import { queryKeys } from '@/api/queryKeys';
@@ -39,6 +43,28 @@ export const useCreateDisplayArtwork = (displayId: number) => {
     mutationFn: (body: CreateExhibitionArtworkRequestDto) =>
       createExhibitionArtwork(displayId, body),
     onSuccess: invalidate,
+  });
+};
+
+// PATCH /v1/artworks/:artworkId
+export const useUpdateDisplayArtwork = (displayId: number) => {
+  const queryClient = useQueryClient();
+  const invalidate = useInvalidateDisplayArtworks(displayId);
+
+  return useMutation({
+    mutationFn: ({
+      artworkId,
+      body,
+    }: {
+      artworkId: number;
+      body: UpdateExhibitionArtworkRequestDto;
+    }) => updateExhibitionArtwork(artworkId, body),
+    onSuccess: (_, variables) => {
+      invalidate();
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.displayArtworks.detail(variables.artworkId),
+      });
+    },
   });
 };
 

--- a/src/pages/artwork-register/ArtworkRegisterPage.tsx
+++ b/src/pages/artwork-register/ArtworkRegisterPage.tsx
@@ -58,6 +58,20 @@ const formatMonthDay = (date: string | undefined) => {
   return month && day ? `${month}.${day}` : date;
 };
 
+const getSortedImageUrls = (
+  images: { imageUrl: string; imageType?: string; sortOrder?: number }[] | undefined,
+  imageType: 'ARTWORK' | 'WORK_PROCESS',
+) =>
+  (images ?? [])
+    .filter((image) =>
+      imageType === 'WORK_PROCESS'
+        ? image.imageType === 'WORK_PROCESS'
+        : image.imageType !== 'WORK_PROCESS',
+    )
+    .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+    .map((image) => image.imageUrl)
+    .filter(Boolean);
+
 export function ArtworkRegisterPage() {
   return (
     <ArtworkRegisterDraftProvider>
@@ -346,16 +360,20 @@ function ArtworkRegisterPageContent() {
   );
 
   useEffect(() => {
+    if (isEditMode) return;
+
     if (artworkImages.length === 0 && draft.artworkImageUrls.length > 0) {
       setUploadedArtworkImages(draft.artworkImageUrls);
     }
-  }, [artworkImages.length, setUploadedArtworkImages, draft.artworkImageUrls]);
+  }, [isEditMode, artworkImages.length, setUploadedArtworkImages, draft.artworkImageUrls]);
 
   useEffect(() => {
+    if (isEditMode) return;
+
     if (processImages.length === 0 && draft.processImageUrls.length > 0) {
       setUploadedProcessImages(draft.processImageUrls);
     }
-  }, [processImages.length, setUploadedProcessImages, draft.processImageUrls]);
+  }, [isEditMode, processImages.length, setUploadedProcessImages, draft.processImageUrls]);
 
   useEffect(() => {
     if (isEditMode) return;
@@ -390,6 +408,17 @@ function ArtworkRegisterPageContent() {
     setSize(artworkDetail.size || '');
 
     setPoint(artworkDetail.point || '');
+
+    const artworkImageUrls = getSortedImageUrls(artworkDetail.images, 'ARTWORK');
+    const processImageUrls = getSortedImageUrls(artworkDetail.images, 'WORK_PROCESS');
+
+    if (artworkImageUrls.length > 0) {
+      setUploadedArtworkImages(artworkImageUrls);
+    }
+
+    if (processImageUrls.length > 0) {
+      setUploadedProcessImages(processImageUrls);
+    }
   }, [
     isEditMode,
     artworkDetail,
@@ -399,6 +428,8 @@ function ArtworkRegisterPageContent() {
     setPoint,
     setSize,
     setTitle,
+    setUploadedArtworkImages,
+    setUploadedProcessImages,
     setYear,
   ]);
 

--- a/src/pages/artwork-register/ArtworkRegisterPage.tsx
+++ b/src/pages/artwork-register/ArtworkRegisterPage.tsx
@@ -31,7 +31,11 @@ import {
   type ArtworkRegisterMode,
 } from '@/contexts/artworkRegisterDraftState';
 import { useArtworkDetail } from '@/hooks/queries/useArtworkDetail';
-import { useCreateDisplayArtwork, useDisplayArtworks } from '@/hooks/queries/useDisplayArtworks';
+import {
+  useCreateDisplayArtwork,
+  useDisplayArtworks,
+  useUpdateDisplayArtwork,
+} from '@/hooks/queries/useDisplayArtworks';
 import { useDisplayDetail } from '@/hooks/queries/useDisplayDetail';
 import { useDisplayMembers } from '@/hooks/queries/useDisplayMembers';
 import { useArtworkRegisterDraft } from '@/hooks/useArtworkRegisterDraft';
@@ -114,8 +118,12 @@ function ArtworkRegisterPageContent() {
     maxImages: MAX_ARTWORK_PROGRESS_IMAGES,
   });
   const createArtwork = useCreateDisplayArtwork(displayId);
+  const updateArtwork = useUpdateDisplayArtwork(displayId);
   const isSubmitting =
-    artworkUpload.isUploading || processUpload.isUploading || createArtwork.isPending;
+    artworkUpload.isUploading ||
+    processUpload.isUploading ||
+    createArtwork.isPending ||
+    updateArtwork.isPending;
   const artworkImages = artworkUpload.images;
   const processImages = processUpload.images;
   const setUploadedArtworkImages = artworkUpload.setUploadedImages;
@@ -474,8 +482,9 @@ function ArtworkRegisterPageContent() {
   ]);
 
   /* 작가 인증 + 전시 소속인만 전시작을 등록할 수 있습니다. */
-  const artworkPolicy = useArtworkPolicy(display);
+  const artworkPolicy = useArtworkPolicy(display, artworkDetail);
   const canCreateArtwork = hasPermission(artworkPolicy, 'create');
+  const canEditArtwork = hasPermission(artworkPolicy, 'edit');
 
   const exhibition = useMemo(
     () => ({
@@ -738,13 +747,10 @@ function ArtworkRegisterPageContent() {
   const handleSubmit = async () => {
     if (isSubmitting) return;
 
-    if (isEditMode) {
-      navigate(`/exhibition/${displayId}/artworks`, { replace: true });
-      return;
-    }
+    const hasSubmitPermission = isEditMode ? canEditArtwork : canCreateArtwork;
 
-    if (!canCreateArtwork) {
-      setSubmitError('작품을 등록할 권한이 없어요.');
+    if (!hasSubmitPermission) {
+      setSubmitError(isEditMode ? '작품을 수정할 권한이 없어요.' : '작품을 등록할 권한이 없어요.');
       return;
     }
 
@@ -801,78 +807,91 @@ function ArtworkRegisterPageContent() {
       return;
     }
 
-    createArtwork.mutate(
-      {
-        displayId,
-        artworkName: title.trim(),
-        content: description.trim(),
-        type: artworkType,
-        types: artworkTypes.length > 0 ? artworkTypes : [artworkType],
-        productionYear: toArtworkRegisterProductionYear(year),
-        materialMedia: medium.trim(),
-        size: size.trim(),
-        point: point.trim(),
-        /*
-         * 작품 이미지와 작업과정 이미지를 imageType으로 구분해 보냅니다.
-         * 서버가 width/height를 @Positive 원시 int로 받아 0이나 누락은 거절되어 고정값을 씁니다.
-         */
-        images: [
-          ...artworkImageUrls.map((imageUrl, index) => ({
-            imageUrl,
-            /* 대표 이미지는 작품 이미지 중 첫 장만 지정합니다. */
-            isThumbnail: index === 0,
-            imageType: 'ARTWORK',
-            width: DEFAULT_ARTWORK_IMAGE_WIDTH,
-            height: DEFAULT_ARTWORK_IMAGE_HEIGHT,
-            sortOrder: index + 1,
-          })),
-          ...processImageUrls.map((imageUrl, index) => ({
-            imageUrl,
-            isThumbnail: false,
-            imageType: 'WORK_PROCESS',
-            width: DEFAULT_ARTWORK_IMAGE_WIDTH,
-            height: DEFAULT_ARTWORK_IMAGE_HEIGHT,
-            sortOrder: index + 1,
-          })),
-        ],
-        artistName: displayAuthor.name.trim(),
-        artistUserId,
-        /* 계정이 연결된 팀원은 userIds로, 직접 입력한 작가는 rawNames로 보냅니다. */
-        coAuthors: {
-          userIds: collaborators
-            .map((person) => person.userId)
-            .filter((coAuthorUserId) => coAuthorUserId !== userId)
-            .filter((userId): userId is number => typeof userId === 'number'),
-          rawNames: collaborators
-            .filter((person) => typeof person.userId !== 'number')
-            .map((person) => person.name),
-        },
-        qaHandlerUserIds,
+    const artworkPayload = {
+      displayId,
+      artworkName: title.trim(),
+      content: description.trim(),
+      type: artworkType,
+      types: artworkTypes.length > 0 ? artworkTypes : [artworkType],
+      productionYear: toArtworkRegisterProductionYear(year),
+      materialMedia: medium.trim(),
+      size: size.trim(),
+      point: point.trim(),
+      /*
+       * 작품 이미지와 작업과정 이미지를 imageType으로 구분해 보냅니다.
+       * 서버가 width/height를 @Positive 원시 int로 받아 0이나 누락은 거절되어 고정값을 씁니다.
+       */
+      images: [
+        ...artworkImageUrls.map((imageUrl, index) => ({
+          imageUrl,
+          /* 대표 이미지는 작품 이미지 중 첫 장만 지정합니다. */
+          isThumbnail: index === 0,
+          imageType: 'ARTWORK',
+          width: DEFAULT_ARTWORK_IMAGE_WIDTH,
+          height: DEFAULT_ARTWORK_IMAGE_HEIGHT,
+          sortOrder: index + 1,
+        })),
+        ...processImageUrls.map((imageUrl, index) => ({
+          imageUrl,
+          isThumbnail: false,
+          imageType: 'WORK_PROCESS',
+          width: DEFAULT_ARTWORK_IMAGE_WIDTH,
+          height: DEFAULT_ARTWORK_IMAGE_HEIGHT,
+          sortOrder: index + 1,
+        })),
+      ],
+      artistName: displayAuthor.name.trim(),
+      artistUserId,
+      /* 계정이 연결된 팀원은 userIds로, 직접 입력한 작가는 rawNames로 보냅니다. */
+      coAuthors: {
+        userIds: collaborators
+          .map((person) => person.userId)
+          .filter((coAuthorUserId) => coAuthorUserId !== userId)
+          .filter((userId): userId is number => typeof userId === 'number'),
+        rawNames: collaborators
+          .filter((person) => typeof person.userId !== 'number')
+          .map((person) => person.name),
       },
-      {
-        onSuccess: () => {
-          const primaryQnaAssignee =
-            qnaAssigneeOptions.find((person) => person.id === effectiveQnaAssigneeIds[0]) ??
-            qnaAssigneeOptions[0];
+      qaHandlerUserIds,
+    };
 
-          resetDraft();
-          completeFlow();
-          navigate(`/exhibition/${displayId}/complete`, {
-            replace: true,
-            state: {
-              type: 'artwork',
-              title: title.trim(),
-              artistName: displayAuthor.name.trim(),
-              registrantName: myDisplayNickname || accountId,
-              registrantAccount: accountId,
-              qnaAssigneeName: primaryQnaAssignee?.name,
-              qnaAssigneeAccount: primaryQnaAssignee?.account,
-            },
-          });
+    if (isEditMode) {
+      updateArtwork.mutate(
+        { artworkId, body: artworkPayload },
+        {
+          onSuccess: () => {
+            resetDraft();
+            navigate(`/exhibition/${displayId}/artworks`, { replace: true });
+          },
+          onError: () => setSubmitError('작품 수정에 실패했어요. 잠시 후 다시 시도해주세요.'),
         },
-        onError: () => setSubmitError('작품 등록에 실패했어요. 잠시 후 다시 시도해주세요.'),
+      );
+      return;
+    }
+
+    createArtwork.mutate(artworkPayload, {
+      onSuccess: () => {
+        const primaryQnaAssignee =
+          qnaAssigneeOptions.find((person) => person.id === effectiveQnaAssigneeIds[0]) ??
+          qnaAssigneeOptions[0];
+
+        resetDraft();
+        completeFlow();
+        navigate(`/exhibition/${displayId}/complete`, {
+          replace: true,
+          state: {
+            type: 'artwork',
+            title: title.trim(),
+            artistName: displayAuthor.name.trim(),
+            registrantName: myDisplayNickname || accountId,
+            registrantAccount: accountId,
+            qnaAssigneeName: primaryQnaAssignee?.name,
+            qnaAssigneeAccount: primaryQnaAssignee?.account,
+          },
+        });
       },
-    );
+      onError: () => setSubmitError('작품 등록에 실패했어요. 잠시 후 다시 시도해주세요.'),
+    });
   };
 
   const handleChoiceNext = () => {


### PR DESCRIPTION
## 📝 작업 내용

- 작품 수정 페이지에서 상세 응답의 `images`를 `imageType` 기준으로 분리해 업로더 초기값으로 설정했습니다.
- `ARTWORK` 이미지는 작품 업로드 영역에, `WORK_PROCESS` 이미지는 작업과정 영역에 표시되도록 수정했습니다.
- 수정 모드에서는 등록 draft 이미지가 상세 이미지 초기화를 덮어쓰지 않도록 처리했습니다.
- 작품 수정 제출 시 `PATCH /v1/artworks/{artworkId}` API가 호출되도록 endpoint/hook/submit 로직을 추가했습니다.
- 수정 모드 권한 확인은 `artwork:create`가 아니라 `artwork:edit` 기준으로 처리했습니다.
- 작업과정 라벨 문구를 정리했습니다.

## 🔍 관련 이슈

- Close #354

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

검증 명령:
- `pnpm build`
- `pnpm lint`

## 💬 기타 참고 사항

- 기존 상세 API 응답의 이미지 정렬 순서를 유지하기 위해 `sortOrder` 기준으로 정렬했습니다.
- 수정 제출은 등록과 동일한 이미지 payload 구조를 사용합니다.