### PR TITLE
탐색 필터 단일 선택 스키마 반영

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -31,11 +31,7 @@ export const createQueryString = (query?: QueryParams): string => {
           searchParams.append(key, String(v));
         }
       });
-    } else if (
-      typeof value === 'string' &&
-      value.includes(',') &&
-      ['field', 'status', 'region', 'type', 'fields'].includes(key)
-    ) {
+    } else if (typeof value === 'string' && value.includes(',') && ['fields'].includes(key)) {
       value.split(',').forEach((v) => {
         const trimmed = v.trim();
         if (trimmed) {

--- a/src/components/search/filter/FilterModal.tsx
+++ b/src/components/search/filter/FilterModal.tsx
@@ -24,9 +24,9 @@ export function FilterModal({
   onReset,
   onResetAndApply,
 }: FilterModalProps) {
-  const activeEntries = (Object.entries(filters) as Array<[FilterTab, string[]]>).flatMap(
-    ([tab, values]) => (values ?? []).map((val) => ({ tab, value: val })),
-  );
+  const activeEntries = (Object.entries(filters) as Array<[FilterTab, string | null]>)
+    .filter((entry): entry is [FilterTab, string] => Boolean(entry[1]))
+    .map(([tab, value]) => ({ tab, value }));
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -99,8 +99,8 @@ export function FilterModal({
                 {FILTER_TAB_OPTIONS[tab].map((option) => {
                   const isOptionSelected =
                     option === '전체'
-                      ? (filters[tab] ?? []).length === 0 || (filters[tab] ?? []).includes('전체')
-                      : (filters[tab] ?? []).includes(option);
+                      ? filters[tab] === null || filters[tab] === '전체'
+                      : filters[tab] === option;
 
                   return (
                     <FilterChip

--- a/src/components/search/filter/filterOptions.ts
+++ b/src/components/search/filter/filterOptions.ts
@@ -76,16 +76,13 @@ export const FILTER_TAB_OPTIONS: Record<FilterTab, string[]> = {
 };
 
 export const DEFAULT_FILTER_STATE: FilterState = {
-  전시분야: [],
-  전시상태: [],
-  전시유형: [],
-  지역: [],
+  전시분야: null,
+  전시상태: null,
+  전시유형: null,
+  지역: null,
 };
 
-export const getFilterOptionValues = ({ options }: FilterConfig, labels: string[]) => {
-  if (!labels || labels.length === 0) return null;
-  const values = labels
-    .map((label) => options.find((option) => option.label === label)?.value)
-    .filter((v): v is string => Boolean(v));
-  return values.length > 0 ? values.join(',') : null;
+export const getFilterOptionValue = ({ options }: FilterConfig, label: string | null) => {
+  if (!label) return null;
+  return options.find((option) => option.label === label)?.value ?? null;
 };

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -7,7 +7,7 @@ import type { SearchDisplaysRequestDto } from '@/api/dto';
 import filterIcon from '@/assets/search/filter.svg';
 import filterSelectedDotIcon from '@/assets/search/filter-selected-dot.svg';
 import { LoadingView } from '@/components/common';
-import { getFilterOptionValues } from '@/components/search/filter/filterOptions';
+import { getFilterOptionValue } from '@/components/search/filter/filterOptions';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 import {
@@ -33,12 +33,30 @@ const createSearchDisplayParams = (query: string, filters: FilterState) => {
     size: 20,
   };
 
-  (Object.entries(filters) as Array<[FilterTab, string[]]>).forEach(([tab, labels]) => {
+  (Object.entries(filters) as Array<[FilterTab, string | null]>).forEach(([tab, label]) => {
     const config = FILTER_CONFIG[tab];
-    params[config.param] = getFilterOptionValues(config, labels);
+    params[config.param] = getFilterOptionValue(config, label);
   });
 
   return params;
+};
+
+const normalizeFilterValue = (value: string | string[] | null | undefined) => {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+};
+
+const mergeFilters = (filters?: Partial<Record<FilterTab, string | string[] | null>>) => {
+  const base: FilterState = { ...DEFAULT_FILTER_STATE };
+  if (!filters) return base;
+
+  (Object.entries(filters) as Array<[FilterTab, string | string[] | null | undefined]>).forEach(
+    ([tab, value]) => {
+      base[tab] = normalizeFilterValue(value);
+    },
+  );
+
+  return base;
 };
 
 export function SearchPage() {
@@ -98,26 +116,27 @@ export function SearchPage() {
     );
   };
 
-  const stateFilters = (location.state as { filters?: Partial<FilterState> })?.filters;
+  const stateFilters = (
+    location.state as { filters?: Partial<Record<FilterTab, string | string[] | null>> }
+  )?.filters;
   const targetFiltersKey = `${paramType ?? ''}_${paramStatus ?? ''}_${JSON.stringify(stateFilters ?? {})}`;
 
   const [prevKey, setPrevKey] = useState(targetFiltersKey);
   const [filters, setFilters] = useState<FilterState>(() => {
-    const base: FilterState = { ...DEFAULT_FILTER_STATE };
-    if (stateFilters) return { ...base, ...stateFilters };
-    if (paramType) base['전시유형'] = [paramType];
-    if (paramStatus) base['전시상태'] = [paramStatus];
+    const base = mergeFilters(stateFilters);
+    if (paramType) base['전시유형'] = paramType;
+    if (paramStatus) base['전시상태'] = paramStatus;
     return base;
   });
 
   if (prevKey !== targetFiltersKey) {
     setPrevKey(targetFiltersKey);
-    const base: FilterState = { ...DEFAULT_FILTER_STATE };
+    const base = mergeFilters(stateFilters);
     if (stateFilters) {
-      setFilters({ ...base, ...stateFilters });
+      setFilters(base);
     } else {
-      if (paramType) base['전시유형'] = [paramType];
-      if (paramStatus) base['전시상태'] = [paramStatus];
+      if (paramType) base['전시유형'] = paramType;
+      if (paramStatus) base['전시상태'] = paramStatus;
       setFilters(base);
     }
   }
@@ -147,23 +166,16 @@ export function SearchPage() {
   const { data: nearbyData } = useNearbyDisplays(nearbyParamsWithSearch);
   const nearbyExhibitions = nearbyData ?? [];
 
-  const activeFilterEntries = (Object.entries(filters) as Array<[FilterTab, string[]]>).flatMap(
-    ([tab, values]) => (values ?? []).map((val) => ({ tab, value: val })),
-  );
+  const activeFilterEntries = (Object.entries(filters) as Array<[FilterTab, string | null]>)
+    .filter((entry): entry is [FilterTab, string] => Boolean(entry[1]))
+    .map(([tab, value]) => ({ tab, value }));
 
   const updateFilter = (tab: FilterTab, value: string) => {
     setFilters((prev) => {
-      const current = prev[tab] ?? [];
       if (value === '전체') {
-        return { ...prev, [tab]: [] };
+        return { ...prev, [tab]: null };
       }
-      if (tab === '전시분야') {
-        return { ...prev, [tab]: current.includes(value) ? [] : [value] };
-      }
-      const updated = current.includes(value)
-        ? current.filter((v) => v !== value)
-        : [...current, value];
-      return { ...prev, [tab]: updated };
+      return { ...prev, [tab]: prev[tab] === value ? null : value };
     });
   };
 
@@ -250,7 +262,7 @@ export function SearchPage() {
                   key={field}
                   label={field}
                   onClick={() => updateFilter('전시분야', field)}
-                  selected={(filters['전시분야'] ?? []).includes(field)}
+                  selected={filters['전시분야'] === field}
                 />
               ))}
             </div>

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,3 +1,3 @@
 export type FilterTab = '전시분야' | '전시상태' | '지역' | '전시유형';
 
-export type FilterState = Record<FilterTab, string[]>;
+export type FilterState = Record<FilterTab, string | null>;


### PR DESCRIPTION
## 📝 작업 내용

- 탐색 필터 상태를 같은 필터 그룹당 단일 값만 유지하도록 변경했습니다.
- 필터 모달/상단 분야 칩에서 선택한 값을 다시 누르면 해제되고, 다른 값을 누르면 기존 값이 교체되도록 정리했습니다.
- 검색 API 요청 파라미터가 `field`, `status`, `region`, `type` 단일 string으로 직렬화되도록 수정했습니다.
- URL/state 기반 초기 필터 값도 단일 값으로 정규화했습니다.

## 🔍 관련 이슈

- Closes #363

## 🖼️ 스크린샷

- 별도 첨부 없음

## 🧪 테스트 결과

- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

- `pnpm build` 성공 확인했습니다.
- 기존 Vite dynamic/static import chunk 경고는 동일하게 발생합니다.
